### PR TITLE
Move `AbstractStack` Tests

### DIFF
--- a/CoqOfRust/core/simulations/assert.v
+++ b/CoqOfRust/core/simulations/assert.v
@@ -1,0 +1,33 @@
+Require Import Coq.Strings.String.
+Require Import CoqOfRust.simulations.M.
+Import simulations.M.Notations.
+Require Import CoqOfRust.core.simulations.bool.
+Import simulations.bool.Notations.
+Require Import CoqOfRust.core.simulations.eq.
+Import simulations.eq.Notations.
+
+Module Assert.
+  Definition assert {State : Set} (b : MS? State string bool) :
+      MS? State string unit :=
+    ifS? b
+    then returnS? tt
+    else panicS? "assertion failed".
+
+  Definition assert_eq
+      {State A : Set} (x y :  MS? State string A) `{Eq.Trait A} :
+      MS? State string unit :=
+    assert (
+      letS? x := x in
+      letS? y := y in
+      returnS? (x =? y)
+    ).
+
+  Definition test {State : Set} (x : MS? State string unit) (s : State) : Prop :=
+    fst (x s) = return!? tt.
+End Assert.
+
+Module Notations.
+  Notation "assertS?" := Assert.assert.
+  Notation "assert_eqS?" := Assert.assert_eq.
+  Notation "testS?" := Assert.test.
+End Notations.

--- a/CoqOfRust/core/simulations/assert.v
+++ b/CoqOfRust/core/simulations/assert.v
@@ -7,20 +7,31 @@ Require Import CoqOfRust.core.simulations.eq.
 Import simulations.eq.Notations.
 
 Module Assert.
-  Definition assert {State : Set} (b : MS? State string bool) :
+  Module Stateful.
+    Definition assert {State : Set} (b : MS? State string bool) :
+        MS? State string unit :=
+      ifS? b
+      then returnS? tt
+      else panicS? "assertion failed".
+
+    Definition assert_eq
+        {State A : Set} (x y :  MS? State string A) `{Eq.Trait A} :
+        MS? State string unit :=
+      assert (
+        letS? x := x in
+        letS? y := y in
+        returnS? (x =? y)
+      ).
+  End Stateful.
+
+  Definition assert {State : Set} (b : bool) :
       MS? State string unit :=
-    ifS? b
-    then returnS? tt
-    else panicS? "assertion failed".
+    Stateful.assert (returnS? b).
 
   Definition assert_eq
-      {State A : Set} (x y :  MS? State string A) `{Eq.Trait A} :
+      {State A : Set} (x y : A) `{Eq.Trait A} :
       MS? State string unit :=
-    assert (
-      letS? x := x in
-      letS? y := y in
-      returnS? (x =? y)
-    ).
+    Stateful.assert_eq (returnS? x) (returnS? y).
 
   Definition test {State : Set} (x : MS? State string unit) (s : State) : Prop :=
     fst (x s) = return!? tt.
@@ -29,5 +40,9 @@ End Assert.
 Module Notations.
   Notation "assertS?" := Assert.assert.
   Notation "assert_eqS?" := Assert.assert_eq.
+
+  Notation "assertS?ofS?" := Assert.Stateful.assert.
+  Notation "assert_eqS?ofS?" := Assert.Stateful.assert_eq.
+
   Notation "testS?" := Assert.test.
 End Notations.

--- a/CoqOfRust/core/simulations/bool.v
+++ b/CoqOfRust/core/simulations/bool.v
@@ -1,6 +1,7 @@
 Require Import Coq.Strings.String.
 Require Import CoqOfRust.simulations.M.
 Import simulations.M.Notations.
+Require Import CoqOfRust.core.simulations.eq.
 
 Module Bool.
   Definition and {State Error} (x y : MS? State Error bool) : MS? State Error bool :=
@@ -41,3 +42,10 @@ Module Notations.
   Notation "'notS?' b" := (Bool.not b) (at level 60).
   Notation "'ifS?' b 'then' x 'else' y" := (Bool.if_then_else b x y) (at level 200, right associativity).
 End Notations.
+
+Module ImplEq.
+  Global Instance I :
+    Eq.Trait bool := {
+      eqb := Bool.eqb;
+    }.
+End ImplEq.

--- a/CoqOfRust/core/simulations/eq.v
+++ b/CoqOfRust/core/simulations/eq.v
@@ -1,0 +1,9 @@
+Module Eq.
+  Class Trait (Self : Set) : Set := {
+    eqb: Self -> Self -> bool
+  }.
+End Eq.
+
+Module Notations.
+  Notation "x =? y" := (Eq.eqb x y) (at level 70).
+End Notations.

--- a/CoqOfRust/core/simulations/integers.v
+++ b/CoqOfRust/core/simulations/integers.v
@@ -16,3 +16,10 @@ Module ImplEq.
       eqb := Z.eqb;
     }.
 End ImplEq.
+
+Module ImplEqNat.
+  Global Instance I :
+    Eq.Trait nat := {
+      eqb := Nat.eqb;
+    }.
+End ImplEqNat.

--- a/CoqOfRust/core/simulations/integers.v
+++ b/CoqOfRust/core/simulations/integers.v
@@ -1,5 +1,6 @@
 Require Import CoqOfRust.CoqOfRust.
 Require Import simulations.M.
+Require Import CoqOfRust.core.simulations.eq.
 
 Module U64.
   Definition checked_add (a b : Z) : option Z :=
@@ -8,3 +9,10 @@ Module U64.
     then Some r
     else None.
 End U64.
+
+Module ImplEq.
+  Global Instance I :
+    Eq.Trait Z := {
+      eqb := Z.eqb;
+    }.
+End ImplEq.

--- a/CoqOfRust/core/simulations/option.v
+++ b/CoqOfRust/core/simulations/option.v
@@ -1,7 +1,8 @@
 Require Import CoqOfRust.CoqOfRust.
 Require Import simulations.M.
-Require CoqOfRust.core.simulations.default.
 Import simulations.M.Notations.
+Require Import CoqOfRust.core.simulations.default.
+Require Import CoqOfRust.core.simulations.eq.
 
 Module Option.
   Definition Self (T : Set) : Set :=
@@ -30,9 +31,28 @@ Module Option.
     expect self "".
 End Option.
 
-Module Impl_Default_for_Option_T.
+Module ImplDefault.
   Global Instance I (T : Set) :
-      core.simulations.default.Default.Trait (option T) := {
-    default := None;
-  }.
-End Impl_Default_for_Option_T.
+    Default.Trait (option T) := {
+      default := None;
+    }.
+End ImplDefault.
+
+Module ImplEq.
+  Global Instance I (T : Set) `{Eq.Trait T} :
+    Eq.Trait (option T) := {
+      eqb x y := 
+        match x with
+        | Some a =>
+          match y with
+          | Some b => Eq.eqb a b
+          | None => false
+          end
+        | None =>
+          match y with
+          | Some _ => false
+          | None => true
+          end
+        end;
+    }.
+End ImplEq.

--- a/CoqOfRust/core/simulations/result.v
+++ b/CoqOfRust/core/simulations/result.v
@@ -1,0 +1,24 @@
+Require Import CoqOfRust.CoqOfRust.
+Require Import simulations.M.
+Import simulations.M.Notations.
+Require Import CoqOfRust.core.simulations.default.
+Require Import CoqOfRust.core.simulations.eq.
+
+Module ImplEq.
+  Global Instance I (A E : Set) `{Eq.Trait A} `{Eq.Trait E} :
+    Eq.Trait (Result.t A E) := {
+      eqb x y := 
+        match x with
+        | Result.Ok a =>
+          match y with
+          | Result.Ok b => Eq.eqb a b
+          | Result.Err _ => false
+          end
+        | Result.Err e1 =>
+          match y with
+          | Result.Ok _ => false
+          | Result.Err e2 => Eq.eqb e1 e2
+          end
+        end;
+    }.
+End ImplEq.

--- a/CoqOfRust/core/simulations/tuple.v
+++ b/CoqOfRust/core/simulations/tuple.v
@@ -1,0 +1,12 @@
+Require Import CoqOfRust.CoqOfRust.
+Require Import simulations.M.
+Import simulations.M.Notations.
+Require Import CoqOfRust.core.simulations.eq.
+Import simulations.eq.Notations.
+
+Module ImplEq.
+  Global Instance I (A B : Set) `{Eq.Trait A} `{Eq.Trait B} :
+    Eq.Trait (A * B) := {
+      eqb '(a, b) '(c, d) := ((a =? c) && (b =? d))%bool;
+    }.
+End ImplEq.

--- a/CoqOfRust/core/simulations/unit.v
+++ b/CoqOfRust/core/simulations/unit.v
@@ -1,0 +1,11 @@
+Require Import Coq.Strings.String.
+Require Import CoqOfRust.simulations.M.
+Import simulations.M.Notations.
+Require Import CoqOfRust.core.simulations.eq.
+
+Module ImplEq.
+  Global Instance I :
+    Eq.Trait unit := {
+      eqb _ _ := true;
+    }.
+End ImplEq.

--- a/CoqOfRust/core/simulations/vector.v
+++ b/CoqOfRust/core/simulations/vector.v
@@ -34,7 +34,7 @@ Module Vector.
   Definition pop_front {A : Set} : MS? (list A) string (option A) :=
     letS? l := readS? in
     match l with
-    | [] => panicS? "pop_front: empty vector"
+    | [] => returnS? None
     | x :: xs =>
       letS? _ := writeS? xs in
       returnS? (Some x)
@@ -43,11 +43,11 @@ Module Vector.
   Definition pop {A : Set} : MS? (list A) string (option A) :=
     letS? l := readS? in
     match last_error l with
-    | None => panicS? "pop: empty vector"
+    | None => returnS? None
     | Some x =>
       letS? _ := writeS? (List.removelast l) in
       returnS? (Some x)
-    end.  
+    end.
 End Vector.
 
 Module ImplEq.

--- a/CoqOfRust/core/simulations/vector.v
+++ b/CoqOfRust/core/simulations/vector.v
@@ -1,6 +1,7 @@
 Require Import CoqOfRust.CoqOfRust.
 Require Import simulations.M.
 Import simulations.M.Notations.
+Require Import CoqOfRust.core.simulations.eq.
 
 Fixpoint last_error {A : Set} (l : list A) : option A :=
   match l with
@@ -48,3 +49,10 @@ Module Vector.
       returnS? (Some x)
     end.  
 End Vector.
+
+Module ImplEq.
+  Global Instance I (A : Set) `{Eq.Trait A} :
+    Eq.Trait (list A) := {
+      eqb := List.eqb (Eq.eqb);
+    }.
+End ImplEq.

--- a/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
@@ -197,7 +197,7 @@ Module AbstractStack.
     }
   *)
 
-  Definition pop_eq_n {A : Set} (item : A) (n : Z) :
+  Definition pop_eq_n {A : Set} (n : Z) :
       MS? (t A) string (Result.t A AbsStackError.t) :=
     letS? self := readS? in
     if (is_empty self || (n >? len self))%bool 
@@ -225,9 +225,9 @@ Module AbstractStack.
     }
   *)
 
-  Definition pop {A : Set} (item : A) :
+  Definition pop {A : Set} :
       MS? (t A) string (Result.t A AbsStackError.t) :=
-    pop_eq_n item 1.
+    pop_eq_n 1.
 
   (*
     /// Pop any n items off the stack. Unlike `pop_n`, items do not have to be equal

--- a/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
@@ -104,6 +104,11 @@ Module AbstractStack.
     | _ => false
     end.
 
+  Definition self_is_empty {A : Set} :
+      MS? (t A) string bool :=
+    letS? s := readS? in
+    returnS? (is_empty s).
+
   (*
     /// Push n copies of an item on the stack
     pub fn push_n(&mut self, item: T, n: u64) -> Result<(), AbsStackError> {

--- a/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
@@ -148,13 +148,14 @@ Module AbstractStack.
           letS? result := liftS?of? Vector.first_mut readS? in
           match result with
           | Some (count, last_item) =>
-            liftS?of!? (lens!?of? Vector.first_mut) (
               if item =? last_item
               then
+              liftS?of!? (lens!?of? Vector.first_mut) (
                 writeS? ((count + n)%Z, last_item)
+              )
               else
-                returnS? tt
-            )
+              letS? values := readS? in
+              writeS? ((n, item) :: values)
           | None =>
             letS? values := readS? in
             writeS? ((n, item) :: values)

--- a/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
@@ -131,7 +131,7 @@ Module AbstractStack.
     }
   *)
 
-  Definition push_n {A : Set} (item : A) (eq : A -> A -> bool) (n : Z) :
+  Definition push_n {A : Set} (item : A) `{Eq.Trait A} (n : Z) :
       MS? (t A) string (Result.t unit AbsStackError.t) :=
     if n =? 0
     then returnS? (Result.Ok tt)
@@ -146,7 +146,7 @@ Module AbstractStack.
           match result with
           | Some (count, last_item) =>
             liftS?of!? (lens!?of? Vector.first_mut) (
-              if eq item last_item
+              if item =? last_item
               then
                 writeS? ((count + n)%Z, last_item)
               else
@@ -167,9 +167,9 @@ Module AbstractStack.
     }
   *)
 
-  Definition push {A : Set} (item : A) (eq : A -> A -> bool) :
+  Definition push {A : Set} (item : A) `{Eq.Trait A} :
       MS? (t A) string (Result.t unit AbsStackError.t) :=
-    push_n item eq 1.
+    push_n item 1.
 
   (*
     /// Pops n values off the stack, erroring if there are not enough items or if the n items are

--- a/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
@@ -273,7 +273,7 @@ Module AbstractStack.
         match l with
         | O => panicS? "unreachable"
         | S l' => 
-          letS? _ := Vector.pop in
+          letS? _ := Vector.pop_front in
           pop_any_n_helper l' (rem - count)
         end
       else
@@ -290,6 +290,6 @@ Module AbstractStack.
         letS? values := readS? in
         pop_any_n_helper (List.length values) n
       ) in
-      letS? _ := writeS? (self <| len := len self - n |>) in
+      letS? _ := liftS? Lens.len (writeS? (len self - n)) in
       returnS? (Result.Ok tt).
 End AbstractStack.

--- a/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
@@ -55,7 +55,20 @@ Module AbstractStack.
       Lens.read stack := values stack;
       Lens.write stack vs := stack <| values := vs |>
     |}.
+
+    Definition len {A : Set} : Lens.t (t A) Z := {|
+      Lens.read stack := len stack;
+      Lens.write stack x := stack <| len := x |>
+    |}.
   End Lens.
+
+  Definition self_values {A : Set} :
+      MS? (t A) string (list (Z * A)) :=
+    liftS? Lens.values readS?.
+
+  Definition self_len {A : Set} :
+      MS? (t A) string Z :=
+    liftS? Lens.len readS?.
 
   (*
     /// Creates an empty stack
@@ -93,6 +106,11 @@ Module AbstractStack.
       MS? (t A) string bool :=
     letS? s := readS? in
     returnS? (is_empty s).
+
+  Definition self_is_not_empty {A : Set} :
+      MS? (t A) string bool :=
+    letS? s := readS? in
+    returnS? (negb (is_empty s)).
 
   (*
     /// Push n copies of an item on the stack

--- a/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
@@ -22,27 +22,12 @@ Module AbsStackError.
   | Underflow
   | Overflow.
 
+  Scheme Boolean Equality for t.
+
   Module ImplEq.
     Global Instance I :
       Eq.Trait AbsStackError.t := {
-        eqb e1 e2 :=
-          match e1 with
-          | AbsStackError.ElementNotEqual => 
-            match e2 with
-            | AbsStackError.ElementNotEqual => true
-            | _ => false
-            end
-          | AbsStackError.Underflow => 
-            match e2 with
-            | AbsStackError.Underflow => true
-            | _ => false
-            end
-          | AbsStackError.Overflow =>
-            match e2 with
-            | AbsStackError.Overflow => true
-            | _ => false
-            end
-          end;
+        eqb := t_beq;
       }.
   End ImplEq.
 End AbsStackError.

--- a/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
@@ -3,7 +3,9 @@ Require Import CoqOfRust.simulations.M.
 Require Import CoqOfRust.core.simulations.integers.
 Require Import CoqOfRust.core.simulations.vector.
 Require Import CoqOfRust.core.simulations.option.
+Require Import CoqOfRust.core.simulations.eq.
 Import simulations.M.Notations.
+Import simulations.eq.Notations.
 
 (*
   #[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Copy, Debug)]
@@ -19,6 +21,30 @@ Module AbsStackError.
   | ElementNotEqual
   | Underflow
   | Overflow.
+
+  Module ImplEq.
+    Global Instance I :
+      Eq.Trait AbsStackError.t := {
+        eqb e1 e2 :=
+          match e1 with
+          | AbsStackError.ElementNotEqual => 
+            match e2 with
+            | AbsStackError.ElementNotEqual => true
+            | _ => false
+            end
+          | AbsStackError.Underflow => 
+            match e2 with
+            | AbsStackError.Underflow => true
+            | _ => false
+            end
+          | AbsStackError.Overflow =>
+            match e2 with
+            | AbsStackError.Overflow => true
+            | _ => false
+            end
+          end;
+      }.
+  End ImplEq.
 End AbsStackError.
 
 (*

--- a/CoqOfRust/move_sui/simulations/move_abstract_stack/unit_tests/mod.v
+++ b/CoqOfRust/move_sui/simulations/move_abstract_stack/unit_tests/mod.v
@@ -27,28 +27,28 @@ Import simulations.assert.Notations.
 Definition test_empty_stack :
     MS? (AbstractStack.t Z) string unit :=
   letS? empty := readS? in
-  letS? _ := assertS? (AbstractStack.self_is_empty) in
+  letS? _ := assertS?ofS? AbstractStack.self_is_empty in
   letS? _ :=
-    assert_eqS?
+    assert_eqS?ofS?
       (AbstractStack.pop)
       (returnS? (Result.Err AbsStackError.Underflow)) in
   letS? _ :=
-    assert_eqS?
+    assert_eqS?ofS?
       (AbstractStack.pop_any_n 1)
       (returnS? (Result.Err AbsStackError.Underflow)) in
   letS? _ :=
-    assert_eqS?
+    assert_eqS?ofS?
       (AbstractStack.pop_any_n 100)
       (returnS? (Result.Err AbsStackError.Underflow)) in
   letS? _ :=
-    assert_eqS?
+    assert_eqS?ofS?
       (AbstractStack.pop_eq_n 12)
       (returnS? (Result.Err AbsStackError.Underflow)) in
   letS? _ :=
-    assert_eqS?
+    assert_eqS?ofS?
       (AbstractStack.pop_eq_n 112)
       (returnS? (Result.Err AbsStackError.Underflow)) in
-  assertS? (AbstractStack.self_is_empty).
+  assertS?ofS? AbstractStack.self_is_empty.
 
 Lemma test_empty_stack_correct :
   testS? test_empty_stack AbstractStack.new.

--- a/CoqOfRust/move_sui/simulations/move_abstract_stack/unit_tests/mod.v
+++ b/CoqOfRust/move_sui/simulations/move_abstract_stack/unit_tests/mod.v
@@ -1,0 +1,57 @@
+Require Import CoqOfRust.CoqOfRust.
+Require Import CoqOfRust.simulations.M.
+Require Import CoqOfRust.core.simulations.unit.
+Require Import CoqOfRust.core.simulations.result.
+Require Import CoqOfRust.core.simulations.assert.
+Require Import CoqOfRust.move_sui.simulations.move_abstract_stack.lib.
+Import simulations.M.Notations.
+Import simulations.assert.Notations.
+
+(*
+  #[test]
+  fn test_empty_stack() {
+      let mut empty = AbstractStack::<usize>::new();
+      assert!(empty.is_empty());
+
+      // pop on empty stack
+      assert_eq!(empty.pop(), Err(AbsStackError::Underflow));
+      assert_eq!(empty.pop_any_n(nonzero(1)), Err(AbsStackError::Underflow));
+      assert_eq!(empty.pop_any_n(nonzero(100)), Err(AbsStackError::Underflow));
+      assert_eq!(empty.pop_eq_n(nonzero(12)), Err(AbsStackError::Underflow));
+      assert_eq!(empty.pop_eq_n(nonzero(112)), Err(AbsStackError::Underflow));
+
+      assert!(empty.is_empty());
+  }
+*)
+
+Definition test_empty_stack :
+    MS? (AbstractStack.t Z) string unit :=
+  letS? empty := readS? in
+  letS? _ := assertS? (AbstractStack.self_is_empty) in
+  letS? _ :=
+    assert_eqS?
+      (AbstractStack.pop)
+      (returnS? (Result.Err AbsStackError.Underflow)) in
+  letS? _ :=
+    assert_eqS?
+      (AbstractStack.pop_any_n 1)
+      (returnS? (Result.Err AbsStackError.Underflow)) in
+  letS? _ :=
+    assert_eqS?
+      (AbstractStack.pop_any_n 100)
+      (returnS? (Result.Err AbsStackError.Underflow)) in
+  letS? _ :=
+    assert_eqS?
+      (AbstractStack.pop_eq_n 12)
+      (returnS? (Result.Err AbsStackError.Underflow)) in
+  letS? _ :=
+    assert_eqS?
+      (AbstractStack.pop_eq_n 112)
+      (returnS? (Result.Err AbsStackError.Underflow)) in
+  assertS? (AbstractStack.self_is_empty).
+
+Lemma test_empty_stack_correct :
+  testS? test_empty_stack AbstractStack.new.
+Proof.
+  reflexivity.
+Qed.

--- a/CoqOfRust/move_sui/simulations/move_abstract_stack/unit_tests/mod.v
+++ b/CoqOfRust/move_sui/simulations/move_abstract_stack/unit_tests/mod.v
@@ -55,3 +55,287 @@ Lemma test_empty_stack_correct :
 Proof.
   reflexivity.
 Qed.
+
+(*
+  #[test]
+  fn test_simple_push_pop() {
+      let mut s = AbstractStack::new();
+      s.push(1).unwrap();
+      assert!(!s.is_empty());
+      assert_eq!(s.len(), 1);
+      s.assert_run_lengths([1]);
+      assert_eq!(s.pop(), Ok(1));
+      assert!(s.is_empty());
+      assert_eq!(s.len(), 0);
+
+      s.push(1).unwrap();
+      s.push(2).unwrap();
+      s.push(3).unwrap();
+      assert!(!s.is_empty());
+      assert_eq!(s.len(), 3);
+      s.assert_run_lengths([1, 1, 1]);
+      assert_eq!(s.pop(), Ok(3));
+      assert_eq!(s.pop(), Ok(2));
+      assert_eq!(s.pop(), Ok(1));
+      assert!(s.is_empty());
+      assert_eq!(s.len(), 0);
+
+      s.push_n(1, 1).unwrap();
+      s.push_n(2, 2).unwrap();
+      s.push_n(3, 3).unwrap();
+      assert!(!s.is_empty());
+      assert_eq!(s.len(), 6);
+      s.assert_run_lengths([1, 2, 3]);
+      assert_eq!(s.pop(), Ok(3));
+      assert_eq!(s.pop(), Ok(3));
+      assert_eq!(s.pop(), Ok(3));
+      assert_eq!(s.pop(), Ok(2));
+      assert_eq!(s.pop(), Ok(2));
+      assert_eq!(s.pop(), Ok(1));
+      assert!(s.is_empty());
+      assert_eq!(s.len(), 0);
+
+      s.push_n(1, 1).unwrap();
+      s.push_n(2, 2).unwrap();
+      s.push_n(3, 3).unwrap();
+      assert!(!s.is_empty());
+      assert_eq!(s.len(), 6);
+      s.assert_run_lengths([1, 2, 3]);
+      assert_eq!(s.pop_eq_n(nonzero(3)), Ok(3));
+      assert_eq!(s.pop_eq_n(nonzero(2)), Ok(2));
+      assert_eq!(s.pop_eq_n(nonzero(1)), Ok(1));
+      assert!(s.is_empty());
+      assert_eq!(s.len(), 0);
+
+      s.push(1).unwrap();
+      s.push(2).unwrap();
+      s.push(2).unwrap();
+      s.push(3).unwrap();
+      s.push(3).unwrap();
+      s.push(3).unwrap();
+      assert!(!s.is_empty());
+      s.assert_run_lengths([1, 2, 3]);
+      assert_eq!(s.len(), 6);
+      assert_eq!(s.pop_eq_n(nonzero(3)), Ok(3));
+      assert_eq!(s.pop_eq_n(nonzero(2)), Ok(2));
+      assert_eq!(s.pop_eq_n(nonzero(1)), Ok(1));
+      assert!(s.is_empty());
+      assert_eq!(s.len(), 0);
+
+      s.push_n(1, 1).unwrap();
+      s.push_n(2, 2).unwrap();
+      s.push_n(3, 3).unwrap();
+      assert!(!s.is_empty());
+      s.assert_run_lengths([1, 2, 3]);
+      assert_eq!(s.len(), 6);
+      s.pop_any_n(nonzero(6)).unwrap();
+      assert_eq!(s.len(), 0);
+      assert!(s.is_empty());
+
+      s.push(1).unwrap();
+      s.push(2).unwrap();
+      s.push(2).unwrap();
+      s.push(3).unwrap();
+      s.push(3).unwrap();
+      s.push(3).unwrap();
+      assert!(!s.is_empty());
+      s.assert_run_lengths([1, 2, 3]);
+      assert_eq!(s.len(), 6);
+      s.pop_any_n(nonzero(4)).unwrap();
+      s.pop_any_n(nonzero(2)).unwrap();
+      assert!(s.is_empty());
+      assert_eq!(s.len(), 0);
+  }
+*)
+
+Definition test_simple_push_pop :
+    MS? (AbstractStack.t Z) string unit :=
+
+  letS? s := readS? in
+  letS? _ := AbstractStack.push 1 in
+  letS? _ := assertS?ofS? AbstractStack.self_is_not_empty in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 1) in
+  letS? _ := AbstractStack.assert_run_lengths [1] in
+  letS? _ := assert_eqS?ofS? AbstractStack.pop (returnS? (Result.Ok 1)) in
+  letS? _ := assertS?ofS? (AbstractStack.self_is_empty) in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 0) in
+
+  letS? _ := AbstractStack.push 1 in
+  letS? _ := AbstractStack.push 2 in
+  letS? _ := AbstractStack.push 3 in
+  letS? _ := assertS?ofS? AbstractStack.self_is_not_empty in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 3) in
+  letS? _ := AbstractStack.assert_run_lengths [1; 1; 1] in
+  letS? _ := assert_eqS?ofS? AbstractStack.pop (returnS? (Result.Ok 3)) in
+  letS? _ := assert_eqS?ofS? AbstractStack.pop (returnS? (Result.Ok 2)) in
+  letS? _ := assert_eqS?ofS? AbstractStack.pop (returnS? (Result.Ok 1)) in
+  letS? _ := assertS?ofS? (AbstractStack.self_is_empty) in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 0) in
+
+  letS? _ := AbstractStack.push_n 1 1 in
+  letS? _ := AbstractStack.push_n 2 2 in
+  letS? _ := AbstractStack.push_n 3 3 in
+  letS? _ := assertS?ofS? AbstractStack.self_is_not_empty in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 6) in
+  letS? _ := AbstractStack.assert_run_lengths [3; 2; 1] in
+  letS? _ := assert_eqS?ofS? AbstractStack.pop (returnS? (Result.Ok 3)) in
+  letS? _ := assert_eqS?ofS? AbstractStack.pop (returnS? (Result.Ok 3)) in
+  letS? _ := assert_eqS?ofS? AbstractStack.pop (returnS? (Result.Ok 3)) in
+  letS? _ := assert_eqS?ofS? AbstractStack.pop (returnS? (Result.Ok 2)) in
+  letS? _ := assert_eqS?ofS? AbstractStack.pop (returnS? (Result.Ok 2)) in
+  letS? _ := assert_eqS?ofS? AbstractStack.pop (returnS? (Result.Ok 1)) in
+  letS? _ := assertS?ofS? (AbstractStack.self_is_empty) in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 0) in
+
+  letS? _ := AbstractStack.push_n 1 1 in
+  letS? _ := AbstractStack.push_n 2 2 in
+  letS? _ := AbstractStack.push_n 3 3 in
+  letS? _ := assertS?ofS? AbstractStack.self_is_not_empty in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 6) in
+  letS? _ := AbstractStack.assert_run_lengths [3; 2; 1] in
+  letS? _ := assert_eqS?ofS? (AbstractStack.pop_eq_n 3) (returnS? (Result.Ok 3)) in
+  letS? _ := assert_eqS?ofS? (AbstractStack.pop_eq_n 2) (returnS? (Result.Ok 2)) in
+  letS? _ := assert_eqS?ofS? (AbstractStack.pop_eq_n 1) (returnS? (Result.Ok 1)) in
+  letS? _ := assertS?ofS? (AbstractStack.self_is_empty) in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 0) in
+
+  letS? _ := AbstractStack.push 1 in
+  letS? _ := AbstractStack.push 2 in
+  letS? _ := AbstractStack.push 2 in
+  letS? _ := AbstractStack.push 3 in
+  letS? _ := AbstractStack.push 3 in
+  letS? _ := AbstractStack.push 3 in
+  letS? _ := assertS?ofS? AbstractStack.self_is_not_empty in
+  letS? _ := AbstractStack.assert_run_lengths [3; 2; 1] in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 6) in
+  letS? _ := assert_eqS?ofS? (AbstractStack.pop_eq_n 3) (returnS? (Result.Ok 3)) in
+  letS? _ := assert_eqS?ofS? (AbstractStack.pop_eq_n 2) (returnS? (Result.Ok 2)) in
+  letS? _ := assert_eqS?ofS? (AbstractStack.pop_eq_n 1) (returnS? (Result.Ok 1)) in
+  letS? _ := assertS?ofS? (AbstractStack.self_is_empty) in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 0) in
+
+  letS? _ := AbstractStack.push_n 1 1 in
+  letS? _ := AbstractStack.push_n 2 2 in
+  letS? _ := AbstractStack.push_n 3 3 in
+  letS? _ := assertS?ofS? AbstractStack.self_is_not_empty in
+  letS? _ := AbstractStack.assert_run_lengths [3; 2; 1] in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 6) in
+  letS? _ := AbstractStack.pop_any_n 6 in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 0) in
+  letS? _ := assertS?ofS? (AbstractStack.self_is_empty) in
+
+  letS? _ := AbstractStack.push 1 in
+  letS? _ := AbstractStack.push 2 in
+  letS? _ := AbstractStack.push 2 in
+  letS? _ := AbstractStack.push 3 in
+  letS? _ := AbstractStack.push 3 in
+  letS? _ := AbstractStack.push 3 in
+  letS? _ := assertS?ofS? AbstractStack.self_is_not_empty in
+  letS? _ := AbstractStack.assert_run_lengths [3; 2; 1] in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 6) in
+  letS? _ := AbstractStack.pop_any_n 4 in
+  letS? _ := AbstractStack.pop_any_n 2 in
+  letS? _ := assertS?ofS? (AbstractStack.self_is_empty) in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 0) in
+
+  returnS? tt.
+
+Lemma test_simple_push_pop_correct :
+  testS? test_simple_push_pop AbstractStack.new.
+Proof.
+  reflexivity.
+Qed.
+
+(*
+  #[test]
+  fn test_not_eq() {
+      let mut s = AbstractStack::new();
+      s.push(1).unwrap();
+      s.push(2).unwrap();
+      s.push(2).unwrap();
+      s.push(3).unwrap();
+      s.push(3).unwrap();
+      s.push(3).unwrap();
+      assert_eq!(s.len(), 6);
+      s.assert_run_lengths([1, 2, 3]);
+      assert_eq!(s.pop_eq_n(nonzero(4)), Err(AbsStackError::ElementNotEqual));
+      assert_eq!(s.pop_eq_n(nonzero(5)), Err(AbsStackError::ElementNotEqual));
+      assert_eq!(s.len(), 6);
+      s.assert_run_lengths([1, 2, 3]);
+  }
+*)
+
+Definition test_not_eq :
+    MS? (AbstractStack.t Z) string unit :=
+  letS? s := readS? in
+  letS? _ := AbstractStack.push 1 in
+  letS? _ := AbstractStack.push 2 in
+  letS? _ := AbstractStack.push 2 in
+  letS? _ := AbstractStack.push 3 in
+  letS? _ := AbstractStack.push 3 in
+  letS? _ := AbstractStack.push 3 in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 6) in
+  letS? _ := AbstractStack.assert_run_lengths [3; 2; 1] in
+  letS? _ :=
+    assert_eqS?ofS?
+      (AbstractStack.pop_eq_n 4)
+      (returnS? (Result.Err AbsStackError.ElementNotEqual)) in
+  letS? _ :=
+    assert_eqS?ofS?
+      (AbstractStack.pop_eq_n 4)
+      (returnS? (Result.Err AbsStackError.ElementNotEqual)) in
+  letS? _ := assert_eqS?ofS? (AbstractStack.self_len) (returnS? 6) in
+  AbstractStack.assert_run_lengths [3; 2; 1].
+
+Lemma test_not_eq_correct :
+  testS? test_not_eq AbstractStack.new.
+Proof.
+  reflexivity.
+Qed.
+
+(*
+  #[test]
+  fn test_not_enough_values() {
+      let mut s = AbstractStack::new();
+      s.push(1).unwrap();
+      s.push(2).unwrap();
+      s.push(2).unwrap();
+      s.push(3).unwrap();
+      s.push(3).unwrap();
+      s.push(3).unwrap();
+      assert_eq!(s.len(), 6);
+      s.assert_run_lengths([1, 2, 3]);
+      assert_eq!(s.pop_eq_n(nonzero(7)), Err(AbsStackError::Underflow));
+      assert_eq!(s.pop_any_n(nonzero(7)), Err(AbsStackError::Underflow));
+      assert_eq!(s.len(), 6);
+      s.assert_run_lengths([1, 2, 3]);
+  }
+*)
+
+Definition test_not_enough_values :
+    MS? (AbstractStack.t Z) string unit :=
+  letS? s := readS? in
+  letS? _ := AbstractStack.push 1 in
+  letS? _ := AbstractStack.push 2 in
+  letS? _ := AbstractStack.push 2 in
+  letS? _ := AbstractStack.push 3 in
+  letS? _ := AbstractStack.push 3 in
+  letS? _ := AbstractStack.push 3 in
+  letS? _ := assert_eqS?ofS? AbstractStack.self_len (returnS? 6) in
+  letS? _ := AbstractStack.assert_run_lengths [3; 2; 1] in
+  letS? _ :=
+    assert_eqS?ofS?
+      (AbstractStack.pop_eq_n 7)
+      (returnS? (Result.Err AbsStackError.Underflow)) in
+  letS? _ :=
+    assert_eqS?ofS?
+      (AbstractStack.pop_any_n 7)
+      (returnS? (Result.Err AbsStackError.Underflow)) in
+  letS? _ := assert_eqS?ofS? (AbstractStack.self_len) (returnS? 6) in
+  AbstractStack.assert_run_lengths [3; 2; 1].
+
+Lemma test_not_enough_values_correct :
+  testS? test_not_enough_values AbstractStack.new.
+Proof.
+  reflexivity.
+Qed.

--- a/CoqOfRust/simulations/M.v
+++ b/CoqOfRust/simulations/M.v
@@ -110,6 +110,15 @@ Module StatePanic.
       | Panic.Panic error => (Panic.Panic error, state)
       end.
 
+  (* same as [List.fold_left] but for functions that return a monadic value *)
+  Fixpoint fold {State Error A B : Set}
+      (f : A -> B -> t State Error A) (l : list B) (init : A) :
+      t State Error A :=
+    match l with
+    | nil => return_ init
+    | cons x xs => bind (fold f xs init) (fun init => f init x)
+    end.
+
   Definition read {State Error : Set} : t State Error State :=
     fun state => (return!? state, state).
 
@@ -135,6 +144,8 @@ Module StatePanicNotations.
   Notation "'letS?' ' x ':=' X 'in' Y" :=
     (StatePanic.bind X (fun x => Y))
     (at level 200, x pattern, X at level 100, Y at level 200).
+
+  Notation "foldS?" := StatePanic.fold.
 
   Notation "readS?" := StatePanic.read.
 


### PR DESCRIPTION
This pull request adds simulations for tests for Move `AbstractStack` methods.

Additionally, this pull request adds:
- simulations for `Eq` Trait and its implementation for some of the core types and Move's `AbsStackError` type
- simulations for Rust's `assert` and `assert_eq` macros, that are used to write simulations for tests
- `foldS?` operation: similar to `List.fold_left` but for functions that return a value wrapped in a monad
- various improvements and fixes for simulations of `AbstractStack` methods

In Rust, tests use `assert` and `assert_eq` macros, which cause a panic if the test condition fails. We can write simulations for Rust tests the same way we write simulations for normal Rust functions. Then, we can state a lemma that simulation passes the test, i.e. that an execution of the simulation does not result with a panic. Such lemma can be trivially proven with computation and application of `reflexivity`. By ensuring that our simulations pass the same tests that the Rust code passes, i.e. by ensuring that our simulations and the Rust code behave equivalently on the provided test cases, we can argue that our simulations behave equivalently to the Rust code in general.

