### PR TITLE
Simulations from proof of equality of simulations

### DIFF
--- a/CoqOfRust/blacklist.txt
+++ b/CoqOfRust/blacklist.txt
@@ -1,3 +1,4 @@
+examples/default/examples/ink_contracts/proofs/erc20.v
 # This file works but is taking a very long time (ten minutes)
 revm/opcode.v
 examples/default/examples/ink_contracts/proofs/erc721.v

--- a/CoqOfRust/core/num/simulations/mod.v
+++ b/CoqOfRust/core/num/simulations/mod.v
@@ -1,0 +1,26 @@
+Require Import CoqOfRust.CoqOfRust.
+Require Import CoqOfRust.proofs.M.
+Require Import CoqOfRust.simulations.M.
+Require core.simulations.intrinsics.
+
+Require Import core.num.mod.
+
+Import Run.
+
+Module Impl_u64.
+  Definition run_overflowing_sub (self rhs : Z) :
+    Run.pure (num.Impl_u64.overflowing_sub [] [φ self; φ rhs])
+      (fun (v : (Z * bool)) => inl (φ v)).
+  Proof.
+    unfold Run.pure; intros.
+    run_symbolic.
+    eapply Run.CallPrimitiveGetFunction. {
+      apply core.intrinsics.intrinsics.Function_sub_with_overflow.
+    }
+    eapply Run.CallClosure. {
+      apply core.simulations.intrinsics.run_sub_with_overflow_u64_u64.
+    }
+    intros; destruct value_inter as [a b]; run_symbolic.
+    now instantiate (1 := (a, b)).
+  Defined.
+End Impl_u64.

--- a/CoqOfRust/core/proofs/default.v
+++ b/CoqOfRust/core/proofs/default.v
@@ -6,15 +6,10 @@ Require core.simulations.default.
 Import Run.
 
 Module Default.
-  Record TraitHasRun (Self : Set) (Self_ty : Ty.t)
-    `{ToValue Self}
-    `{core.simulations.default.Default.Trait Self} :
-    Prop := {
-    default :
-      exists default,
-      IsTraitMethod "core::default::Default" Self_ty [] "default" default /\
-      Run.pure
-        (default [] [])
-        (inl (φ core.simulations.default.Default.default));
+  Record InstanceWithRun (Self : Set) `{ToTy Self} `{ToValue Self} : Set := {
+    default : {default @
+      IsTraitMethod "core::default::Default" (Φ Self) [] "default" default *
+      Run.pure (default [] []) (fun v => inl (φ v))
+    };
   }.
 End Default.

--- a/CoqOfRust/core/proofs/option.v
+++ b/CoqOfRust/core/proofs/option.v
@@ -8,14 +8,11 @@ Require CoqOfRust.core.simulations.option.
 Import Run.
 
 Module Impl_Option_T.
-  Lemma run_unwrap_or_default {T : Set} {T_ty : Ty.t}
-    {_ : ToValue T}
-    {_ : core.simulations.default.Default.Trait T}
-    (self : option T) :
-    core.proofs.default.Default.TraitHasRun T T_ty ->
+  Definition run_unwrap_or_default {T : Set} `{ToTy T} `{ToValue T} (self : option T) :
+    core.proofs.default.Default.InstanceWithRun T ->
     Run.pure
-      (core.option.option.Impl_core_option_Option_T.unwrap_or_default T_ty [] [φ self])
-      (inl (φ (core.simulations.option.Impl_Option_T.unwrap_or_default self))).
+      (core.option.option.Impl_core_option_Option_T.unwrap_or_default (Φ T) [] [φ self])
+      (fun v => inl (φ v)).
   Proof.
     intros H_Default.
     destruct H_Default as [[default [H_default H_run_default]]].
@@ -29,7 +26,8 @@ Module Impl_Option_T.
       eapply Run.CallClosure. {
         apply H_run_default.
       }
+      intros.
       run_symbolic.
     }
-  Qed.
+  Defined.
 End Impl_Option_T.

--- a/CoqOfRust/core/simulations/intrinsics.v
+++ b/CoqOfRust/core/simulations/intrinsics.v
@@ -7,9 +7,9 @@ Require core.intrinsics.
 Import Run.
 
 Definition sub_with_overflow_kind (kind : Integer.t) (x y : Z) : Z * bool :=
-  let z := Integer.normalize_wrap kind (x - y) in
+  let z := x - y in
   let has_overflow := orb (z <? Integer.min kind) (Integer.max kind <? z) in
-  (z, has_overflow).
+  (Integer.normalize_wrap kind z, has_overflow).
 
 (* TODO: add the other integer cases *)
 Axiom sub_with_overflow_u64_eq :
@@ -25,6 +25,8 @@ Definition run_sub_with_overflow_u64_u64 (self rhs : Z) :
     (fun (v : (Z * bool)) => inl (φ v)).
 Proof.
   unfold Run.pure; intros.
-  rewrite sub_with_overflow_u64_eq.
+  eapply Run.Rewrite. {
+    rewrite sub_with_overflow_u64_eq; reflexivity.
+  }
   with_strategy opaque [sub_with_overflow_kind] run_symbolic.
 Defined.

--- a/CoqOfRust/core/simulations/intrinsics.v
+++ b/CoqOfRust/core/simulations/intrinsics.v
@@ -1,0 +1,30 @@
+Require Import CoqOfRust.CoqOfRust.
+Require Import proofs.M.
+Require Import simulations.M.
+
+Require core.intrinsics.
+
+Import Run.
+
+Definition sub_with_overflow_kind (kind : Integer.t) (x y : Z) : Z * bool :=
+  let z := Integer.normalize_wrap kind (x - y) in
+  let has_overflow := orb (z <? Integer.min kind) (Integer.max kind <? z) in
+  (z, has_overflow).
+
+(* TODO: add the other integer cases *)
+Axiom sub_with_overflow_u64_eq :
+  core.intrinsics.intrinsics.sub_with_overflow [Ty.path "u64"] =
+  fun α =>
+    match α with
+    | [ Value.Integer x; Value.Integer y ] => M.pure (φ (sub_with_overflow_kind Integer.U64 x y))
+    | _ => M.impossible
+    end.
+
+Definition run_sub_with_overflow_u64_u64 (self rhs : Z) :
+  Run.pure (core.intrinsics.intrinsics.sub_with_overflow [Ty.path "u64"] [φ self; φ rhs])
+    (fun (v : (Z * bool)) => inl (φ v)).
+Proof.
+  unfold Run.pure; intros.
+  rewrite sub_with_overflow_u64_eq.
+  with_strategy opaque [sub_with_overflow_kind] run_symbolic.
+Defined.

--- a/CoqOfRust/lib/lib.v
+++ b/CoqOfRust/lib/lib.v
@@ -84,18 +84,18 @@ Module Integer.
 
   Definition normalize_wrap (kind : Integer.t) (z : Z) : Z :=
     match kind with
-    | Integer.U8 => Z.modulo z 2^8
-    | Integer.U16 => Z.modulo z 2^16
-    | Integer.U32 => Z.modulo z 2^32
-    | Integer.U64 => Z.modulo z 2^64
-    | Integer.U128 => Z.modulo z 2^128
-    | Integer.Usize => Z.modulo z 2^64
-    | Integer.I8 => Z.modulo (z + 2^7) 2^8 - 2^7
-    | Integer.I16 => Z.modulo (z + 2^15) 2^16 - 2^15
-    | Integer.I32 => Z.modulo (z + 2^31) 2^32 - 2^31
-    | Integer.I64 => Z.modulo (z + 2^63) 2^64 - 2^63
-    | Integer.I128 => Z.modulo (z + 2^127) 2^128 - 2^127
-    | Integer.Isize => Z.modulo (z + 2^63) 2^64 - 2^63
+    | Integer.U8 => Z.modulo z (2^8)
+    | Integer.U16 => Z.modulo z (2^16)
+    | Integer.U32 => Z.modulo z (2^32)
+    | Integer.U64 => Z.modulo z (2^64)
+    | Integer.U128 => Z.modulo z (2^128)
+    | Integer.Usize => Z.modulo z (2^64)
+    | Integer.I8 => Z.modulo (z + 2^7) (2^8) - 2^7
+    | Integer.I16 => Z.modulo (z + 2^15) (2^16) - 2^15
+    | Integer.I32 => Z.modulo (z + 2^31) (2^32) - 2^31
+    | Integer.I64 => Z.modulo (z + 2^63) (2^64) - 2^63
+    | Integer.I128 => Z.modulo (z + 2^127) (2^128) - 2^127
+    | Integer.Isize => Z.modulo (z + 2^63) (2^64) - 2^63
     end.
 
   Definition normalize_with_error (kind : Integer.t) (z : Z) : Z + string :=

--- a/CoqOfRust/proofs/M.v
+++ b/CoqOfRust/proofs/M.v
@@ -57,50 +57,50 @@ Definition IsTraitMethod
   List.assoc instance method_name = Some (InstanceField.Method method).
 
 Module Run.
-  Reserved Notation "{{ env , env_to_value , state | e ⇓ result | state' }}".
+  Reserved Notation "{{ env , env_to_value , state | e ⇓ to_value | P_state }}".
 
-  Inductive t `{State.Trait} {Env : Set} (env : Env) (env_to_value : Env -> Value.t)
-      (* Be aware of the order of parameters: the result and final state are at
-         the beginning. This is due to the way polymorphic types for inductive
-         work in Coq, and the fact that the result is always the same as we are
-         in continuation passing style. *)
-      (result : Value.t + Exception.t) (state' : State) :
-      M -> State -> Prop :=
-  | Pure :
-    {{ env, env_to_value, state' | LowM.Pure result ⇓ result | state' }}
+  Inductive t `{State.Trait} {Env A : Set} (env : Env) (env_to_value : Env -> Value.t)
+      (state : State)
+      (to_value : A -> Value.t + Exception.t) (P_state : State -> Prop) :
+      M -> Set :=
+  | Pure
+      (result : A)
+      (result' : Value.t + Exception.t) :
+    result' = to_value result ->
+    P_state state ->
+    {{ env, env_to_value, state | LowM.Pure result' ⇓ to_value | P_state }}
   | CallPrimitiveStateAllocImmediate
-      (state : State) (v : Value.t)
+      (v : Value.t)
       (k : Value.t -> M) :
     {{ env, env_to_value, state |
-      k (Value.Pointer (Pointer.Immediate v)) ⇓ result
-    | state' }} ->
+      k (Value.Pointer (Pointer.Immediate v)) ⇓ to_value
+    | P_state }} ->
     {{ env, env_to_value, state |
-      LowM.CallPrimitive (Primitive.StateAlloc v) k ⇓ result
-    | state' }}
+      LowM.CallPrimitive (Primitive.StateAlloc v) k ⇓ to_value
+    | P_state }}
   | CallPrimitiveStateAllocMutable
       (address : Address)
       (value : State.get_Set address)
       (value' : Value.t)
-      (to_value : State.get_Set address -> Value.t)
-      (state : State)
+      (pointer_to_value : State.get_Set address -> Value.t)
+      (state_inter : State)
       (k : Value.t -> M) :
-    let r := Value.Pointer (Pointer.mutable address to_value) in
-    value' = to_value value ->
+    let r := Value.Pointer (Pointer.mutable address pointer_to_value) in
+    value' = pointer_to_value value ->
     State.read address state = None ->
-    State.alloc_write address state value = Some state' ->
-    {{ env, env_to_value, state | k r ⇓ result | state' }} ->
+    State.alloc_write address state value = Some state_inter ->
+    {{ env, env_to_value, state_inter | k r ⇓ to_value | P_state }} ->
     {{ env, env_to_value, state |
-      LowM.CallPrimitive (Primitive.StateAlloc value') k ⇓ result
-    | state' }}
+      LowM.CallPrimitive (Primitive.StateAlloc value') k ⇓ to_value
+    | P_state }}
   | CallPrimitiveStateRead
-      {A : Set} {to_value : A -> Value.t} address path big_to_value projection injection
+      {A : Set} {pointer_to_value : A -> Value.t} address path big_to_value projection injection
       (value : State.get_Set address)
       (sub_value : A)
-      (state : State)
       (k : Value.t -> M) :
     let mutable :=
       Pointer.Mutable.Make
-        (Value := Value.t) (A := A) (to_value := to_value) (Address := Address)
+        (Value := Value.t) (A := A) (to_value := pointer_to_value) (Address := Address)
         (Big_A := State.get_Set address)
         address
         path
@@ -110,84 +110,93 @@ Module Run.
     State.read address state = Some value ->
     projection value = Some sub_value ->
     {{ env, env_to_value, state |
-      k (to_value sub_value) ⇓
-      result
-    | state' }} ->
+      k (pointer_to_value sub_value) ⇓
+      to_value
+    | P_state }} ->
     {{ env, env_to_value, state |
       LowM.CallPrimitive (Primitive.StateRead mutable) k ⇓
-      result
-    | state' }}
+      to_value
+    | P_state }}
   | CallPrimitiveStateWrite
-      {A : Set} {to_value : A -> Value.t} address path big_to_value projection injection
+      {A : Set} {pointer_to_value : A -> Value.t} address path big_to_value projection injection
       (value : A) (value' : Value.t)
       (big_value new_big_value : State.get_Set address)
-      (state state_inter : State)
+      (state_inter : State)
       (k : Value.t -> M) :
     let mutable :=
       Pointer.Mutable.Make
-        (Value := Value.t) (A := A) (to_value := to_value) (Address := Address)
+        (Value := Value.t) (A := A) (to_value := pointer_to_value) (Address := Address)
         (Big_A := State.get_Set address)
         address
         path
         big_to_value
         projection
         injection in
-    value' = to_value value ->
+    value' = pointer_to_value value ->
     State.read address state = Some big_value ->
     injection big_value value = Some new_big_value ->
     State.alloc_write address state new_big_value = Some state_inter ->
-    {{ env, env_to_value, state_inter | k (Value.Tuple []) ⇓ result | state' }} ->
+    {{ env, env_to_value, state_inter | k (Value.Tuple []) ⇓ to_value | P_state }} ->
     {{ env, env_to_value, state |
       LowM.CallPrimitive (Primitive.StateWrite mutable value') k ⇓
-      result
-    | state' }}
-  | CallPrimitiveGetSubPointer {A Sub_A : Set} {to_value : A -> Value.t}
-      (mutable : Pointer.Mutable.t Value.t to_value)
+      to_value
+    | P_state }}
+  | CallPrimitiveGetSubPointer {A Sub_A : Set} {pointer_to_value : A -> Value.t}
+      (mutable : Pointer.Mutable.t Value.t pointer_to_value)
       index sub_projection sub_injection sub_to_value
-      (state : State)
       (k : Value.t -> M) :
     (* Communtativity of the read *)
     (forall (a : A),
       Option.map (sub_projection a) sub_to_value =
-      Value.read_path (to_value a) [index]
+      Value.read_path (pointer_to_value a) [index]
     ) ->
     (* Communtativity of the write *)
     (forall (a : A) (sub_a : Sub_A),
-      Option.map (sub_injection a sub_a) to_value =
-      Value.write_value (to_value a) [index] (sub_to_value sub_a)
+      Option.map (sub_injection a sub_a) pointer_to_value =
+      Value.write_value (pointer_to_value a) [index] (sub_to_value sub_a)
     ) ->
     {{ env, env_to_value, state |
       k (Value.Pointer (Pointer.Mutable (Pointer.Mutable.get_sub
         mutable index sub_projection sub_injection sub_to_value
       ))) ⇓
-      result
-    | state' }} ->
+      to_value
+    | P_state }} ->
     {{ env, env_to_value, state |
       LowM.CallPrimitive (Primitive.GetSubPointer mutable index) k ⇓
-      result
-    | state' }}
+      to_value
+    | P_state }}
   | CallPrimitiveEnvRead
-      (state : State) (k : Value.t -> M) :
-    {{ env, env_to_value, state | k (env_to_value env) ⇓ result | state' }} ->
+      (k : Value.t -> M) :
+    {{ env, env_to_value, state | k (env_to_value env) ⇓ to_value | P_state }} ->
     {{ env, env_to_value, state |
-      LowM.CallPrimitive Primitive.EnvRead k ⇓ result
-    | state' }}
+      LowM.CallPrimitive Primitive.EnvRead k ⇓ to_value
+    | P_state }}
+  | CallPrimitiveGetFunction
+      (name : string) (generic_tys : list Ty.t)
+      (function : list Ty.t -> list Value.t -> M)
+      (k : Value.t -> M) :
+    let closure :=
+      Value.Closure (existS (Value.t, M) (function generic_tys)) in
+    M.IsFunction name function ->
+    {{ env, env_to_value, state | k closure ⇓ to_value | P_state }} ->
+    {{ env, env_to_value, state |
+      LowM.CallPrimitive (Primitive.GetFunction name generic_tys) k ⇓
+      to_value
+    | P_state }}
   | CallPrimitiveGetAssociatedFunction
-      (state : State)
       (ty : Ty.t) (name : string) (generic_tys : list Ty.t)
       (associated_function : list Ty.t -> list Value.t -> M)
       (k : Value.t -> M) :
     let closure :=
       Value.Closure (existS (Value.t, M) (associated_function generic_tys)) in
     M.IsAssociatedFunction ty name associated_function ->
-    {{ env, env_to_value, state | k closure ⇓ result | state' }} ->
+    {{ env, env_to_value, state | k closure ⇓ to_value | P_state }} ->
     {{ env, env_to_value, state |
       LowM.CallPrimitive
         (Primitive.GetAssociatedFunction ty name generic_tys) k ⇓
-        result
-    | state' }}
+        to_value
+    | P_state }}
   | CallPrimitiveGetTraitMethod
-      (state : State)
       (trait_name : string) (self_ty : Ty.t) (trait_tys : list Ty.t)
       (method_name : string) (generic_tys : list Ty.t)
       (method : list Ty.t -> list Value.t -> M)
@@ -195,7 +204,7 @@ Module Run.
     let closure :=
       Value.Closure (existS (Value.t, M) (method generic_tys)) in
     IsTraitMethod trait_name self_ty trait_tys method_name method ->
-    {{ env, env_to_value, state | k closure ⇓ result | state' }} ->
+    {{ env, env_to_value, state | k closure ⇓ to_value | P_state }} ->
     {{ env, env_to_value, state |
       LowM.CallPrimitive
         (Primitive.GetTraitMethod
@@ -205,34 +214,92 @@ Module Run.
           method_name
           generic_tys)
         k ⇓
-        result
-    | state' }}
-  | CallClosure
-      (state state_inter : State)
+        to_value
+    | P_state }}
+  | CallClosure {A_inter : Set}
+      (to_value_inter : A_inter -> Value.t + Exception.t) (P_state_inter : State -> Prop)
       (f : list Value.t -> M) (args : list Value.t)
-      (value : Value.t + Exception.t)
       (k : Value.t + Exception.t -> M) :
     let closure := Value.Closure (existS (Value.t, M) f) in
-    {{ env, env_to_value, state | f args ⇓ value | state_inter }} ->
-    {{ env, env_to_value, state_inter | k value ⇓ result | state' }} ->
-    {{ env, env_to_value, state | LowM.CallClosure closure args k ⇓ result | state' }}
+    {{ env, env_to_value, state | f args ⇓ to_value_inter | P_state_inter }} ->
+    (forall (value_inter : A_inter) (state_inter : State),
+      P_state_inter state_inter ->
+      {{ env, env_to_value, state_inter | k (to_value_inter value_inter) ⇓ to_value | P_state }}
+    ) ->
+    {{ env, env_to_value, state | LowM.CallClosure closure args k ⇓ to_value | P_state }}
 
-  where "{{ env , env_to_value , state | e ⇓ result | state' }}" :=
-    (t env env_to_value result state' e state).
+  where "{{ env , env_to_value , state | e ⇓ to_value | P_state }}" :=
+    (t env env_to_value state to_value P_state e).
 
-  Definition pure (e : M) (result : Value.t + Exception.t) : Prop :=
+  Definition pure {A : Set} (e : M) (to_value : A -> Value.t + Exception.t) : Set :=
     forall
       (State Address : Set) `(State.Trait State Address)
       (Env : Set) (env : Env) (env_to_value : Env -> Value.t)
       (state : State),
-    {{ env, env_to_value, state | e ⇓ result | state }}.
+    {{ env, env_to_value, state |
+      e ⇓ to_value
+    | fun state' => state' = state }}.
 End Run.
+
+Import Run.
+
+Fixpoint evaluate `{State.Trait} {Env A : Set}
+    {env : Env} {env_to_value : Env -> Value.t} {state : State}
+    {e : M} {to_value : A -> Value.t + Exception.t}
+    {P_state : State -> Prop}
+    (run : {{ env, env_to_value, state | e ⇓ to_value | P_state }}) :
+  A * { state : State | P_state state }.
+Proof.
+  destruct run.
+  { split.
+    { exact result. }
+    { eexists.
+      match goal with
+      | H : P_state _ |- _ => exact H
+      end.
+    }
+  }
+  { eapply evaluate.
+    exact run.
+  }
+  { eapply evaluate.
+    exact run.
+  }
+  { eapply evaluate.
+    exact run.
+  }
+  { eapply evaluate.
+    exact run.
+  }
+  { eapply evaluate.
+    exact run.
+  }
+  { eapply evaluate.
+    exact run.
+  }
+  { eapply evaluate.
+    exact run.
+  }
+  { eapply evaluate.
+    exact run.
+  }
+  { eapply evaluate.
+    exact run.
+  }
+  { destruct (evaluate _ _ _ _ _ _ _ _ _ _ _ run) as [value_inter [state_inter H_state_inter]].
+    eapply evaluate.
+    match goal with
+    | H : forall _ _ _, _ |- _ => apply (H value_inter)
+    end.
+    exact H_state_inter.
+  }
+Defined.
 
 Module SubPointer.
   Module Runner.
     Module Valid.
       Inductive t {A Sub_A : Set} `{ToValue A} `{ToValue Sub_A} :
-          SubPointer.Runner.t A Sub_A -> Prop :=
+          SubPointer.Runner.t A Sub_A -> Set :=
       | Intro
           (index : Pointer.Index.t)
           (projection : A -> option Sub_A)
@@ -257,28 +324,29 @@ Module SubPointer.
 
   Import Run.
 
-  Lemma run
-      {A Sub_A : Set} `{ToValue A} `{ToValue Sub_A}
+  Definition run
+      {Result : Set} {A Sub_A : Set} `{ToValue A} `{ToValue Sub_A}
       {runner : SubPointer.Runner.t A Sub_A}
       (H_runner : Runner.Valid.t runner)
       (mutable : Pointer.Mutable.t (A := A) Value.t φ)
-      `{State.Trait} {Env : Set} (env : Env) (env_to_value : Env -> Value.t)
-      (result : Value.t + Exception.t) (state state' : State) (k : Value.t -> M)
+      `{State.Trait} {Env : Set} (env : Env) (env_to_value : Env -> Value.t) (state : State)
+      (to_value : Result -> Value.t + Exception.t) (P_state : State -> Prop)
+      (k : Value.t -> M)
       (index : Pointer.Index.t) :
     index = runner.(SubPointer.Runner.index) ->
     {{ env, env_to_value, state |
       k (Value.Pointer (Pointer.Mutable (SubPointer.get_sub mutable runner))) ⇓
-      result
-    | state' }} ->
+      to_value
+    | P_state }} ->
     {{ env, env_to_value, state |
       LowM.CallPrimitive (Primitive.GetSubPointer mutable index) k ⇓
-      result
-    | state' }}.
+      to_value
+    | P_state }}.
   Proof.
     intros.
     destruct H_runner.
     eapply Run.CallPrimitiveGetSubPointer; sfirstorder.
-  Qed.
+  Defined.
 End SubPointer.
 
 (** Simplify the usual case of read of immediate value. *)
@@ -291,27 +359,26 @@ Qed.
 
 Ltac run_symbolic_state_read :=
   match goal with
-  | |- Run.t _ _ _ _ (LowM.CallPrimitive (Primitive.StateRead (
+  | |- Run.t _ _ _ _ _ (LowM.CallPrimitive (Primitive.StateRead (
       Pointer.Mutable.Make ?address _ _ _ _
-    )) _) _ =>
+    )) _) =>
     let H := fresh "H" in
-    epose proof (H := Run.CallPrimitiveStateRead _ _ _ _ address);
+    epose proof (H := Run.CallPrimitiveStateRead _ _ _ _ _ address);
     eapply H; [reflexivity | reflexivity |];
     clear H
   end.
 
 Ltac run_symbolic_state_write :=
   match goal with
-  | |- Run.t ?env ?env_to_value ?result ?state'
+  | |- Run.t ?env ?env_to_value ?state ?to_value ?P_state
       (LowM.CallPrimitive (Primitive.StateWrite (
         Pointer.Mutable.Make ?address ?path ?big_to_value ?projection ?injection
-      ) ?value') ?k)
-      ?state =>
+      ) ?value') ?k) =>
     let H := fresh "H" in
     epose proof (H :=
       Run.CallPrimitiveStateWrite
-        env env_to_value result state' address path big_to_value projection injection _
-        value' _ _ _ _ k
+        env env_to_value state to_value P_state address path big_to_value projection injection _
+        value' _ _ _ k
     );
     apply H; try reflexivity;
     clear H
@@ -322,7 +389,7 @@ Ltac run_symbolic_one_step :=
   | |- Run.t _ _ _ _ _ _ =>
     (* We do not use [Run.CallClosure] and let the user use existing lemma
        for this kind of case. *)
-    apply Run.Pure ||
+    (eapply Run.Pure; trivial) ||
     apply Run.CallPrimitiveStateAllocImmediate ||
     apply Run.CallPrimitiveEnvRead ||
     run_symbolic_state_read ||

--- a/CoqOfRust/revm/instructions/simulations/arithmetic.v
+++ b/CoqOfRust/revm/instructions/simulations/arithmetic.v
@@ -1,0 +1,8 @@
+Require Import CoqOfRust.CoqOfRust.
+Require Import CoqOfRust.proofs.M.
+
+Import Run.
+
+(* Definition run_record_cost 
+
+Definition run_add  *)

--- a/CoqOfRust/revm/instructions/simulations/arithmetic.v
+++ b/CoqOfRust/revm/instructions/simulations/arithmetic.v
@@ -1,8 +1,0 @@
-Require Import CoqOfRust.CoqOfRust.
-Require Import CoqOfRust.proofs.M.
-
-Import Run.
-
-(* Definition run_record_cost 
-
-Definition run_add  *)

--- a/CoqOfRust/revm/simulations/gas.v
+++ b/CoqOfRust/revm/simulations/gas.v
@@ -93,13 +93,17 @@ Module Impl_revm_interpreter_gas_Gas.
   Defined.
 End Impl_revm_interpreter_gas_Gas.
 
-(* Definition dummy_gas : Gas.t := {|
-  Gas.limit := 0;
-  Gas.remaining := 12;
-  Gas.refunded := 0;
-|}.
+Module Test.
+  Definition dummy_gas : Gas.t := {|
+    Gas.limit := 0;
+    Gas.remaining := 12;
+    Gas.refunded := 0;
+  |}.
 
-Definition foo : bool :=
-  fst (evaluate (Impl_revm_interpreter_gas_Gas.run_record_cost dummy_gas 3)).
+  Definition compute_gas (cost : Z) :=
+    evaluate (Impl_revm_interpreter_gas_Gas.run_record_cost dummy_gas cost).
 
-Compute foo. *)
+  Compute compute_gas 3.
+  Compute compute_gas 12.
+  Compute compute_gas 23.
+End Test.

--- a/CoqOfRust/revm/simulations/gas.v
+++ b/CoqOfRust/revm/simulations/gas.v
@@ -1,0 +1,105 @@
+Require Import CoqOfRust.CoqOfRust.
+Require Import CoqOfRust.proofs.M.
+Require Import CoqOfRust.simulations.M.
+Require core.num.mod.
+Require core.num.simulations.mod.
+
+Require Import revm.gas.
+
+Import Run.
+
+Module Gas.
+  (* pub struct Gas {
+      /// The initial gas limit. This is constant throughout execution.
+      limit: u64,
+      /// The remaining gas.
+      remaining: u64,
+      /// Refunded gas. This is used only at the end of execution.
+      refunded: i64,
+  } *)
+  Record t : Set := {
+    limit : Z;
+    remaining : Z;
+    refunded : Z;
+  }.
+
+  Global Instance IsToTy : ToTy t := {
+    Φ := Ty.path "revm_interpreter::gas::Gas";
+  }.
+
+  Global Instance IsToValue : ToValue t := {
+    φ x :=
+      Value.StructRecord "revm_interpreter::gas::Gas" [
+        ("limit", φ x.(limit));
+        ("remaining", φ x.(remaining));
+        ("refunded", φ x.(refunded))
+      ];
+  }.
+
+  Module SubPointer.
+    Definition get_remaining : SubPointer.Runner.t t Z := {|
+      SubPointer.Runner.index :=
+        Pointer.Index.StructRecord "revm_interpreter::gas::Gas" "remaining";
+      SubPointer.Runner.projection x := Some x.(remaining);
+      SubPointer.Runner.injection x y := Some (x <| remaining := y |>);
+    |}.
+
+    Lemma get_remaining_is_valid :
+      SubPointer.Runner.Valid.t get_remaining.
+    Proof.
+      hauto l: on.
+    Qed.
+  End SubPointer.
+End Gas.
+
+Module State.
+  Definition t : Set :=
+    Gas.t.
+
+  Global Instance I : M.State.Trait t unit := {
+    get_Set _ := t;
+    read _ v := Some v;
+    alloc_write _ _ v := Some v;
+  }.
+
+  Lemma is_valid : M.State.Valid.t I.
+    sauto lq: on rew: off.
+  Qed.
+End State.
+
+Module Impl_revm_interpreter_gas_Gas.
+  Definition run_record_cost (state : State.t) (cost : Z) :
+    {{ tt, fun _ => Value.Tuple [], state |
+      gas.Impl_revm_interpreter_gas_Gas.record_cost [] [
+        Value.Pointer (Pointer.mutable (A := Gas.t) tt φ);
+        φ cost
+      ] ⇓
+      (fun (v : bool) => inl (φ v))
+    | fun _ => True }}.
+  Proof.
+    run_symbolic.
+    eapply Run.CallPrimitiveGetAssociatedFunction. {
+      apply core.num.mod.num.Impl_u64.AssociatedFunction_overflowing_sub.
+    }
+    apply (SubPointer.run Gas.SubPointer.get_remaining_is_valid); [reflexivity|].
+    run_symbolic.
+    eapply Run.CallClosure. {
+      apply core.num.simulations.mod.Impl_u64.run_overflowing_sub.
+    }
+    intros [remaining overflow] **; run_symbolic.
+    destruct overflow; run_symbolic.
+    apply (SubPointer.run Gas.SubPointer.get_remaining_is_valid); [reflexivity|].
+    run_symbolic.
+  Defined.
+End Impl_revm_interpreter_gas_Gas.
+
+(* Definition dummy_gas : Gas.t := {|
+  Gas.limit := 0;
+  Gas.remaining := 12;
+  Gas.refunded := 0;
+|}.
+
+Definition foo : bool :=
+  fst (evaluate (Impl_revm_interpreter_gas_Gas.run_record_cost dummy_gas 3)).
+
+Compute foo. *)

--- a/CoqOfRust/simulations/M.v
+++ b/CoqOfRust/simulations/M.v
@@ -9,6 +9,10 @@ Class ToValue (A : Set) : Set := {
   φ : A -> Value.t;
 }.
 
+Global Instance BoolIsToValue : ToValue bool := {
+  φ b := Value.Bool b;
+}.
+
 Global Instance ZIsToValue : ToValue Z := {
   φ z := Value.Integer z;
 }.


### PR DESCRIPTION
Trying to save the time spent writing the Rust simulations. Following the way presented in https://formal.land/blog/2024/05/22/translation-of-python-code-simulations-from-trace

An example that finally works is at the end of https://github.com/formal-land/coq-of-rust/blob/guillaume-claret%40simulation-proofs-in-Set/CoqOfRust/revm/simulations/gas.v :

- We make a proof of simulation for the Rust function:
  ```rust
  pub fn record_cost(&mut self, cost: u64) -> bool {
      let (remaining, overflow) = self.remaining.overflowing_sub(cost);
      let success = !overflow;
      if success {
          self.remaining = remaining;
      }
      success
  }
  ```
- We can compute it with the expected result on a `dummy_gas` for `self` and various values of `cost`, with or without overflow.