### PR TITLE
More on `type_safety`, part 3

### DIFF
--- a/CoqOfRust/move_sui/simulations/move_binary_format/errors.v
+++ b/CoqOfRust/move_sui/simulations/move_binary_format/errors.v
@@ -22,7 +22,7 @@ Module ExecutionState.
 End ExecutionState.
 
 (* TODO(progress): 
-- Implement functions with mutations, for example `at_code_offset`. 
+- Rewrite `mut` functions with `StatePanic` monads, for example `at_code_offset`. 
   Maybe implement Lens for `PartialVMError`. See the NOTE there
 *)
 

--- a/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
+++ b/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
@@ -21,6 +21,7 @@ End PartialVMResult.
 (* **************** *)
 
 (* NOTE: used in `type_safety` for reference
+   TODO: implement the function such that it panics for Error and returns the value for Ok
 macro_rules! safe_unwrap_err {
     ($e:expr) => {{
         match $e {

--- a/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
+++ b/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
@@ -4,6 +4,10 @@ Require Import CoqOfRust.lib.lib.
 
 Import simulations.M.Notations.
 
+(* TODO(progress):
+  - Implement `SignaturePool` for `signature_at`
+*)
+
 (* NOTE: temporary stub for mutual dependency issue *)
 (* Require CoqOfRust.move_sui.simulations.move_binary_format.errors.
 Module PartialVMResult := errors.PartialVMResult. *)
@@ -440,7 +444,7 @@ Module CompiledModule.
   (* struct_def_instantiations : list StructDefInstantiation; *)
   (* function_instantiations : list FunctionInstantiation; *)
   (* field_instantiations : list FieldInstantiation; *)
-  (* signatures : SignaturePool; *)
+  signatures : SignaturePool;
   (* identifiers : IdentifierPool; *)
   (* address_identifiers : AddressIdentifierPool; *)
   (* constant_pool : ConstantPool; *)
@@ -493,6 +497,14 @@ Module CompiledModule.
     *)
     Definition abilities (self : Self) (ty : SignatureToken.t) (constraints : list AbilitySet.t) 
       : PartialVMResult.t AbilitySet.t. Admitted.
+
+    (* 
+    pub fn signature_at(&self, idx: SignatureIndex) -> &Signature {
+        &self.signatures[idx.into_index()]
+    }
+    *)
+    (* NOTE: into_index is actually just idx.0 as usize so we just inline it *)
+    Definition signature_at(self : Self) (idx : SignatureIndex) : Signature.t. Admitted.
   End Impl_move_sui_simulations_move_binary_format_file_format_CompiledModule.
 End CompiledModule.
 

--- a/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
+++ b/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
@@ -4,6 +4,10 @@ Require Import CoqOfRust.lib.lib.
 
 Import simulations.M.Notations.
 
+(* TODO(progress):
+- Resolve the List.nth problem for `SignatureToken`
+*)
+
 (* NOTE: temporary stub for mutual dependency issue *)
 (* Require CoqOfRust.move_sui.simulations.move_binary_format.errors.
 Module PartialVMResult := errors.PartialVMResult. *)
@@ -506,8 +510,9 @@ Module CompiledModule.
     (* NOTE: into_index is actually just `idx.0 as usize` so we just inline it *)
     Definition signature_at(self : Self) (idx : SignatureIndex.t) : Signature.t :=
       let idx := idx.(SignatureIndex.a0) in
-      (* NOTE: WARNING: default value `-1` is provided *)
-      list.nth idx self.(signatures) (-1).
+      (* NOTE: WARNING: Default value provided for `List.nth`. To be modified in the future  *)
+      let default_token := [SignatureToken.Bool] in
+      List.nth (Z.to_nat idx) self.(signatures) (Signature.Build_t default_token).
 
   End Impl_move_sui_simulations_move_binary_format_file_format_CompiledModule.
 End CompiledModule.

--- a/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
+++ b/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
@@ -63,6 +63,14 @@ Module CodeOffset.
   Record t : Set := { a0 : Z; }.
 End CodeOffset.
 
+Module ModuleHandleIndex.
+  Record t : Set := { a0 : Z; }.
+End ModuleHandleIndex.
+
+Module IdentifierIndex.
+  Record t : Set := { a0 : Z; }.
+End IdentifierIndex.
+
 (* Template for `define_index!` macro
 
 pub struct $name(pub TableIndex);
@@ -234,7 +242,14 @@ pub struct FunctionHandle {
 }
 *)
 Module FunctionHandle.
-  Record t : Set := { }.
+  Record t : Set := { 
+  module : ModuleHandleIndex.t;
+  name : IdentifierIndex.t;
+  parameters : SignatureIndex.t;
+  return_ : SignatureIndex.t;
+  type_parameters : list AbilitySet.t;
+  
+  }.
 End FunctionHandle.
 
 (* 

--- a/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
+++ b/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
@@ -5,7 +5,7 @@ Require Import CoqOfRust.lib.lib.
 Import simulations.M.Notations.
 
 (* TODO(progress):
-- Resolve the List.nth problem for `SignatureToken`
+- `List.nth` issue: remove `SignatureToken.Bool` with something better
 *)
 
 (* NOTE: temporary stub for mutual dependency issue *)

--- a/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
+++ b/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
@@ -4,10 +4,6 @@ Require Import CoqOfRust.lib.lib.
 
 Import simulations.M.Notations.
 
-(* TODO(progress):
-  - Implement `SignaturePool` for `signature_at`
-*)
-
 (* NOTE: temporary stub for mutual dependency issue *)
 (* Require CoqOfRust.move_sui.simulations.move_binary_format.errors.
 Module PartialVMResult := errors.PartialVMResult. *)
@@ -137,11 +133,11 @@ Module AbilitySet.
   Record t : Set := { a0 : Z; }.
 End AbilitySet.
 
-(* NOTE: Below are taken from `move`'s simulation and could be deprecated *)
 Module SignatureIndex.
-  Inductive t : Set :=
-  | Make (_ : Z).
+  Record t : Set := { a0 : Z; }.
 End SignatureIndex.
+
+(* NOTE: Below are taken from `move`'s simulation and could be deprecated *)
 
 Module ConstantPoolIndex.
   Inductive t : Set :=
@@ -308,6 +304,10 @@ Module Signature.
   Definition len (self : t) : Z := Z.of_nat (List.length self.(a0)).
 End Signature.
 
+Module SignaturePool.
+  Definition t := list Signature.t.
+End SignaturePool.
+
 Module Bytecode.
   Inductive t : Set :=
   | Pop
@@ -444,7 +444,7 @@ Module CompiledModule.
   (* struct_def_instantiations : list StructDefInstantiation; *)
   (* function_instantiations : list FunctionInstantiation; *)
   (* field_instantiations : list FieldInstantiation; *)
-  signatures : SignaturePool;
+  signatures : SignaturePool.t;
   (* identifiers : IdentifierPool; *)
   (* address_identifiers : AddressIdentifierPool; *)
   (* constant_pool : ConstantPool; *)
@@ -503,8 +503,12 @@ Module CompiledModule.
         &self.signatures[idx.into_index()]
     }
     *)
-    (* NOTE: into_index is actually just idx.0 as usize so we just inline it *)
-    Definition signature_at(self : Self) (idx : SignatureIndex) : Signature.t. Admitted.
+    (* NOTE: into_index is actually just `idx.0 as usize` so we just inline it *)
+    Definition signature_at(self : Self) (idx : SignatureIndex.t) : Signature.t :=
+      let idx := idx.(SignatureIndex.a0) in
+      (* NOTE: WARNING: default value `-1` is provided *)
+      list.nth idx self.(signatures) (-1).
+
   End Impl_move_sui_simulations_move_binary_format_file_format_CompiledModule.
 End CompiledModule.
 

--- a/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
+++ b/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
@@ -5,12 +5,19 @@ Require Import CoqOfRust.lib.lib.
 Import simulations.M.Notations.
 
 (* TODO(progress):
+- Implement `safe_unwrap_err`
+- (IMPORTANT)Implement `AbilitySet` and its `impl`s. In particular, being used for `verify_instr`:
+  - Implement `has_drop`
+  - Implement `has_copy`
+  - Implement `has_key`
+  Luckily they aren't mutable functions!
+- Implement `CompiledModule`'s `abilities`
 - `List.nth` issue: remove `SignatureToken.Bool` with something better
 *)
 
-(* NOTE: temporary stub for mutual dependency issue *)
-(* Require CoqOfRust.move_sui.simulations.move_binary_format.errors.
-Module PartialVMResult := errors.PartialVMResult. *)
+(* NOTE(MUTUAL DEPENDENCY ISSUE): The following structs are temporary stub 
+   since this file has mutual dependency with another file. Although it works 
+   for now, we shouldn't ignore this. *)
 Module PartialVMError.
   Inductive t : Set := .
 End PartialVMError.
@@ -20,7 +27,7 @@ End PartialVMResult.
 
 (* **************** *)
 
-(* NOTE: used in `type_safety` for reference
+(* DRAFT: used in `type_safety` for reference
    TODO: implement the function such that it panics for Error and returns the value for Ok
 macro_rules! safe_unwrap_err {
     ($e:expr) => {{
@@ -72,7 +79,7 @@ Module IdentifierIndex.
   Record t : Set := { a0 : Z; }.
 End IdentifierIndex.
 
-(* Template for `define_index!` macro
+(* DRAFT: Template for `define_index!` macro
 
 pub struct $name(pub TableIndex);
 

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
@@ -87,7 +87,8 @@ Module FunctionContext.
         locals : module.signature_at code.(CodeUnit.locals);
         type_parameters : function_handle.(FunctionHandle.type_parameters);
         cfg : VMControlFlowGraph::new code.(CodeUnit.code);
-      |}
+      |} in
+      result.
     
     Definition parameters (self : Self) := self.(parameters).
 

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
@@ -13,10 +13,6 @@ Module CompiledModule := file_format.CompiledModule.
 Module FunctionHandle := file_format.FunctionHandle.
 Module Bytecode := file_format.Bytecode.
 
-(* TODO(progress):
-- Implement `new`
-*)
-
 (* 
 pub struct VMControlFlowGraph {
     /// The basic blocks

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
@@ -9,6 +9,8 @@ Module Signature := file_format.Signature.
 Module AbilitySet := file_format.AbilitySet.
 Module FunctionDefinitionIndex := file_format.FunctionDefinitionIndex.
 Module CodeUnit := file_format.CodeUnit.
+Module CompiledModule := file_format.CompiledModule.
+Module FunctionHandle := file_format.FunctionHandle.
 
 (* TODO(progress):
 - Implement `new`
@@ -77,16 +79,17 @@ Module FunctionContext.
     (* TODO: check if there're missing dependencies *)
     Definition new (module : CompiledModule.t) (index : FunctionDefinitionIndex.t) (code : CodeUnit.t)
       (function_handle : FunctionHandle.t) :=
+      let signature_at := CompiledModule.Impl_move_sui_simulations_move_binary_format_file_format_CompiledModule.signature_at in
       let result : Self :=
       {|
-        index : Some index;
-        code : code;
+        index := Some index;
+        code := code;
         (* TODO: correct the signature_at *)
-        parameters : module.signature_at function_handle.(FunctionHandle.parameters);
-        return_ : module.signature_at function_handle.(FunctionHandle.return_);
-        locals : module.signature_at code.(CodeUnit.locals);
-        type_parameters : function_handle.(FunctionHandle.type_parameters);
-        cfg : VMControlFlowGraph::new code.(CodeUnit.code);
+        parameters := signature_at module function_handle.(FunctionHandle.parameters);
+        return_ := signature_at module function_handle.(FunctionHandle.return_);
+        locals := signature_at module code.(CodeUnit.locals);
+        type_parameters := function_handle.(FunctionHandle.type_parameters);
+        cfg := VMControlFlowGraph::new code.(CodeUnit.code);
       |} in
       result.
     

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
@@ -11,6 +11,7 @@ Module FunctionDefinitionIndex := file_format.FunctionDefinitionIndex.
 Module CodeUnit := file_format.CodeUnit.
 Module CompiledModule := file_format.CompiledModule.
 Module FunctionHandle := file_format.FunctionHandle.
+Module Bytecode := file_format.Bytecode.
 
 (* TODO(progress):
 - Implement `new`
@@ -30,6 +31,8 @@ pub struct VMControlFlowGraph {
 Module VMControlFlowGraph.
   Record t : Set := { }.
 End VMControlFlowGraph.
+
+Definition VMControlFlowGraph_new (code : list Bytecode.t) : VMControlFlowGraph.t. Admitted.
 
 (* pub struct FunctionContext<'a> {
     index: Option<FunctionDefinitionIndex>,
@@ -89,7 +92,7 @@ Module FunctionContext.
         return_ := signature_at module function_handle.(FunctionHandle.return_);
         locals := signature_at module code.(CodeUnit.locals);
         type_parameters := function_handle.(FunctionHandle.type_parameters);
-        cfg := VMControlFlowGraph::new code.(CodeUnit.code);
+        cfg := VMControlFlowGraph_new code.(CodeUnit.code);
       |} in
       result.
     

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
@@ -12,7 +12,6 @@ Module CodeUnit := file_format.CodeUnit.
 
 (* TODO(progress):
 - Implement `new`
-  - Implement `CompiledModule::signature_at`
 *)
 
 (* 
@@ -75,7 +74,20 @@ Module FunctionContext.
           }
       }
     *)
-    Definition new : Set. Admitted.
+    (* TODO: check if there're missing dependencies *)
+    Definition new (module : CompiledModule.t) (index : FunctionDefinitionIndex.t) (code : CodeUnit.t)
+      (function_handle : FunctionHandle.t) :=
+      let result : Self :=
+      {|
+        index : Some index;
+        code : code;
+        (* TODO: correct the signature_at *)
+        parameters : module.signature_at function_handle.(FunctionHandle.parameters);
+        return_ : module.signature_at function_handle.(FunctionHandle.return_);
+        locals : module.signature_at code.(CodeUnit.locals);
+        type_parameters : function_handle.(FunctionHandle.type_parameters);
+        cfg : VMControlFlowGraph::new code.(CodeUnit.code);
+      |}
     
     Definition parameters (self : Self) := self.(parameters).
 

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
@@ -60,7 +60,6 @@ Module FunctionContext.
     Definition Self : Set := 
       move_sui.simulations.move_bytecode_verifier.absint.FunctionContext.t.
 
-    (* TODO: Implement this *)
     (* 
       pub fn new(
           module: &'a CompiledModule,
@@ -79,7 +78,6 @@ Module FunctionContext.
           }
       }
     *)
-    (* TODO: check if there're missing dependencies *)
     Definition new (module : CompiledModule.t) (index : FunctionDefinitionIndex.t) (code : CodeUnit.t)
       (function_handle : FunctionHandle.t) :=
       let signature_at := CompiledModule.Impl_move_sui_simulations_move_binary_format_file_format_CompiledModule.signature_at in
@@ -87,7 +85,6 @@ Module FunctionContext.
       {|
         index := Some index;
         code := code;
-        (* TODO: correct the signature_at *)
         parameters := signature_at module function_handle.(FunctionHandle.parameters);
         return_ := signature_at module function_handle.(FunctionHandle.return_);
         locals := signature_at module code.(CodeUnit.locals);

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
@@ -12,6 +12,7 @@ Module CodeUnit := file_format.CodeUnit.
 
 (* TODO(progress):
 - Implement `new`
+  - Implement `CompiledModule::signature_at`
 *)
 
 (* 

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
@@ -38,6 +38,7 @@ Module AbstractStack := move_abstract_stack.lib.AbstractStack.
 
 (* TODO(progress):
   - Implement `abilities` in `file_format` and resolve the mutual dependency issue completely
+  - Implement `safe_unwrap_err!` macro
   - List.nth issue: remove `SignatureToken.Bool` with something better
 *)
 

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
@@ -34,6 +34,7 @@ Module StatusCode := vm_status.StatusCode.
 *)
 
 (* TODO(progress):
+  - Use `AbstractStack::Pop` correctly
   - Implement `abilities` in `file_format` and resolve the mutual dependency issue completely
   - List.nth issue: remove `SignatureToken.Bool` with something better
 *)

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
@@ -35,6 +35,7 @@ Module StatusCode := vm_status.StatusCode.
 
 (* TODO(progress):
   - Implement `abilities` in `file_format` and resolve the mutual dependency issue completely
+  - Implement `CompiledModule::signature_at`
   - Remove `SignatureToken.Bool` with something better
 *)
 

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
@@ -35,7 +35,7 @@ Module StatusCode := vm_status.StatusCode.
 
 (* TODO(progress):
   - Implement `abilities` in `file_format` and resolve the mutual dependency issue completely
-  - Remove `SignatureToken.Bool` with something better
+  - List.nth issue: remove `SignatureToken.Bool` with something better
 *)
 
 (* TODO: tbd after PR #577 *)

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
@@ -32,14 +32,19 @@ Module StatusCode := vm_status.StatusCode.
 Require CoqOfRust.move_sui.simulations.move_abstract_stack.lib.
 Module AbstractStack := move_abstract_stack.lib.AbstractStack.
 
-(* NOTE:
-  - `meter : impl Meter` parameters are ignored in the simulation
-*)
+Require CoqOfRust.move_sui.simulations.move_bytecode_verifier_meter.lib.
+Module Scope := move_bytecode_verifier_meter.lib.Scope.
+(* NOTE(IMPORTANT): For now we just simplify `Meter` to the actual `BoundMeter` struct
+   since it's the only implementation that contains useful logic *)
+Module Meter := move_bytecode_verifier_meter.lib.Meter.BoundMeter.
 
 (* TODO(progress):
+  - (IMPORTANT)Push the progress on this file by:
+    1. Implement `safe_unwrap_err!` macro
+    2. Implement `Lens` from `BoundMeter` for `TypeSafetyChecker`
+  - 3. Implement `mut` functions in this file
   - Implement `abilities` in `file_format` and resolve the mutual dependency issue completely
-  - Implement `safe_unwrap_err!` macro
-  - Implement `mut` functions in this file
+  - Deal with the temporary `coerce`
   - List.nth issue: remove `SignatureToken.Bool` with something better
 *)
 
@@ -162,6 +167,7 @@ Module TypeSafetyChecker.
           )
       }
     *)
+    (* TODO: Implement Lens from `BoundMeter` to `TypeSafetyChecker` *)
     Definition charge_ty_ (self : Self) (ty : SignatureToken.t) (n : Z) : PartialVMResult.t unit :=
       return?? tt.
 
@@ -203,7 +209,6 @@ Module TypeSafetyChecker.
         Ok(())
     }
     *)
-    (* NOTE: with `safe_unwrap_err` macro, we might need to use the Result monad seriously here... *)
     Definition push (self : Self) (ty : SignatureToken.t) : PartialVMResult.t unit :=
       return?? tt.
 
@@ -1059,7 +1064,7 @@ fn verify_instr(
 
 Definition verify_instr (verifier : TypeSafetyChecker.t) (bytecode : Bytecode.t) 
   (offset : CodeOffset.t) : PartialVMResult.t unit :=
-  (* TODO: IMPORTANT: wrap up the pattern match with a Result monad *)
+  (* TODO: wrap up the function with a StatePanic monad *)
   match bytecode with
   (* 
     Bytecode::Pop => {
@@ -1076,7 +1081,7 @@ Definition verify_instr (verifier : TypeSafetyChecker.t) (bytecode : Bytecode.t)
   | Bytecode.Pop => 
     (* let _stack := verifier.(TypeSafetyChecker.stack) in
     let operand := AbstractStack.pop _stack in
-    let abilities := _ in (* TODO: Implement `abilities`! *)
+    let abilities := _ in
     let _ := _ in *)
     return?? tt
 

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
@@ -58,7 +58,7 @@ Definition AbstractStack_new : AbstractStack SignatureToken.t. Admitted.
   // TODO: figure out how `meter` works exactly in where?
 *)
 
-(* NOTE: temp brutal helper function. Should be removed with regarding to mutual dependency issue *)
+(* NOTE: temp brutal helper function. Should be removed with regard to the mutual dependency issue *)
 Axiom coerce : forall (a : file_format.PartialVMResult.t file_format.AbilitySet.t), PartialVMResult.t AbilitySet.t.
 
 Module Locals.
@@ -217,7 +217,8 @@ Module TypeSafetyChecker.
     }
     *)
     (* NOTE: with `safe_unwrap_err` macro, we might need to use the Result monad seriously here... *)
-    Definition push (self : Self) (ty : SignatureToken.t) : PartialVMResult.t unit. Admitted.
+    Definition push (self : Self) (ty : SignatureToken.t) : PartialVMResult.t unit :=
+      return?? tt.
 
     (* 
       fn push_n(

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
@@ -37,7 +37,6 @@ Module AbstractStack := move_abstract_stack.lib.AbstractStack.
 *)
 
 (* TODO(progress):
-  - Use `AbstractStack::Pop` correctly
   - Implement `abilities` in `file_format` and resolve the mutual dependency issue completely
   - List.nth issue: remove `SignatureToken.Bool` with something better
 *)

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
@@ -29,6 +29,9 @@ Module PartialVMError := errors.PartialVMError.
 Require CoqOfRust.move_sui.simulations.move_core_types.vm_status.
 Module StatusCode := vm_status.StatusCode.
 
+Require CoqOfRust.move_sui.simulations.move_abstract_stack.lib.
+Module AbstractStack := move_abstract_stack.lib.AbstractStack.
+
 (* NOTE:
   - `meter : impl Meter` parameters are ignored in the simulation
 *)
@@ -40,8 +43,7 @@ Module StatusCode := vm_status.StatusCode.
 *)
 
 (* TODO: tbd after PR #577 *)
-Definition AbstractStack (A : Set) : Set. Admitted.
-Definition AbstractStack_new : AbstractStack SignatureToken.t. Admitted.
+Definition AbstractStack_new : AbstractStack.t SignatureToken.t. Admitted.
 
 (* DRAFT: template for adding trait parameters *)
 (* Definition test_0 : forall (A : Set), { _ : Set @ Meter.Trait A } -> A -> Set. Admitted. *)
@@ -109,7 +111,7 @@ Module TypeSafetyChecker.
     module : CompiledModule.t;
     function_context : FunctionContext.t;
     locals : Locals.t;
-    stack : AbstractStack SignatureToken.t;
+    stack : AbstractStack.t SignatureToken.t;
   }.
   Module Impl_move_sui_simulations_move_bytecode_verifier_type_safety_TypeSafetyChecker.
     Definition Self : Set := 
@@ -1086,6 +1088,7 @@ Definition verify_instr (verifier : TypeSafetyChecker.t) (bytecode : Bytecode.t)
       }
     }
   *)
+  (* NOTE: `State` for this function should contain `verifier` *)
   | Bytecode.Pop => 
     let operand := _ in
     let abilities := _ in (* TODO: Implement `abilities`! *)

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
@@ -1074,11 +1074,29 @@ Definition verify_instr (verifier : TypeSafetyChecker.t) (bytecode : Bytecode.t)
   (offset : CodeOffset.t) : PartialVMResult.t unit :=
   (* TODO: IMPORTANT: wrap up the pattern match with a Result monad *)
   match bytecode with
-  | Bytecode.Pop => return?? tt
+  (* 
+    Bytecode::Pop => {
+      let operand = safe_unwrap_err!(verifier.stack.pop());
+      let abilities = verifier
+          .module
+          .abilities(&operand, verifier.function_context.type_parameters());
+      if !abilities?.has_drop() {
+          return Err(verifier.error(StatusCode::POP_WITHOUT_DROP_ABILITY, offset));
+      }
+    }
+  *)
+  | Bytecode.Pop => 
+    let operand := _ in
+    let abilities := _ in (* TODO: Implement `abilities`! *)
+    let _ := _ in
+    return?? tt
+
+  (* Bytecode::Branch(_) | Bytecode::Nop => (), *)
+  | Bytecode.Branch _ | Bytecode.Nop => return?? tt
+
   | Bytecode.Ret => return?? tt
   | Bytecode.BrTrue idx => return?? tt
   | Bytecode.BrFalse idx => return?? tt
-  | Bytecode.Branch idx => return?? tt
   | Bytecode.LdU8 idx => return?? tt
   | Bytecode.LdU64 idx => return?? tt
   | Bytecode.LdU128 idx => return?? tt
@@ -1128,7 +1146,6 @@ Definition verify_instr (verifier : TypeSafetyChecker.t) (bytecode : Bytecode.t)
   | Bytecode.Le => return?? tt
   | Bytecode.Ge => return?? tt
   | Bytecode.Abort => return?? tt
-  | Bytecode.Nop => return?? tt
   | Bytecode.Exists idx => return?? tt
   | Bytecode.ExistsGeneric idx => return?? tt
   | Bytecode.MoveFrom idx => return?? tt

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
@@ -48,19 +48,6 @@ Definition AbstractStack_new : AbstractStack.t SignatureToken.t. Admitted.
 (* DRAFT: template for adding trait parameters *)
 (* Definition test_0 : forall (A : Set), { _ : Set @ Meter.Trait A } -> A -> Set. Admitted. *)
 
-(* DRAFT: example code for how verifier works
-  Bytecode::Or | Bytecode::And => {
-      let operand1 = safe_unwrap_err!(verifier.stack.pop()); // <- used the `Result` monad
-      let operand2 = safe_unwrap_err!(verifier.stack.pop());
-      if operand1 == ST::Bool && operand2 == ST::Bool {
-          verifier.push(meter, ST::Bool)?; // <- used the `push` & `charge_ty` functions in `TypeSafetyChecker`
-      } else {
-          return Err(verifier.error(StatusCode::BOOLEAN_OP_TYPE_MISMATCH_ERROR, offset));
-      }
-  }
-  // TODO: figure out how `meter` works exactly in where?
-*)
-
 (* NOTE: temp brutal helper function. Should be removed with regard to the mutual dependency issue *)
 Axiom coerce : forall (a : file_format.PartialVMResult.t file_format.AbilitySet.t), PartialVMResult.t AbilitySet.t.
 

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
@@ -42,9 +42,6 @@ Module AbstractStack := move_abstract_stack.lib.AbstractStack.
   - List.nth issue: remove `SignatureToken.Bool` with something better
 *)
 
-(* TODO: tbd after PR #577 *)
-Definition AbstractStack_new : AbstractStack.t SignatureToken.t. Admitted.
-
 (* DRAFT: template for adding trait parameters *)
 (* Definition test_0 : forall (A : Set), { _ : Set @ Meter.Trait A } -> A -> Set. Admitted. *)
 
@@ -113,7 +110,7 @@ Module TypeSafetyChecker.
         TypeSafetyChecker.module := module;
         TypeSafetyChecker.function_context := function_context; 
         TypeSafetyChecker.locals := locals;
-        TypeSafetyChecker.stack := AbstractStack_new;
+        TypeSafetyChecker.stack := AbstractStack.new;
       |}.
 
     Definition local_at (self : Self) (i : LocalIndex.t) : SignatureToken.t :=
@@ -1077,7 +1074,8 @@ Definition verify_instr (verifier : TypeSafetyChecker.t) (bytecode : Bytecode.t)
   *)
   (* NOTE: `State` for this function should contain `verifier` *)
   | Bytecode.Pop => 
-    let operand := _ in
+    let _stack := verifier.(TypeSafetyChecker.stack) in
+    let operand := AbstractStack.pop _stack in
     let abilities := _ in (* TODO: Implement `abilities`! *)
     let _ := _ in
     return?? tt

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
@@ -35,7 +35,6 @@ Module StatusCode := vm_status.StatusCode.
 
 (* TODO(progress):
   - Implement `abilities` in `file_format` and resolve the mutual dependency issue completely
-  - Implement `CompiledModule::signature_at`
   - Remove `SignatureToken.Bool` with something better
 *)
 

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
@@ -1074,10 +1074,10 @@ Definition verify_instr (verifier : TypeSafetyChecker.t) (bytecode : Bytecode.t)
   *)
   (* NOTE: `State` for this function should contain `verifier` *)
   | Bytecode.Pop => 
-    let _stack := verifier.(TypeSafetyChecker.stack) in
+    (* let _stack := verifier.(TypeSafetyChecker.stack) in
     let operand := AbstractStack.pop _stack in
     let abilities := _ in (* TODO: Implement `abilities`! *)
-    let _ := _ in
+    let _ := _ in *)
     return?? tt
 
   (* Bytecode::Branch(_) | Bytecode::Nop => (), *)

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
@@ -39,6 +39,7 @@ Module AbstractStack := move_abstract_stack.lib.AbstractStack.
 (* TODO(progress):
   - Implement `abilities` in `file_format` and resolve the mutual dependency issue completely
   - Implement `safe_unwrap_err!` macro
+  - Implement `mut` functions in this file
   - List.nth issue: remove `SignatureToken.Bool` with something better
 *)
 
@@ -147,7 +148,6 @@ Module TypeSafetyChecker.
         .Impl_move_sui_simulations_move_binary_format_errors_PartialVMError.at_code_offset 
           pvme index offset.
 
-    (* NOTE: Since we ignore the `Meter` trait, these functions will be greatly simplified... *)
     (* 
       fn charge_ty_(
           &mut self,

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -4,6 +4,183 @@ Require Import CoqOfRust.lib.lib.
 
 Import simulations.M.Notations.
 
+Require CoqOfRust.move_sui.simulations.move_binary_format.errors.
+Module PartialVMResult := errors.PartialVMResult.
+Module PartialVMError := errors.PartialVMError.
+
+(* TODO(progress):
+- Implement `BoundMeter` just in case
+- Write out the exact function chains from `verify_instr`
+- Implement `Scope` or stub it
+- Maybe move `BoundMeter` and `DummyMeter` to their files
+*)
+
+(* 
+use crate::{Meter, Scope};
+*)
+(* pub struct DummyMeter; *)
+Module DummyMeter.
+  Record t : Set := { }.
+
+  (* impl Meter for DummyMeter  *)
+  Module Impl_move_sui_simulations_move_bytecode_verifier_meter_DummyMeter.
+    Definition Self : Set := 
+      move_sui.simulations.move_bytecode_verifier_meter.DummyMeter.t.
+
+    (* fn enter_scope(&mut self, _name: &str, _scope: Scope) {} *)
+    Definition enter_scope (self : Self) (_name : str) (_scope : Scope) := .
+
+    (* fn transfer(&mut self, _from: Scope, _to: Scope, _factor: f32) -> PartialVMResult<()> { Ok(()) } *)
+    (* TODO: translate the `f32` here correctly *)
+    Definition transfer (self : Self) (_from : Scope) (_to : Scope) (_factor : Z) : PartialVMResult.t unit := return?? tt.
+
+    (* fn add(&mut self, _scope: Scope, _units: u128) -> PartialVMResult<()> { Ok(()) } *)
+    Definition add (self : Self) (_scope : Scope) (_units : Z) : PartialVMResult.t unit := return?? tt.
+  End Impl_move_sui_simulations_move_bytecode_verifier_meter_DummyMeter.
+End DummyMeter.
+
+(* bound.rs
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Meter, Scope};
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::vm_status::StatusCode;
+use move_vm_config::verifier::MeterConfig;
+
+/// Module and function level metering.
+
+impl Bounds {
+    fn add(&mut self, units: u128) -> PartialVMResult<()> {
+        if let Some(max) = self.max {
+            let new_units = self.units.saturating_add(units);
+            if new_units > max {
+                // TODO: change to a new status PROGRAM_TOO_COMPLEX once this is rolled out. For
+                // now we use an existing code to avoid breaking changes on potential rollback.
+                return Err(PartialVMError::new(StatusCode::CONSTRAINT_NOT_SATISFIED)
+                    .with_message(format!(
+                        "program too complex (in `{}` with `{} current + {} new > {} max`)",
+                        self.name, self.units, units, max
+                    )));
+            }
+            self.units = new_units;
+        }
+        Ok(())
+    }
+}
+
+impl BoundMeter {
+    pub fn new(config: MeterConfig) -> Self {
+        Self {
+            pkg_bounds: Bounds {
+                name: "<unknown>".to_string(),
+                units: 0,
+                max: config.max_per_pkg_meter_units,
+            },
+            mod_bounds: Bounds {
+                name: "<unknown>".to_string(),
+                units: 0,
+                max: config.max_per_mod_meter_units,
+            },
+            fun_bounds: Bounds {
+                name: "<unknown>".to_string(),
+                units: 0,
+                max: config.max_per_fun_meter_units,
+            },
+        }
+    }
+
+    fn get_bounds_mut(&mut self, scope: Scope) -> &mut Bounds {
+        match scope {
+            Scope::Package => &mut self.pkg_bounds,
+            Scope::Module => &mut self.mod_bounds,
+            Scope::Function => &mut self.fun_bounds,
+            Scope::Transaction => panic!("transaction scope unsupported."),
+        }
+    }
+
+    fn get_bounds(&self, scope: Scope) -> &Bounds {
+        match scope {
+            Scope::Package => &self.pkg_bounds,
+            Scope::Module => &self.mod_bounds,
+            Scope::Function => &self.fun_bounds,
+            Scope::Transaction => panic!("transaction scope unsupported."),
+        }
+    }
+
+    pub fn get_usage(&self, scope: Scope) -> u128 {
+        self.get_bounds(scope).units
+    }
+
+    pub fn get_limit(&self, scope: Scope) -> Option<u128> {
+        self.get_bounds(scope).max
+    }
+}
+*)
+(* 
+struct Bounds {
+    name: String,
+    units: u128,
+    max: Option<u128>,
+}
+*)
+Module Bounds.
+  Record t : Set := {
+    name : string;
+    units : Z;
+    max : option Z;
+  }.
+End Bounds.
+
+(* 
+pub struct BoundMeter {
+    pkg_bounds: Bounds,
+    mod_bounds: Bounds,
+    fun_bounds: Bounds,
+}
+*)
+Module BoundMeter.
+  Record t : Set := {
+    pkg_bounds : Bounds.t;
+    mod_bounds : Bounds.t;
+    fun_bounds : Bounds.t;
+  }
+  (* 
+  impl Meter for BoundMeter {
+  }
+  *)
+  Module Impl_move_sui_simulations_move_bytecode_verifier_meter_BoundMeter.
+    Definition Self : Set := 
+      move_sui.simulations.move_bytecode_verifier_meter.BoundMeter.t.
+
+    (* 
+    fn enter_scope(&mut self, name: &str, scope: Scope) {
+        let bounds = self.get_bounds_mut(scope);
+        bounds.name = name.into();
+        bounds.units = 0;
+    }
+    *)
+    (* TODO: Implement get_bounds_mut *)
+    Definition enter_scope (self : Self) (name : str) (scope : Scope) : unit. Admitted.
+
+    (* 
+    fn transfer(&mut self, from: Scope, to: Scope, factor: f32) -> PartialVMResult<()> {
+        let units = (self.get_bounds_mut(from).units as f32 * factor) as u128;
+        self.add(to, units)
+    }
+    *)
+    Definition transfer (self : Self) (from : Scope) (to : Scope) (factor : f32) : PartialVMResult.t unit. Admitted.
+
+    (* 
+    fn add(&mut self, scope: Scope, units: u128) -> PartialVMResult<()> {
+        self.get_bounds_mut(scope).add(units)
+    }
+    *)
+    Definition add (self : Self) (scope : Scope) (units : Z) : PartialVMResult.t unit. Admitted.
+    
+  End Impl_move_sui_simulations_move_bytecode_verifier_meter_BoundMeter.
+End BoundMeter.
+
 (* TODO: Implement `Meter` trait as Coq Class *)
 Module Meter.
   Class Trait (Self : Set) : Set := { }.

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -15,9 +15,7 @@ Module PartialVMError := errors.PartialVMError.
 - Maybe move `BoundMeter` and `DummyMeter` to their files
 *)
 
-(* 
-use crate::{Meter, Scope};
-*)
+(* use crate::{Meter, Scope}; *)
 (* pub struct DummyMeter; *)
 Module DummyMeter.
   Record t : Set := { }.
@@ -182,6 +180,50 @@ Module BoundMeter.
 End BoundMeter.
 
 (* TODO: Implement `Meter` trait as Coq Class *)
+(* 
+pub trait Meter {
+    /// Indicates the begin of a new scope.
+    fn enter_scope(&mut self, name: &str, scope: Scope);
+
+    /// Transfer the amount of metering from once scope to the next. If the current scope has
+    /// metered N units, the target scope will be charged with N*factor.
+    fn transfer(&mut self, from: Scope, to: Scope, factor: f32) -> PartialVMResult<()>;
+
+    /// Add the number of units to the meter, returns an error if a limit is hit.
+    fn add(&mut self, scope: Scope, units: u128) -> PartialVMResult<()>;
+
+    /// Adds the number of items.
+    fn add_items(
+        &mut self,
+        scope: Scope,
+        units_per_item: u128,
+        items: usize,
+    ) -> PartialVMResult<()> {
+        if items == 0 {
+            return Ok(());
+        }
+        self.add(scope, units_per_item.saturating_mul(items as u128))
+    }
+
+    /// Adds the number of items with growth factor
+    fn add_items_with_growth(
+        &mut self,
+        scope: Scope,
+        mut units_per_item: u128,
+        items: usize,
+        growth_factor: f32,
+    ) -> PartialVMResult<()> {
+        if items == 0 {
+            return Ok(());
+        }
+        for _ in 0..items {
+            self.add(scope, units_per_item)?;
+            units_per_item = growth_factor.mul(units_per_item as f32) as u128;
+        }
+        Ok(())
+    }
+}
+*)
 Module Meter.
   Class Trait (Self : Set) : Set := { }.
 End Meter.

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -12,8 +12,7 @@ Require CoqOfRust.move_sui.simulations.move_core_types.vm_status.
 Module StatusCode := vm_status.StatusCode.
 
 (* TODO(progress):
-- Fix bugs in `Bounds.add`: 
-  - Implement saturated addition
+- Implement saturated additions
 - Investigate the exact function chains from `verify_instr` 
   - Explain when will other verify functions use `verify_instr`
   - Examine further if `DummyMeter` can be safely replaced by `BoundMeter`
@@ -24,8 +23,8 @@ Module StatusCode := vm_status.StatusCode.
 - We can restructure the `Meter` into a large module, since its content are pretty few.
   Currently we implement the structs as the following tree:
   Module Meter
-  - Module BoundMeter
-  - Module DummyMeter
+  | - Module BoundMeter
+  | - Module DummyMeter
 - We ignore `f32` since related parameters are mostly factors to be multiplied with.
   These parameters will be either ignored or treated as a sole Z value.
 *)
@@ -112,7 +111,6 @@ Module Bounds.
           letS? _ := writeS? self in
           returnS? (Result.Ok tt)
       | None => 
-          letS? _ := writeS? self in
           returnS? (Result.Ok tt)
       end.
   End Impl_move_sui_simulations_move_bytecode_verifier_meter_Bounds.
@@ -332,6 +330,7 @@ Module Meter.
         if items =? 0
         then (returnS? (Result.Ok tt))
         else letS? self := readS? in
+        (* TODO: Implement saturating_mul *)
         add scope (Z.mul units_per_item items).
       
     End Impl_move_sui_simulations_move_bytecode_verifier_meter_BoundMeter.

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -99,7 +99,7 @@ Module Bounds.
 
     (* NOTE: since PartialVMResult<()> = Result () PartialVMError, we expand the definition for the monad *)
     Definition add (self : Self) (units : Z) : MS? State PartialVMError.t unit :=
-      let _return :=
+      let _return : MS? State PartialVMError.t unit :=
         match self.(max) with
         | Some max => 
         (* let new_units = self.units.saturating_add(units); *)
@@ -116,12 +116,14 @@ Module Bounds.
                         )));
               *)
               (* NOTE: for now we ignore the message *)
-              then panicS? (
+              then panicS? "stub-error"
+              (* 
                 PartialVMError.Impl_move_sui_simulations_move_binary_format_errors_PartialVMError
-                  .new StatusCode.CONSTRAINT_NOT_SATISFIED)
-              else returnS? tt in (* we should never arrive at this stub *)
+                  .new StatusCode.CONSTRAINT_NOT_SATISFIED *)
+              (* we should never arrive at this stub *)
+              else returnS? tt in 
             (* self.units = new_units; *)
-            let self := self <| units := units |> in (* TODO: update self *)
+            let self := self <| Bounds.units := units |> in (* TODO: update self *)
             writeS? self
         | None => returnS? tt
         end in

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -12,8 +12,6 @@ Require CoqOfRust.move_sui.simulations.move_core_types.vm_status.
 Module StatusCode := vm_status.StatusCode.
 
 (* TODO(progress):
-- (Important) Check `mut` functions for `BoundMeter` have been implemented correctly
-  with a focus on correctly mutating the states
 - Fix bugs in `Bounds.add`: 
   - Implement saturated addition
 - Investigate the exact function chains from `verify_instr` 

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -14,8 +14,6 @@ Module StatusCode := vm_status.StatusCode.
 (* TODO(progress):
 - Fix bugs in `Bounds.add`: 
   - Implement saturated addition
-- Implement `BoundMeter::add`:
-  - Implement `Lens` from `Bounds` to `BoundMeter`
 - Write out the exact function chains from `verify_instr` 
   - Explain when will other verify functions use `verify_instr`
   - Examine further if `DummyMeter` can be safely replaced by `BoundMeter`
@@ -325,12 +323,13 @@ Module Meter.
       Definition add (self : Self) (scope : Scope.t) (units : Z) 
         : MS? State string (PartialVMResult.t unit) :=
         letS? bounds := return!?toS? (get_bounds_mut self scope) in
-        let units := bounds.(Bounds.units) in
-        let bounds : MS? Bounds.State string (PartialVMResult.t unit) := 
-          Bounds.Impl_move_sui_simulations_move_bytecode_verifier_meter_Bounds.add 
-            bounds units in
-        (* TODO: write the updated bounds to the bounds state *)
-        let boundmeter := Lens.lift (Lens_BoundMeter_State_Bounds_State.values scope) bounds in
+        letS? boundmeter := liftS? 
+          (Lens_BoundMeter_State_Bounds_State.values scope) 
+          (Bounds.Impl_move_sui_simulations_move_bytecode_verifier_meter_Bounds.add 
+          bounds units)
+          in
+        letS? _ := writeS? boundmeter in
+
         (* TODO: figure out why `writeS?` doesn't work *)
         (* letS? _ := writeS? in *)
         returnS? (Result.Ok tt).

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -285,14 +285,16 @@ Module Meter.
         self : Self;
       }.
 
+      (* TODO: write test to test out lens combination *)
+
       Definition enter_scope (self : Self) (name : string) (scope : Scope.t) : MS? State string unit :=
         let bounds := get_bounds_mut self scope in
           match bounds with
-          (* TODO: finish this *)
           | Panic.Value value => 
-            let bounds := 
-                Impl_move_sui_simulations_move_bytecode_verifier_meter_BoundMeter
-                .get_bounds_mut self in
+          (* TODO: lift the value with lens... *)
+            let!? bounds := LensPanic.lift (Impl_move_sui_simulations_move_bytecode_verifier_meter_BoundMeter
+                .get_bounds_mut self) readS? in
+            let bounds := bounds <| Bounds.name := name |> in 
             returnS? tt
 
           | Panic.Panic error => fun state => ((panic!? error), state)

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -327,6 +327,12 @@ Module Meter.
           self.add(scope, units_per_item.saturating_mul(items as u128))
       }
       *)
+      Definition add_items (scope : Scope.t) (units_per_item items : Z) 
+        : MS? State string (PartialVMResult.t unit) :=
+        if items =? 0
+        then (returnS? (Result.Ok tt))
+        else letS? self := readS? in
+        add scope (Z.mul units_per_item items).
       
     End Impl_move_sui_simulations_move_bytecode_verifier_meter_BoundMeter.
   End BoundMeter.

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -9,8 +9,10 @@ Module PartialVMResult := errors.PartialVMResult.
 Module PartialVMError := errors.PartialVMError.
 
 (* TODO(progress):
-- Write out the exact function chains from `verify_instr`
-- Implement `Scope` or stub it
+- Implement `Scope` since it's strongly related
+- Write out the exact function chains from `verify_instr` 
+  - Explain when will other verify functions use `verify_instr`
+  - Examine further if `DummyMeter` can be safely replaced by `BoundMeter`
 - Correctly Implement `f32`
 - Maybe move `BoundMeter` and `DummyMeter` to their files
 *)
@@ -152,13 +154,24 @@ Module BoundMeter.
       move_sui.simulations.move_bytecode_verifier_meter.BoundMeter.t.
 
     (* 
+    fn get_bounds_mut(&mut self, scope: Scope) -> &mut Bounds {
+        match scope {
+            Scope::Package => &mut self.pkg_bounds,
+            Scope::Module => &mut self.mod_bounds,
+            Scope::Function => &mut self.fun_bounds,
+            Scope::Transaction => panic!("transaction scope unsupported."),
+        }
+    }
+    *)
+    Definition get_bounds_mut (self : Self) (scope : Scope) : Bounds.t. Admitted.
+
+    (* 
     fn enter_scope(&mut self, name: &str, scope: Scope) {
         let bounds = self.get_bounds_mut(scope);
         bounds.name = name.into();
         bounds.units = 0;
     }
     *)
-    (* TODO: Implement get_bounds_mut *)
     Definition enter_scope (self : Self) (name : str) (scope : Scope) : unit. Admitted.
 
     (* 

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -293,14 +293,11 @@ Module Meter.
         self : Self;
       }.
 
-      (* DRAFT: 
-      MS? State PartialVMError.t unit
-      *)
       Definition enter_scope (self : Self) (name : string) (scope : Scope.t) : MS? State PartialVMError.t unit :=
         let bounds := get_bounds_mut self scope in
           match bounds with
+          (* TODO: finish this *)
           | Panic.Value value => returnS? tt
-
           | Panic.Panic error => fun state => (panic!? error)
           end.
         returnS? tt.

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -12,10 +12,9 @@ Require CoqOfRust.move_sui.simulations.move_core_types.vm_status.
 Module StatusCode := vm_status.StatusCode.
 
 (* TODO(progress):
-- Suggestion: change the type order for `M!? Error A` into `M!? A Error`
-- Fix bugs in `Bounds.add`: implement saturated addition
-- Implement `enter_scope` correctly, with a correct State monad
-  - Currently we use `MS? State PartialVMError.t unit`. Maybe there's a better candidate for `Error` type within
+- Fix bugs in `Bounds.add`: 
+  - Implement saturated addition
+  - Define correct state for `Bounds.add` so that the state propagates
 - Write out the exact function chains from `verify_instr` 
   - Explain when will other verify functions use `verify_instr`
   - Examine further if `DummyMeter` can be safely replaced by `BoundMeter`
@@ -299,6 +298,18 @@ Module Meter.
           writeS? state.
 
       (* 
+      fn add(&mut self, scope: Scope, units: u128) -> PartialVMResult<()> {
+          self.get_bounds_mut(scope).add(units)
+      }
+      *)
+      (* TODO: we might need to simplify the monad *)
+      Definition add (self : Self) (scope : Scope.t) (units : Z) 
+        : MS? State string PartialVMResult.t unit :=
+        letS? bounds := get_bounds_mut self scope in
+        let units := bounds.(Bounds.units)
+        let bounds := 
+
+      (* 
       fn transfer(&mut self, from: Scope, to: Scope, factor: f32) -> PartialVMResult<()> {
           let units = (self.get_bounds_mut(from).units as f32 * factor) as u128;
           self.add(to, units)
@@ -309,14 +320,6 @@ Module Meter.
       letS? bounds := get_bounds_mut self from in
       let units := bounds.(Bounds.units) in
       returnS? tt.
-      
-
-      (* 
-      fn add(&mut self, scope: Scope, units: u128) -> PartialVMResult<()> {
-          self.get_bounds_mut(scope).add(units)
-      }
-      *)
-      Definition add (self : Self) (scope : Scope.t) (units : Z) : PartialVMResult.t unit. Admitted.
       
     End Impl_move_sui_simulations_move_bytecode_verifier_meter_BoundMeter.
   End BoundMeter.

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -297,11 +297,13 @@ Module Meter.
       MS? State PartialVMError.t unit
       *)
       Definition enter_scope (self : Self) (name : string) (scope : Scope.t) : MS? State PartialVMError.t unit :=
-        let bounds := get_bounds_mut scope in
-        match bounds with
-        | return!? value => _
-        | panic!? error => _
-        end.
+        let bounds := get_bounds_mut self scope in
+          match bounds with
+          | Panic.Value value => returnS? tt
+
+          | Panic.Panic error => fun state => (panic!? error)
+          end.
+        returnS? tt.
 
       (* 
       fn transfer(&mut self, from: Scope, to: Scope, factor: f32) -> PartialVMResult<()> {

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -10,6 +10,7 @@ Module PartialVMError := errors.PartialVMError.
 
 (* TODO(progress):
 - Implement `Bounds::add` function
+- Implement `enter_scope` correctly
 - Write out the exact function chains from `verify_instr` 
   - Explain when will other verify functions use `verify_instr`
   - Examine further if `DummyMeter` can be safely replaced by `BoundMeter`
@@ -51,12 +52,6 @@ Module Scope.
 End Scope.
 
 (* bound.rs
-// Copyright (c) The Move Contributors
-// SPDX-License-Identifier: Apache-2.0
-
-use crate::{Meter, Scope};
-use move_binary_format::errors::{PartialVMError, PartialVMResult};
-use move_core_types::vm_status::StatusCode;
 use move_vm_config::verifier::MeterConfig;
 *)
 (* 
@@ -97,7 +92,6 @@ Module Bounds.
   End Impl_move_sui_simulations_move_bytecode_verifier_meter_Bounds.
 End Bounds.
 
-(* TODO: Implement `Meter` trait as Coq Class *)
 (* 
 pub trait Meter {
     /// Indicates the begin of a new scope.

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -9,9 +9,9 @@ Module PartialVMResult := errors.PartialVMResult.
 Module PartialVMError := errors.PartialVMError.
 
 (* TODO(progress):
-- Implement `BoundMeter` just in case
 - Write out the exact function chains from `verify_instr`
 - Implement `Scope` or stub it
+- Correctly Implement `f32`
 - Maybe move `BoundMeter` and `DummyMeter` to their files
 *)
 

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -12,9 +12,11 @@ Require CoqOfRust.move_sui.simulations.move_core_types.vm_status.
 Module StatusCode := vm_status.StatusCode.
 
 (* TODO(progress):
+- (Important) Check `mut` functions for `BoundMeter` have been implemented correctly
+  with a focus on correctly mutating the states
 - Fix bugs in `Bounds.add`: 
   - Implement saturated addition
-- Write out the exact function chains from `verify_instr` 
+- Investigate the exact function chains from `verify_instr` 
   - Explain when will other verify functions use `verify_instr`
   - Examine further if `DummyMeter` can be safely replaced by `BoundMeter`
   - Carefully check where does `DummyMeter` apply and what properties or functions are being accessed
@@ -293,7 +295,7 @@ Module Meter.
         | Scope.Function    => return!? self.(fun_bounds)
         | Scope.Transaction => panic!? "transaction scope unsupported."
         end.
-
+ 
       (* 
       fn enter_scope(&mut self, name: &str, scope: Scope.t) {
           let bounds = self.get_bounds_mut(scope);
@@ -344,6 +346,21 @@ Module Meter.
         letS? bounds := return!?toS? (get_bounds_mut self from) in
         let units := Z.mul bounds.(Bounds.units) factor in
         add self to units.
+
+      (* 
+      /// Adds the number of items.
+      fn add_items(
+          &mut self,
+          scope: Scope,
+          units_per_item: u128,
+          items: usize,
+      ) -> PartialVMResult<()> {
+          if items == 0 {
+              return Ok(());
+          }
+          self.add(scope, units_per_item.saturating_mul(items as u128))
+      }
+      *)
       
     End Impl_move_sui_simulations_move_bytecode_verifier_meter_BoundMeter.
   End BoundMeter.

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -13,9 +13,21 @@ Module PartialVMError := errors.PartialVMError.
 - Write out the exact function chains from `verify_instr` 
   - Explain when will other verify functions use `verify_instr`
   - Examine further if `DummyMeter` can be safely replaced by `BoundMeter`
-- Correctly Implement `f32`
-- Maybe move `BoundMeter` and `DummyMeter` to their files
+  - Carefully check where does `DummyMeter` apply and what properties or functions are being accessed
+- Restructure the `Meter` module(not trait) as in note below
 *)
+
+(* NOTE: DRAFT: We can restructure the `Meter` into a large module, since its content are pretty few.
+Currently we implement the structs separately, but the plan is:
+
+Module Meter
+  - Module BoundMeter
+  - Module DummyMeter
+*)
+
+(* NOTE: 
+  - We ignore `f32` since related parameters are mostly factors to be multiplied with.
+    These parameters will be either ignored or treated as a sole `1`. *)
 
 (* use crate::{Meter, Scope}; *)
 (* pub struct DummyMeter; *)
@@ -28,10 +40,9 @@ Module DummyMeter.
       move_sui.simulations.move_bytecode_verifier_meter.DummyMeter.t.
 
     (* fn enter_scope(&mut self, _name: &str, _scope: Scope) {} *)
-    Definition enter_scope (self : Self) (_name : str) (_scope : Scope) := .
+    Definition enter_scope (self : Self) (_name : str) (_scope : Scope) : unit := tt.
 
     (* fn transfer(&mut self, _from: Scope, _to: Scope, _factor: f32) -> PartialVMResult<()> { Ok(()) } *)
-    (* TODO: translate the `f32` here correctly *)
     Definition transfer (self : Self) (_from : Scope) (_to : Scope) (_factor : Z) : PartialVMResult.t unit := return?? tt.
 
     (* fn add(&mut self, _scope: Scope, _units: u128) -> PartialVMResult<()> { Ok(()) } *)
@@ -180,7 +191,7 @@ Module BoundMeter.
         self.add(to, units)
     }
     *)
-    Definition transfer (self : Self) (from : Scope) (to : Scope) (factor : f32) : PartialVMResult.t unit. Admitted.
+    Definition transfer (self : Self) (from : Scope) (to : Scope) (factor : Z) : PartialVMResult.t unit. Admitted.
 
     (* 
     fn add(&mut self, scope: Scope, units: u128) -> PartialVMResult<()> {
@@ -190,6 +201,11 @@ Module BoundMeter.
     Definition add (self : Self) (scope : Scope) (units : Z) : PartialVMResult.t unit. Admitted.
     
   End Impl_move_sui_simulations_move_bytecode_verifier_meter_BoundMeter.
+
+  Module Dummy.
+    (* TODO: IMPORTANT: move the `DummyMeter` struct along with its impls into this module *)
+  End Dummy.
+
 End BoundMeter.
 
 (* TODO: Implement `Meter` trait as Coq Class *)

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -14,6 +14,8 @@ Module StatusCode := vm_status.StatusCode.
 (* TODO(progress):
 - Fix bugs in `Bounds.add`: 
   - Implement saturated addition
+- Implement `BoundMeter::add`:
+  - Implement `Lens` from `Bounds` to `BoundMeter`
 - Write out the exact function chains from `verify_instr` 
   - Explain when will other verify functions use `verify_instr`
   - Examine further if `DummyMeter` can be safely replaced by `BoundMeter`
@@ -298,6 +300,22 @@ Module Meter.
         end in
         let state : State := {| self := self |} in
           writeS? state.
+
+      Module Lens_Bounds.
+        Definition t : Lens.t Bounds.t Self := {| 
+          Lens.read := _ ;
+          Lens.write := _;
+        |}.
+      End Lens_Bounds.
+
+      (* 
+      Module Lens.
+        Definition values {A : Set} : Lens.t (t A) (list (Z * A)) := {|
+          Lens.read stack := values stack;
+          Lens.write stack vs := stack <| values := vs |>
+        |}.
+      End Lens.
+      *)
 
       (* 
       fn add(&mut self, scope: Scope, units: u128) -> PartialVMResult<()> {

--- a/CoqOfRust/simulations/M.v
+++ b/CoqOfRust/simulations/M.v
@@ -116,6 +116,8 @@ Module StatePanic.
   Definition write {State Error : Set} (state : State) : t State Error unit :=
     fun _ => (return!? tt, state).
 
+  (* TODO: change the `string` to arbitary type `Error` *)
+  (* I think this combinator might be heavily bugged *)
   Definition panic {State A : Set} (msg : string) : t State string A :=
     fun state => (panic!? msg, state).
 

--- a/CoqOfRust/simulations/M.v
+++ b/CoqOfRust/simulations/M.v
@@ -116,8 +116,6 @@ Module StatePanic.
   Definition write {State Error : Set} (state : State) : t State Error unit :=
     fun _ => (return!? tt, state).
 
-  (* TODO: change the `string` to arbitary type `Error` *)
-  (* I think this combinator might be heavily bugged *)
   Definition panic {State A : Set} (msg : string) : t State string A :=
     fun state => (panic!? msg, state).
 


### PR DESCRIPTION
Plans or features:
- [ ] Implement `CompiledModule`
- [x] Implement `Scope` for `Meter` trait
- [x] Implement `Bounds` for `Meter` trait
- [x] Implement the functions in `Meter` trait and specifically two structs that implements this trait
- [ ] Implement `verify_instr`
- [x] Import `AbstractStack` into `type_safety` and used it correctly
- [ ] to be updated...