### PR TITLE
move: simulate the 'verify' function

### DIFF
--- a/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
@@ -320,9 +320,9 @@ Module AbstractStack.
     letS? self := readS? in
     letS? _ := assert_eqS? (List.length (values self)) (List.length lengths) in
     letS? sum :=
-      foldS? (fun acc '((actual, _), expected) =>
+      foldS? 0 (List.combine (values self) lengths) (fun acc '((actual, _), expected) =>
         letS? _ := assert_eqS? actual expected in
         returnS? (acc + expected)%Z
-      ) (List.combine (values self) lengths) 0 in
+      ) in
     assert_eqS? (len self) sum.
 End AbstractStack.

--- a/CoqOfRust/move_sui/simulations/move_binary_format/control_flow_graph.v
+++ b/CoqOfRust/move_sui/simulations/move_binary_format/control_flow_graph.v
@@ -1,0 +1,94 @@
+Require Import CoqOfRust.CoqOfRust.
+Require Import CoqOfRust.simulations.M.
+Require Import CoqOfRust.lib.lib.
+Require Import CoqOfRust.move_sui.simulations.mutual.lib.
+
+Import simulations.M.Notations.
+
+Require CoqOfRust.move_sui.simulations.move_binary_format.file_format.
+Module Bytecode := file_format.Bytecode.
+Module CodeOffset := file_format.CodeOffset.
+
+(* pub type BlockId = CodeOffset; *)
+Module BlockId.
+  Definition t : Set := CodeOffset.t.
+End BlockId.
+
+(* pub trait ControlFlowGraph { *)
+(* We do not implement this trait as it is used only once. *)
+
+(*
+struct BasicBlock {
+    exit: CodeOffset,
+    successors: Vec<BlockId>,
+}
+*)
+Module BasicBlock.
+  Record t : Set := {
+    exit : CodeOffset.t;
+    successors : list BlockId.t;
+  }.
+End BasicBlock.
+
+(* 
+pub struct VMControlFlowGraph {
+    /// The basic blocks
+    blocks: Map<BlockId, BasicBlock>,
+    /// Basic block ordering for traversal
+    traversal_successors: Map<BlockId, BlockId>,
+    /// Map of loop heads with all of their back edges
+    loop_heads: Map<BlockId, /* back edges */ Set<BlockId>>,
+}
+*)
+(* NOTE: STUB: only implement if necessary *)
+Module VMControlFlowGraph.
+  Record t : Set := {
+    blocks : Map.t BlockId.t BasicBlock.t;
+    traversal_successors : Map.t BlockId.t BlockId.t;
+    loop_heads : Map.t BlockId.t (Set_.t BlockId.t);
+  }.
+End VMControlFlowGraph.
+
+Module Impl_VMControlFlowGraph.
+  Definition new (code : list Bytecode.t) : VMControlFlowGraph.t. Admitted.
+
+  (* We put here the functions from the trait [ControlFlowGraph] as it is used only once. *)
+  (*
+    fn block_start(&self, block_id: BlockId) -> CodeOffset {
+        block_id
+    }
+  *)
+  Definition block_start (self : VMControlFlowGraph.t) (block_id : BlockId.t) : CodeOffset.t :=
+    block_id.
+
+  (*
+    fn block_end(&self, block_id: BlockId) -> CodeOffset {
+        self.blocks[&block_id].exit
+    }
+  *)
+  Definition block_end (self : VMControlFlowGraph.t) (block_id : BlockId.t) : CodeOffset.t :=
+    match Map.get self.(VMControlFlowGraph.blocks) block_id with
+    | Some block => block.(BasicBlock.exit)
+    | None => 0 (* NOTE: unreachable code *)
+    end.
+
+  (*
+    fn instr_indexes(&self, block_id: BlockId) -> Box<dyn Iterator<Item = CodeOffset>> {
+        Box::new(self.block_start(block_id)..=self.block_end(block_id))
+    }
+  *)
+  Definition instr_indexes (self : VMControlFlowGraph.t) (block_id : BlockId.t) :
+      list CodeOffset.t :=
+    let start := block_start self block_id in
+    let end_ := block_end self block_id in
+    let length := (end_ - start + 1)%Z in
+    List.map Z.of_nat $ List.seq (Z.to_nat start) (Z.to_nat length).
+
+  (*
+    fn blocks(&self) -> Vec<BlockId> {
+        self.blocks.keys().cloned().collect()
+    }
+  *)
+  Definition blocks (self : VMControlFlowGraph.t) : list BlockId.t :=
+    Map.keys (VMControlFlowGraph.blocks self).
+End Impl_VMControlFlowGraph.

--- a/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
+++ b/CoqOfRust/move_sui/simulations/move_binary_format/file_format.v
@@ -79,8 +79,9 @@ Module TypeParameterIndex.
   Record t : Set := { a0 : Z; }.
 End TypeParameterIndex.
 
+(* pub type CodeOffset = u16; *)
 Module CodeOffset.
-  Record t : Set := { a0 : Z; }.
+  Definition t : Set := Z.
 End CodeOffset.
 
 Module ModuleHandleIndex.

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
@@ -4,31 +4,18 @@ Require Import CoqOfRust.lib.lib.
 
 Import simulations.M.Notations.
 
+Require CoqOfRust.move_sui.simulations.move_binary_format.control_flow_graph.
+Module BlockId := control_flow_graph.BlockId.
+Module VMControlFlowGraph := control_flow_graph.VMControlFlowGraph.
+
 Require CoqOfRust.move_sui.simulations.move_binary_format.file_format.
-Module Signature := file_format.Signature.
 Module AbilitySet := file_format.AbilitySet.
-Module FunctionDefinitionIndex := file_format.FunctionDefinitionIndex.
+Module Bytecode := file_format.Bytecode.
 Module CodeUnit := file_format.CodeUnit.
 Module CompiledModule := file_format.CompiledModule.
+Module FunctionDefinitionIndex := file_format.FunctionDefinitionIndex.
 Module FunctionHandle := file_format.FunctionHandle.
-Module Bytecode := file_format.Bytecode.
-
-(* 
-pub struct VMControlFlowGraph {
-    /// The basic blocks
-    blocks: Map<BlockId, BasicBlock>,
-    /// Basic block ordering for traversal
-    traversal_successors: Map<BlockId, BlockId>,
-    /// Map of loop heads with all of their back edges
-    loop_heads: Map<BlockId, /* back edges */ Set<BlockId>>,
-}
-*)
-(* NOTE: STUB: only implement if necessary *)
-Module VMControlFlowGraph.
-  Record t : Set := { }.
-End VMControlFlowGraph.
-
-Definition VMControlFlowGraph_new (code : list Bytecode.t) : VMControlFlowGraph.t. Admitted.
+Module Signature := file_format.Signature.
 
 (* pub struct FunctionContext<'a> {
     index: Option<FunctionDefinitionIndex>,
@@ -85,10 +72,10 @@ Module FunctionContext.
         return_ := signature_at module function_handle.(FunctionHandle.return_);
         locals := signature_at module code.(CodeUnit.locals);
         type_parameters := function_handle.(FunctionHandle.type_parameters);
-        cfg := VMControlFlowGraph_new code.(CodeUnit.code);
+        cfg := control_flow_graph.Impl_VMControlFlowGraph.new code.(CodeUnit.code);
       |} in
       result.
-    
+
     Definition parameters (self : Self) := self.(parameters).
 
     Definition locals (self : Self) := self.(locals).

--- a/CoqOfRust/move_sui/simulations/mutual/lib.v
+++ b/CoqOfRust/move_sui/simulations/mutual/lib.v
@@ -3,3 +3,17 @@ Require Import CoqOfRust.simulations.M.
 Require Import CoqOfRust.lib.lib.
 
 Import simulations.M.Notations.
+
+(* Note: here we use axioms for these definitions. We should use a standard library for these
+   instead. *)
+Module Map.
+  Parameter t : Set -> Set -> Set.
+
+  Parameter get : forall {K V : Set}, t K V -> K -> option V.
+
+  Parameter keys : forall {K V : Set}, t K V -> list K.
+End Map.
+
+Module Set_.
+  Parameter t : Set -> Set.
+End Set_.


### PR DESCRIPTION
This pull request adds:

- Axioms for `Map` and `Set`. We should use an existing library for these. There is https://github.com/mit-plv/coqutil/tree/master that seems well maintained and in active use.
- A `borrowS?` primitive to temporarily add a value to the current state, and return its final value once the computation is done.
- A simulation for the `verify` function.

Closes https://github.com/formal-land/coq-of-rust/issues/594