### PR TITLE
Add more generic `panic_any` operation to the `StatePanic` monad

### DIFF
--- a/CoqOfRust/simulations/M.v
+++ b/CoqOfRust/simulations/M.v
@@ -125,8 +125,11 @@ Module StatePanic.
   Definition write {State Error : Set} (state : State) : t State Error unit :=
     fun _ => (return!? tt, state).
 
+  Definition panic_any {State Error A : Set} (err : Error) : t State Error A :=
+    fun state => (panic!? err, state).
+
   Definition panic {State A : Set} (msg : string) : t State string A :=
-    fun state => (panic!? msg, state).
+    panic_any msg.
 
   Definition lift_from_panic {State Error A : Set} (value : M!? Error A) : t State Error A :=
     fun state => (value, state).
@@ -150,6 +153,8 @@ Module StatePanicNotations.
   Notation "readS?" := StatePanic.read.
 
   Notation "writeS?" := StatePanic.write.
+
+  Notation "panic_anyS?" := StatePanic.panic_any.
 
   Notation "panicS?" := StatePanic.panic.
 


### PR DESCRIPTION
This pull request adds a more generic `panic_any` operation to the `StatePanic` monad. Usual `panic` operation is an instance of `panic_any` where error type is `string`.

- `panic_any` operation corresponds to [`std::panic::panic_any`](https://doc.rust-lang.org/std/panic/fn.panic_any.html) operation from Rust stdlib
- `panic` operation corresponds to [`std::panic!`](https://doc.rust-lang.org/std/macro.panic.html) macro from Rust