### PR TITLE
Various updates of monads and lenses for simulations

### DIFF
--- a/CoqOfRust/revm/simulations/interpreter/instructions/arithmetic.v
+++ b/CoqOfRust/revm/simulations/interpreter/instructions/arithmetic.v
@@ -26,9 +26,12 @@ Require Import CoqOfRust.revm.simulations.interpreter.instructions.i256.
 Definition add :
     MS? Interpreter.t string unit :=
   letS? _ := gas_macro Gas.VERYLOW in
-  letS? '(op1, op2) := pop_top_macro2 in
+  letS? '(op1, op2_ref) := pop_top_macro2 in
   liftS? Interpreter.Lens.stack (
-    Stack.top_unsafe_write (U256.wrapping_add op1 op2)
+    liftS?of!? op2_ref (
+      letS? op2 := readS? in
+      writeS? (U256.wrapping_add op1 op2)
+    )
   ).
 
 (*
@@ -42,9 +45,12 @@ Definition add :
 Definition mul :
     MS? Interpreter.t string unit :=
   letS? _ := gas_macro Gas.LOW in
-  letS? '(op1, op2) := pop_top_macro2 in
+  letS? '(op1, op2_ref) := pop_top_macro2 in
   liftS? Interpreter.Lens.stack (
-    Stack.top_unsafe_write (U256.wrapping_mul op1 op2)
+    liftS?of!? op2_ref (
+      letS? op2 := readS? in
+      writeS? (U256.wrapping_mul op1 op2)
+    )
   ).
 
 (*
@@ -58,9 +64,12 @@ Definition mul :
 Definition sub :
     MS? Interpreter.t string unit :=
   letS? _ := gas_macro Gas.VERYLOW in
-  letS? '(op1, op2) := pop_top_macro2 in
+  letS? '(op1, op2_ref) := pop_top_macro2 in
   liftS? Interpreter.Lens.stack (
-    Stack.top_unsafe_write (U256.wrapping_sub op1 op2)
+    liftS?of!? op2_ref (
+      letS? op2 := readS? in
+      writeS? (U256.wrapping_sub op1 op2)
+    )
   ).
 
 (*
@@ -76,11 +85,14 @@ Definition sub :
 Definition div :
     MS? Interpreter.t string unit :=
   letS? _ := gas_macro Gas.LOW in
-  letS? '(op1, op2) := pop_top_macro2 in
-  if U256.eq op2 U256.ZERO
-  then returnS? tt
-  else liftS? Interpreter.Lens.stack (
-    Stack.top_unsafe_write (U256.wrapping_div op1 op2)
+  letS? '(op1, op2_ref) := pop_top_macro2 in
+  liftS? Interpreter.Lens.stack (
+    liftS?of!? op2_ref (
+      letS? op2 := readS? in
+      if U256.eq op2 U256.ZERO
+      then returnS? tt
+      else writeS? (U256.wrapping_div op1 op2)
+    )
   ).
 
 (*
@@ -94,9 +106,12 @@ Definition div :
 Definition sdiv :
     MS? Interpreter.t string unit :=
   letS? _ := gas_macro Gas.LOW in
-  letS? '(op1, op2) := pop_top_macro2 in
+  letS? '(op1, op2_ref) := pop_top_macro2 in
   liftS? Interpreter.Lens.stack (
-    Stack.top_unsafe_write (i256_div op1 op2)
+    liftS?of!? op2_ref (
+      letS? op2 := readS? in
+      writeS? (i256_div op1 op2)
+    )
   ).
 
 (*
@@ -112,11 +127,14 @@ Definition sdiv :
 Definition rem :
     MS? Interpreter.t string unit :=
   letS? _ := gas_macro Gas.LOW in
-  letS? '(op1, op2) := pop_top_macro2 in
-  if U256.eq op2 U256.ZERO
-  then returnS? tt
-  else liftS? Interpreter.Lens.stack (
-    Stack.top_unsafe_write (U256.wrapping_rem op1 op2)
+  letS? '(op1, op2_ref) := pop_top_macro2 in
+  liftS? Interpreter.Lens.stack (
+    liftS?of!? op2_ref (
+      letS? op2 := readS? in
+      if U256.eq op2 U256.ZERO
+      then returnS? tt
+      else writeS? (U256.wrapping_rem op1 op2)
+    )
   ).
 
 (*
@@ -130,9 +148,12 @@ Definition rem :
 Definition smod :
     MS? Interpreter.t string unit :=
   letS? _ := gas_macro Gas.LOW in
-  letS? '(op1, op2) := pop_top_macro2 in
+  letS? '(op1, op2_ref) := pop_top_macro2 in
   liftS? Interpreter.Lens.stack (
-    Stack.top_unsafe_write (i256_mod op1 op2)
+    liftS?of!? op2_ref (
+      letS? op2 := readS? in
+      writeS? (i256_mod op1 op2)
+    )
   ).
 
 (*
@@ -146,9 +167,12 @@ Definition smod :
 Definition addmod :
   MS? Interpreter.t string unit :=
   letS? _ := gas_macro Gas.MID in
-  letS? '(op1, op2, op3) := pop_top_macro3 in
+  letS? '(op1, op2, op3_ref) := pop_top_macro3 in
   liftS? Interpreter.Lens.stack (
-    Stack.top_unsafe_write (U256.add_mod op1 op2 op3)
+    liftS?of!? op3_ref (
+      letS? op3 := readS? in
+      writeS? (U256.add_mod op1 op2 op3)
+    )
   ).
 
 (*
@@ -162,9 +186,12 @@ Definition addmod :
 Definition mulmod :
   MS? Interpreter.t string unit :=
   letS? _ := gas_macro Gas.MID in
-  letS? '(op1, op2, op3) := pop_top_macro3 in
+  letS? '(op1, op2, op3_ref) := pop_top_macro3 in
   liftS? Interpreter.Lens.stack (
-    Stack.top_unsafe_write (U256.mul_mod op1 op2 op3)
+    liftS?of!? op3_ref (
+      letS? op3 := readS? in
+      writeS? (U256.mul_mod op1 op2 op3)
+    )
   ).
 
 (*
@@ -177,10 +204,13 @@ Definition mulmod :
 
 Definition exp (SPEC : Spec.t) :
     MS? Interpreter.t string unit :=
-  letS? '(op1, op2) := pop_top_macro2 in
+  letS? '(op1, op2_ref) := pop_top_macro2 in
+  letS? op2 := liftS? Interpreter.Lens.stack (
+    liftS?of!? op2_ref readS?
+  ) in
   letS? _ := gas_or_fail_macro (exp_cost (Spec.SPEC_ID SPEC) op2) in
   liftS? Interpreter.Lens.stack (
-    Stack.top_unsafe_write (U256.wrapping_pow op1 op2)
+    liftS?of!? op2_ref (writeS? (U256.wrapping_pow op1 op2))
   ).
 
 (*
@@ -201,22 +231,25 @@ Definition exp (SPEC : Spec.t) :
 Definition signextend :
     MS? Interpreter.t string unit :=
   letS? _ := gas_macro Gas.LOW in
-  letS? '(ext, x) := pop_top_macro2 in
-  if U256.lt ext (U256.from 31)
-  then
-    let ext := hd 0 (U256.as_limbs ext) in
-    let bit_index := (8 * ext + 7)%Z in
-    let bit := U256.bit x bit_index in
-    let mask :=
-      U256.wrapping_sub
-        (U256.shl (U256.from 1) bit_index)
-        (U256.from 1) in
-    liftS? Interpreter.Lens.stack (
-      Stack.top_unsafe_write (
-        if bit
-        then U256.or x (U256.not mask)
-        else U256.and x mask
-      )
+  letS? '(ext, x_ref) := pop_top_macro2 in
+  liftS? Interpreter.Lens.stack (
+    liftS?of!? x_ref (
+      letS? x := readS? in
+      if U256.lt ext (U256.from 31)
+      then
+        let ext := hd 0 (U256.as_limbs ext) in
+        let bit_index := (8 * ext + 7)%Z in
+        let bit := U256.bit x bit_index in
+        let mask :=
+          U256.wrapping_sub
+            (U256.shl (U256.from 1) bit_index)
+            (U256.from 1) in
+        writeS? (
+          if bit
+          then U256.or x (U256.not mask)
+          else U256.and x mask
+        )
+      else
+        returnS? tt
     )
-  else
-    returnS? tt.
+  ). 

--- a/CoqOfRust/revm/simulations/interpreter/instructions/macros.v
+++ b/CoqOfRust/revm/simulations/interpreter/instructions/macros.v
@@ -5,6 +5,7 @@ Import simulations.M.Notations.
 Require Import CoqOfRust.revm.links.dependencies.
 Require Import CoqOfRust.revm.links.interpreter.interpreter.
 Require Import CoqOfRust.revm.links.interpreter.interpreter.gas.
+Require Import CoqOfRust.revm.links.interpreter.interpreter.stack.
 Require Import CoqOfRust.revm.links.interpreter.interpreter.instruction_result.
 Require Import CoqOfRust.revm.simulations.interpreter.interpreter.
 Require Import CoqOfRust.revm.simulations.interpreter.interpreter.gas.
@@ -101,7 +102,7 @@ Definition gas_or_fail_macro (gas : option Z) :
 *)
 
 Definition pop_top_macro1 :
-  MS? Interpreter.t string U256.t :=
+  MS? Interpreter.t string (LensPanic.t string Stack.t U256.t) :=
   letS? interp := readS? in
   if Stack.len (Interpreter.stack interp) <? 1
   then
@@ -110,10 +111,10 @@ Definition pop_top_macro1 :
     |>) in
     panicS? "Stack underflow"
   else
-    liftS? Interpreter.Lens.stack Stack.top_unsafe.
+    returnS? Stack.top_unsafe.
 
 Definition pop_top_macro2 :
-  MS? Interpreter.t string (U256.t * U256.t) :=
+  MS? Interpreter.t string (U256.t * LensPanic.t string Stack.t U256.t) :=
   letS? interp := readS? in
   if Stack.len (Interpreter.stack interp) <? 2
   then
@@ -125,7 +126,7 @@ Definition pop_top_macro2 :
     liftS? Interpreter.Lens.stack Stack.pop_top_unsafe.
 
 Definition pop_top_macro3 :
-  MS? Interpreter.t string (U256.t * U256.t * U256.t) :=
+  MS? Interpreter.t string (U256.t * U256.t * LensPanic.t string Stack.t U256.t) :=
   letS? interp := readS? in
   if Stack.len (Interpreter.stack interp) <? 3
   then

--- a/CoqOfRust/revm/simulations/interpreter/interpreter/stack.v
+++ b/CoqOfRust/revm/simulations/interpreter/interpreter/stack.v
@@ -67,21 +67,19 @@ Module Stack.
           self.data.get_unchecked_mut(len - 1)
       }
   *)
-  Definition top_unsafe :
-      MS? Stack.t string U256.t :=
-    letS? '(Stack.data stack) := readS? in
-    match stack with
-    | [] => panicS? "Stack underflow"
-    | x :: _ => returnS? x
-    end.
 
-  Definition top_unsafe_write (a : U256.t) :
-      MS? Stack.t string unit :=
-    letS? '(Stack.data stack) := readS? in
-    match stack with
-    | [] => panicS? "Stack underflow"
-    | _ :: xs => writeS? (Stack.data (a :: xs))
-    end.
+  Definition top_unsafe : LensPanic.t string Stack.t U256.t := {|
+    LensPanic.read '(Stack.data stack) :=
+      match stack with
+      | [] => panic!? "Stack underflow"
+      | x :: _ => return!? x
+      end;
+    LensPanic.write '(Stack.data stack) x :=
+      match stack with
+      | [] => panic!? "Stack underflow"
+      | _ :: xs => return!? (Stack.data (x :: xs))
+      end
+  |}.
 
   (*
       /// Pop the topmost value, returning the value and the new topmost value.
@@ -97,10 +95,9 @@ Module Stack.
       }
   *)
   Definition pop_top_unsafe :
-      MS? Stack.t string (U256.t * U256.t) :=
+      MS? Stack.t string (U256.t * LensPanic.t string Stack.t U256.t) :=
     letS? pop := pop_unsafe in
-    letS? top := top_unsafe in
-    returnS? (pop, top).
+    returnS? (pop, top_unsafe).
   
   (*
     /// Pops 2 values from the stack and returns them, in addition to the new topmost value.
@@ -118,9 +115,8 @@ Module Stack.
     }
   *)
   Definition pop2_top_unsafe :
-      MS? Stack.t string (U256.t * U256.t * U256.t) :=
+      MS? Stack.t string (U256.t * U256.t * LensPanic.t string Stack.t U256.t) :=
     letS? pop1 := pop_unsafe in
     letS? pop2 := pop_unsafe in
-    letS? top := top_unsafe in
-    returnS? (pop1, pop2, top).
+    returnS? (pop1, pop2, top_unsafe).
 End Stack.


### PR DESCRIPTION
This pull request implements various updates of monads and lenses for simulations:
- Instead of the `Error` monad which was used previously, `Panic` and `Result` monads are defined to model different kinds of error handling within Rust programs. To complement the `Result` monad, `Option` monad is also defined
- New notations for these monads: `M?` for `Option` monad, `M??` for `Result` monad and `M!?` for `Panic` monad
- New lens: `LensOption`. For this lens, `read` and `write` operations can fail by returning `None` value. The `lift` function for this lens allows to lift state monad computation that returns `option` value
- New lens: `LensPanic`. For this lens, `read` and `write` operations can fail with a panic. If within the `lift` function one of these operations fail, than the result would be the computation that panics
- Notations for different structures are now defined in separate modules, but single `Notations` module that re-exports all notations is also added

Additionally, REVM stack operations are rewritten using `LensPanic`. This provides an example of how lenses can be used to represent subpointers (mutable references). In this example, `LensPanic` is necessary, as the lens is used to represent `top_unsafe` operation, which fails with a panic when called on an empty stack.