### PR TITLE
Add an example of test in Coq for the type-checker

### DIFF
--- a/CoqOfRust/core/simulations/assert.v
+++ b/CoqOfRust/core/simulations/assert.v
@@ -8,15 +8,15 @@ Import simulations.eq.Notations.
 
 Module Assert.
   Module Stateful.
-    Definition assert {State : Set} (b : MS? State string bool) :
-        MS? State string unit :=
+    Definition assert {State : Set} (b : MS? State bool) :
+        MS? State unit :=
       ifS? b
       then returnS? tt
       else panicS? "assertion failed".
 
     Definition assert_eq
-        {State A : Set} (x y :  MS? State string A) `{Eq.Trait A} :
-        MS? State string unit :=
+        {State A : Set} (x y :  MS? State A) `{Eq.Trait A} :
+        MS? State unit :=
       assert (
         letS? x := x in
         letS? y := y in
@@ -25,15 +25,15 @@ Module Assert.
   End Stateful.
 
   Definition assert {State : Set} (b : bool) :
-      MS? State string unit :=
+      MS? State unit :=
     Stateful.assert (returnS? b).
 
   Definition assert_eq
       {State A : Set} (x y : A) `{Eq.Trait A} :
-      MS? State string unit :=
+      MS? State unit :=
     Stateful.assert_eq (returnS? x) (returnS? y).
 
-  Definition test {State : Set} (x : MS? State string unit) (s : State) : Prop :=
+  Definition test {State : Set} (x : MS? State unit) (s : State) : Prop :=
     fst (x s) = return!? tt.
 End Assert.
 

--- a/CoqOfRust/core/simulations/bool.v
+++ b/CoqOfRust/core/simulations/bool.v
@@ -4,7 +4,7 @@ Import simulations.M.Notations.
 Require Import CoqOfRust.core.simulations.eq.
 
 Module Bool.
-  Definition and {State Error} (x y : MS? State Error bool) : MS? State Error bool :=
+  Definition and {State} (x y : MS? State bool) : MS? State bool :=
     letS? a := x in
     if negb a
     then
@@ -13,7 +13,7 @@ Module Bool.
       letS? b := y in
       returnS? b.
 
-  Definition or {State Error} (x y : MS? State Error bool) : MS? State Error bool :=
+  Definition or {State} (x y : MS? State bool) : MS? State bool :=
     letS? a := x in
     if a
     then returnS? true
@@ -21,15 +21,15 @@ Module Bool.
       letS? b := y in
       returnS? (a && b)%bool.
 
-  Definition not {State Error} (x : MS? State Error bool) : MS? State Error bool :=
+  Definition not {State} (x : MS? State bool) : MS? State bool :=
     letS? a := x in
     returnS? (negb a).
 
   Definition if_then_else
-        {State Error A}
-        (b : MS? State Error bool)
-        (x y : MS? State Error A) :
-        MS? State Error A :=
+        {State A}
+        (b : MS? State bool)
+        (x y : MS? State A) :
+        MS? State A :=
     letS? b := b in
     if b
     then x

--- a/CoqOfRust/core/simulations/option.v
+++ b/CoqOfRust/core/simulations/option.v
@@ -18,8 +18,8 @@ Module Option.
     end.
 
   Definition expect {State A : Set}
-      (self : MS? State string (option A)) (msg : string) :
-      MS? State string A :=
+      (self : MS? State (option A)) (msg : string) :
+      MS? State A :=
     letS? value := self in
     match value with
     | None => panicS? msg
@@ -27,7 +27,7 @@ Module Option.
     end.
 
   Definition unwrap {State A : Set}
-    (self : MS? State string (option A)) : MS? State string A :=
+    (self : MS? State (option A)) : MS? State A :=
     expect self "".
 End Option.
 

--- a/CoqOfRust/core/simulations/vector.v
+++ b/CoqOfRust/core/simulations/vector.v
@@ -31,7 +31,7 @@ Module Vector.
         end
     |}.
 
-  Definition pop_front {A : Set} : MS? (list A) string (option A) :=
+  Definition pop_front {A : Set} : MS? (list A) (option A) :=
     letS? l := readS? in
     match l with
     | [] => returnS? None
@@ -40,7 +40,7 @@ Module Vector.
       returnS? (Some x)
     end.
 
-  Definition pop {A : Set} : MS? (list A) string (option A) :=
+  Definition pop {A : Set} : MS? (list A) (option A) :=
     letS? l := readS? in
     match last_error l with
     | None => returnS? None

--- a/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_abstract_stack/lib.v
@@ -65,11 +65,11 @@ Module AbstractStack.
   End Lens.
 
   Definition self_values {A : Set} :
-      MS? (t A) string (list (Z * A)) :=
+      MS? (t A) (list (Z * A)) :=
     liftS? Lens.values readS?.
 
   Definition self_len {A : Set} :
-      MS? (t A) string Z :=
+      MS? (t A) Z :=
     liftS? Lens.len readS?.
 
   (*
@@ -105,12 +105,12 @@ Module AbstractStack.
     end.
 
   Definition self_is_empty {A : Set} :
-      MS? (t A) string bool :=
+      MS? (t A) bool :=
     letS? s := readS? in
     returnS? (is_empty s).
 
   Definition self_is_not_empty {A : Set} :
-      MS? (t A) string bool :=
+      MS? (t A) bool :=
     letS? s := readS? in
     returnS? (negb (is_empty s)).
 
@@ -137,7 +137,7 @@ Module AbstractStack.
   *)
 
   Definition push_n {A : Set} (item : A) `{Eq.Trait A} (n : Z) :
-      MS? (t A) string (Result.t unit AbsStackError.t) :=
+      MS? (t A) (Result.t unit AbsStackError.t) :=
     if n =? 0
     then returnS? (Result.Ok tt)
     else
@@ -174,7 +174,7 @@ Module AbstractStack.
   *)
 
   Definition push {A : Set} (item : A) `{Eq.Trait A} :
-      MS? (t A) string (Result.t unit AbsStackError.t) :=
+      MS? (t A) (Result.t unit AbsStackError.t) :=
     push_n item 1.
 
   (*
@@ -204,7 +204,7 @@ Module AbstractStack.
   *)
 
   Definition pop_eq_n {A : Set} (n : Z) :
-      MS? (t A) string (Result.t A AbsStackError.t) :=
+      MS? (t A) (Result.t A AbsStackError.t) :=
     letS? self := readS? in
     if (is_empty self || (n >? len self))%bool 
     then returnS? (Result.Err AbsStackError.Underflow)
@@ -235,7 +235,7 @@ Module AbstractStack.
   *)
 
   Definition pop {A : Set} :
-      MS? (t A) string (Result.t A AbsStackError.t) :=
+      MS? (t A) (Result.t A AbsStackError.t) :=
     pop_eq_n 1.
 
   (*
@@ -266,7 +266,7 @@ Module AbstractStack.
   *)
 
   Fixpoint pop_any_n_helper {A : Set} (l : nat) (rem : Z) :
-      MS? (list (Z * A)) string unit :=
+      MS? (list (Z * A)) unit :=
     if rem >? 0
     then
       letS? '(count, last) := Option.unwrap (liftS?of? Vector.first_mut readS?) in
@@ -283,7 +283,7 @@ Module AbstractStack.
     else returnS? tt.
 
   Definition pop_any_n {A : Set} (n : Z) :
-      MS? (t A) string (Result.t unit AbsStackError.t) :=
+      MS? (t A) (Result.t unit AbsStackError.t) :=
     letS? self := readS? in
     if (is_empty self || (n >? len self))%bool 
     then returnS? (Result.Err AbsStackError.Underflow)
@@ -316,7 +316,7 @@ Module AbstractStack.
   *)
 
   Definition assert_run_lengths {A : Set} (lengths : list Z) :
-      MS? (t A) string unit :=
+      MS? (t A) unit :=
     letS? self := readS? in
     letS? _ := assert_eqS? (List.length (values self)) (List.length lengths) in
     letS? sum :=

--- a/CoqOfRust/move_sui/simulations/move_abstract_stack/unit_tests/mod.v
+++ b/CoqOfRust/move_sui/simulations/move_abstract_stack/unit_tests/mod.v
@@ -25,7 +25,7 @@ Import simulations.assert.Notations.
 *)
 
 Definition test_empty_stack :
-    MS? (AbstractStack.t Z) string unit :=
+    MS? (AbstractStack.t Z) unit :=
   letS? empty := readS? in
   letS? _ := assertS?ofS? AbstractStack.self_is_empty in
   letS? _ :=
@@ -149,7 +149,7 @@ Qed.
 *)
 
 Definition test_simple_push_pop :
-    MS? (AbstractStack.t Z) string unit :=
+    MS? (AbstractStack.t Z) unit :=
 
   letS? s := readS? in
   letS? _ := AbstractStack.push 1 in
@@ -266,7 +266,7 @@ Qed.
 *)
 
 Definition test_not_eq :
-    MS? (AbstractStack.t Z) string unit :=
+    MS? (AbstractStack.t Z) unit :=
   letS? s := readS? in
   letS? _ := AbstractStack.push 1 in
   letS? _ := AbstractStack.push 2 in
@@ -313,7 +313,7 @@ Qed.
 *)
 
 Definition test_not_enough_values :
-    MS? (AbstractStack.t Z) string unit :=
+    MS? (AbstractStack.t Z) unit :=
   letS? s := readS? in
   letS? _ := AbstractStack.push 1 in
   letS? _ := AbstractStack.push 2 in

--- a/CoqOfRust/move_sui/simulations/move_binary_format/file_format_common.v
+++ b/CoqOfRust/move_sui/simulations/move_binary_format/file_format_common.v
@@ -1,0 +1,148 @@
+Require Import CoqOfRust.CoqOfRust.
+Require Import CoqOfRust.simulations.M.
+Require Import CoqOfRust.lib.lib.
+
+Import simulations.M.Notations.
+
+(*
+pub enum BinaryConstants {}
+impl BinaryConstants {
+    /// The blob that must start a binary.
+    pub const MOVE_MAGIC_SIZE: usize = 4;
+    pub const MOVE_MAGIC: [u8; BinaryConstants::MOVE_MAGIC_SIZE] = [0xA1, 0x1C, 0xEB, 0x0B];
+    /// The `DIEM_MAGIC` size, 4 byte for major version and 1 byte for table count.
+    pub const HEADER_SIZE: usize = BinaryConstants::MOVE_MAGIC_SIZE + 5;
+    /// A (Table Type, Start Offset, Byte Count) size, which is 1 byte for the type and
+    /// 4 bytes for the offset/count.
+    pub const TABLE_HEADER_SIZE: u8 = size_of::<u32>() as u8 * 2 + 1;
+}
+*)
+Module BinaryConstants.
+  Definition MOVE_MAGIC_SIZE : Z := 4.
+  Definition MOVE_MAGIC : list Z := [0xA1; 0x1C; 0xEB; 0x0B].
+  Definition HEADER_SIZE : Z := MOVE_MAGIC_SIZE + 5.
+  Definition TABLE_HEADER_SIZE : Z := 4 * 2 + 1.
+End BinaryConstants.
+
+(*
+pub const TABLE_COUNT_MAX: u64 = 255;
+
+pub const TABLE_OFFSET_MAX: u64 = 0xffff_ffff;
+pub const TABLE_SIZE_MAX: u64 = 0xffff_ffff;
+pub const TABLE_CONTENT_SIZE_MAX: u64 = 0xffff_ffff;
+
+pub const TABLE_INDEX_MAX: u64 = 65535;
+pub const SIGNATURE_INDEX_MAX: u64 = TABLE_INDEX_MAX;
+pub const ADDRESS_INDEX_MAX: u64 = TABLE_INDEX_MAX;
+pub const IDENTIFIER_INDEX_MAX: u64 = TABLE_INDEX_MAX;
+pub const MODULE_HANDLE_INDEX_MAX: u64 = TABLE_INDEX_MAX;
+pub const STRUCT_HANDLE_INDEX_MAX: u64 = TABLE_INDEX_MAX;
+pub const STRUCT_DEF_INDEX_MAX: u64 = TABLE_INDEX_MAX;
+pub const FUNCTION_HANDLE_INDEX_MAX: u64 = TABLE_INDEX_MAX;
+pub const FUNCTION_INST_INDEX_MAX: u64 = TABLE_INDEX_MAX;
+pub const FIELD_HANDLE_INDEX_MAX: u64 = TABLE_INDEX_MAX;
+pub const FIELD_INST_INDEX_MAX: u64 = TABLE_INDEX_MAX;
+pub const STRUCT_DEF_INST_INDEX_MAX: u64 = TABLE_INDEX_MAX;
+pub const CONSTANT_INDEX_MAX: u64 = TABLE_INDEX_MAX;
+*)
+Definition TABLE_COUNT_MAX : Z := 255.
+Definition TABLE_OFFSET_MAX : Z := 2^32 - 1.
+Definition TABLE_SIZE_MAX : Z := 2^32 - 1.
+Definition TABLE_CONTENT_SIZE_MAX : Z := 2^32 - 1.
+Definition TABLE_INDEX_MAX : Z := 2^16 - 1.
+Definition SIGNATURE_INDEX_MAX : Z := TABLE_INDEX_MAX.
+Definition ADDRESS_INDEX_MAX : Z := TABLE_INDEX_MAX.
+Definition IDENTIFIER_INDEX_MAX : Z := TABLE_INDEX_MAX.
+Definition MODULE_HANDLE_INDEX_MAX : Z := TABLE_INDEX_MAX.
+Definition STRUCT_HANDLE_INDEX_MAX : Z := TABLE_INDEX_MAX.
+Definition STRUCT_DEF_INDEX_MAX : Z := TABLE_INDEX_MAX.
+Definition FUNCTION_HANDLE_INDEX_MAX : Z := TABLE_INDEX_MAX.
+Definition FUNCTION_INST_INDEX_MAX : Z := TABLE_INDEX_MAX.
+Definition FIELD_HANDLE_INDEX_MAX : Z := TABLE_INDEX_MAX.
+Definition FIELD_INST_INDEX_MAX : Z := TABLE_INDEX_MAX.
+Definition STRUCT_DEF_INST_INDEX_MAX : Z := TABLE_INDEX_MAX.
+Definition CONSTANT_INDEX_MAX : Z := TABLE_INDEX_MAX.
+
+(*
+pub const BYTECODE_COUNT_MAX: u64 = 65535;
+pub const BYTECODE_INDEX_MAX: u64 = 65535;
+
+pub const LOCAL_INDEX_MAX: u64 = 255;
+
+pub const IDENTIFIER_SIZE_MAX: u64 = 65535;
+
+pub const CONSTANT_SIZE_MAX: u64 = 65535;
+
+pub const METADATA_KEY_SIZE_MAX: u64 = 1023;
+pub const METADATA_VALUE_SIZE_MAX: u64 = 65535;
+
+pub const SIGNATURE_SIZE_MAX: u64 = 255;
+
+pub const ACQUIRES_COUNT_MAX: u64 = 255;
+
+pub const FIELD_COUNT_MAX: u64 = 255;
+pub const FIELD_OFFSET_MAX: u64 = 255;
+
+pub const TYPE_PARAMETER_COUNT_MAX: u64 = 255;
+pub const TYPE_PARAMETER_INDEX_MAX: u64 = 65536;
+
+pub const SIGNATURE_TOKEN_DEPTH_MAX: usize = 256;
+*)
+Definition BYTECODE_COUNT_MAX : Z := 2^16 - 1.
+Definition BYTECODE_INDEX_MAX : Z := 2^16 - 1.
+Definition LOCAL_INDEX_MAX : Z := 255.
+Definition IDENTIFIER_SIZE_MAX : Z := 2^16 - 1.
+Definition CONSTANT_SIZE_MAX : Z := 2^16 - 1.
+Definition METADATA_KEY_SIZE_MAX : Z := 1023.
+Definition METADATA_VALUE_SIZE_MAX : Z := 2^16 - 1.
+Definition SIGNATURE_SIZE_MAX : Z := 255.
+Definition ACQUIRES_COUNT_MAX : Z := 255.
+Definition FIELD_COUNT_MAX : Z := 255.
+Definition FIELD_OFFSET_MAX : Z := 255.
+Definition TYPE_PARAMETER_COUNT_MAX : Z := 255.
+Definition TYPE_PARAMETER_INDEX_MAX : Z := 2^16.
+Definition SIGNATURE_TOKEN_DEPTH_MAX : Z := 256.
+
+(*
+/// Version 1: the initial version
+pub const VERSION_1: u32 = 1;
+
+/// Version 2: changes compared with version 1
+///  + function visibility stored in separate byte before the flags byte
+///  + the flags byte now contains only the is_native information (at bit 0x2)
+///  + new visibility modifiers for "friend" and "script" functions
+///  + friend list for modules
+pub const VERSION_2: u32 = 2;
+
+/// Version 3: changes compared with version 2
+///  + phantom type parameters
+pub const VERSION_3: u32 = 3;
+
+/// Version 4: changes compared with version 3
+///  + bytecode for vector operations
+pub const VERSION_4: u32 = 4;
+
+/// Version 5: changes compared with version 4
+///  +/- script and public(script) verification is now adapter specific
+///  + metadata
+pub const VERSION_5: u32 = 5;
+
+/// Version 6: changes compared with version 5
+///  + u16, u32, u256 integers and corresponding Ld, Cast bytecodes
+pub const VERSION_6: u32 = 6;
+
+// Mark which version is the latest version
+pub const VERSION_MAX: u32 = VERSION_6;
+
+// Mark which oldest version is supported.
+// TODO(#145): finish v4 compatibility; as of now, only metadata is implemented
+pub const VERSION_MIN: u32 = VERSION_5;
+*)
+Definition VERSION_1 : Z := 1.
+Definition VERSION_2 : Z := 2.
+Definition VERSION_3 : Z := 3.
+Definition VERSION_4 : Z := 4.
+Definition VERSION_5 : Z := 5.
+Definition VERSION_6 : Z := 6.
+Definition VERSION_MAX : Z := VERSION_6.
+Definition VERSION_MIN : Z := VERSION_5.

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/absint.v
@@ -11,7 +11,6 @@ Module VMControlFlowGraph := control_flow_graph.VMControlFlowGraph.
 Require CoqOfRust.move_sui.simulations.move_binary_format.file_format.
 Module AbilitySet := file_format.AbilitySet.
 Module Bytecode := file_format.Bytecode.
-Module CodeUnit := file_format.CodeUnit.
 Module CompiledModule := file_format.CompiledModule.
 Module FunctionDefinitionIndex := file_format.FunctionDefinitionIndex.
 Module FunctionHandle := file_format.FunctionHandle.
@@ -31,63 +30,45 @@ Module FunctionContext.
     into the option monad. *)
   Record t : Set := { 
     index : option FunctionDefinitionIndex.t;
-    code : CodeUnit.t;
+    code : file_format.CodeUnit.t;
     parameters : Signature.t;
     return_ : Signature.t;
     locals : Signature.t;
     type_parameters : list AbilitySet.t;
     cfg : VMControlFlowGraph.t;
   }.
-
-  Module Impl_FunctionContext.
-    Definition Self : Set := 
-      move_sui.simulations.move_bytecode_verifier.absint.FunctionContext.t.
-
-    (* 
-      pub fn new(
-          module: &'a CompiledModule,
-          index: FunctionDefinitionIndex,
-          code: &'a CodeUnit,
-          function_handle: &'a FunctionHandle,
-      ) -> Self {
-          Self {
-              index: Some(index),
-              code,
-              parameters: module.signature_at(function_handle.parameters),
-              return_: module.signature_at(function_handle.return_),
-              locals: module.signature_at(code.locals),
-              type_parameters: &function_handle.type_parameters,
-              cfg: VMControlFlowGraph::new(&code.code),
-          }
-      }
-    *)
-    Definition new (module : CompiledModule.t) (index : FunctionDefinitionIndex.t) (code : CodeUnit.t)
-      (function_handle : FunctionHandle.t) :=
-      let signature_at := CompiledModule.Impl_CompiledModule.signature_at in
-      let result : Self :=
-      {|
-        index := Some index;
-        code := code;
-        parameters := signature_at module function_handle.(FunctionHandle.parameters);
-        return_ := signature_at module function_handle.(FunctionHandle.return_);
-        locals := signature_at module code.(CodeUnit.locals);
-        type_parameters := function_handle.(FunctionHandle.type_parameters);
-        cfg := control_flow_graph.Impl_VMControlFlowGraph.new code.(CodeUnit.code);
-      |} in
-      result.
-
-    Definition parameters (self : Self) := self.(parameters).
-
-    Definition locals (self : Self) := self.(locals).
-
-    Definition type_parameters (self : Self) := self.(type_parameters).
-
-    Definition index (self : Self) := self.(index).
-
-    Definition cfg (self : Self) := self.(cfg).
-
-    Definition return_ (self : Self) := self.(return_). 
-
-    Definition code (self : Self) := self.(code).
-  End Impl_FunctionContext.
+  (* 
+    pub fn new(
+        module: &'a CompiledModule,
+        index: FunctionDefinitionIndex,
+        code: &'a CodeUnit,
+        function_handle: &'a FunctionHandle,
+    ) -> Self {
+        Self {
+            index: Some(index),
+            code,
+            parameters: module.signature_at(function_handle.parameters),
+            return_: module.signature_at(function_handle.return_),
+            locals: module.signature_at(code.locals),
+            type_parameters: &function_handle.type_parameters,
+            cfg: VMControlFlowGraph::new(&code.code),
+        }
+    }
+  *)
+  Definition new
+      (module : CompiledModule.t)
+      (index : FunctionDefinitionIndex.t)
+      (code : file_format.CodeUnit.t)
+      (function_handle : FunctionHandle.t) :
+      t :=
+    let signature_at := CompiledModule.Impl_CompiledModule.signature_at in
+    {|
+      index := Some index;
+      code := code;
+      parameters := signature_at module function_handle.(FunctionHandle.parameters);
+      return_ := signature_at module function_handle.(FunctionHandle.return_);
+      locals := signature_at module code.(file_format.CodeUnit.locals);
+      type_parameters := function_handle.(FunctionHandle.type_parameters);
+      cfg := control_flow_graph.Impl_VMControlFlowGraph.new code.(file_format.CodeUnit.code);
+    |}.
 End FunctionContext.

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety.v
@@ -178,8 +178,8 @@ Module TypeSafetyChecker.
       Locals.Impl_Locals.local_at self.(locals) i.
 
     Definition abilities (self : Self) (t : SignatureToken.t) : PartialVMResult.t AbilitySet.t :=
-      let result := CompiledModule.Impl_CompiledModule.abilities self.(module) t $ 
-        FunctionContext.Impl_FunctionContext.type_parameters self.(function_context) in
+      let result := CompiledModule.Impl_CompiledModule.abilities self.(module) t $
+        FunctionContext.type_parameters self.(function_context) in
       (* NOTE(MUTUAL DEPENDENCY ISSUE): Since we're just using a stub in the `file_format`, 
         here we convert the stub into actual PartialVMError... *)
       match result with
@@ -2241,7 +2241,7 @@ Definition verify
     (function_context : FunctionContext.t) :
     MS? Meter.t string (PartialVMResult.t unit) :=
   let verifier := TypeSafetyChecker.Impl_TypeSafetyChecker.new module function_context in
-  let cfg := FunctionContext.Impl_FunctionContext.cfg function_context in
+  let cfg := function_context.(FunctionContext.cfg) in
   letS? _ :=
     borrowS? (fun meter => (verifier, meter)) (fun '(verifier, meter) => (meter, verifier)) (
       foldS? (Result.Ok tt) (control_flow_graph.Impl_VMControlFlowGraph.blocks cfg) (fun _ block_id =>

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety_tests/mod.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety_tests/mod.v
@@ -89,7 +89,7 @@ fn get_fun_context(module: &CompiledModule) -> FunctionContext {
 }
 *)
 Definition get_fun_context (module : file_format.CompiledModule.t) :
-    Panic.t string type_safety.FunctionContext.t :=
+    Panic.t type_safety.FunctionContext.t :=
   match
     module.(file_format.CompiledModule.function_defs),
     module.(file_format.CompiledModule.function_handles)
@@ -113,7 +113,7 @@ Definition get_fun_context (module : file_format.CompiledModule.t) :
 Definition test_verify
     (module : file_format.CompiledModule.t)
     (fun_context : type_safety.FunctionContext.t) :
-    M!? string (type_safety.PartialVMResult.t unit) :=
+    M!? (type_safety.PartialVMResult.t unit) :=
   let dummy_bounds := move_bytecode_verifier_meter.lib.Bounds.Build_t "dummy" 0 None in
   let dummy_meter :=
     move_bytecode_verifier_meter.lib.Meter.BoundMeter.Build_t
@@ -148,7 +148,7 @@ fn test_br_true_false_correct_type() {
 *)
 (** This function should return [Panic.Value tt] if the test succeeds, or an error message which
     is the reason of the failure in case of error. *)
-Definition test_br_true_false_correct_type_BrTrue : Panic.t string unit :=
+Definition test_br_true_false_correct_type_BrTrue : Panic.t unit :=
   let code := [file_format.Bytecode.LdTrue; file_format.Bytecode.BrTrue 0] in
   let module := make_module code in
   let!? fun_context := get_fun_context module in

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety_tests/mod.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier/type_safety_tests/mod.v
@@ -1,0 +1,162 @@
+Require Import CoqOfRust.CoqOfRust.
+Require Import CoqOfRust.simulations.M.
+
+Import simulations.M.Notations.
+
+Require CoqOfRust.move_sui.simulations.move_binary_format.file_format.
+Require CoqOfRust.move_sui.simulations.move_bytecode_verifier.absint.
+Require CoqOfRust.move_sui.simulations.move_bytecode_verifier.type_safety.
+Require CoqOfRust.move_sui.simulations.move_bytecode_verifier_meter.lib.
+
+(*
+fn make_module_with_ret(code: Vec<Bytecode>, return_: SignatureToken) -> CompiledModule {
+    let code_unit = CodeUnit {
+        code,
+        ..Default::default()
+    };
+
+    let fun_def = FunctionDefinition {
+        code: Some(code_unit.clone()),
+        ..Default::default()
+    };
+
+    let fun_handle = FunctionHandle {
+        module: ModuleHandleIndex(0),
+        name: IdentifierIndex(0),
+        parameters: SignatureIndex(0),
+        return_: SignatureIndex(1),
+        type_parameters: vec![],
+    };
+
+    let mut module = empty_module();
+    module.function_handles.push(fun_handle);
+    module.function_defs.push(fun_def);
+    module.signatures = vec![
+        Signature(vec![]),
+        Signature(vec![return_]),
+        Signature(vec![]),
+    ];
+
+    module
+}
+*)
+
+Definition make_module_with_ret
+    (code : list file_format.Bytecode.t)
+    (return_ : file_format.SignatureToken.t) :
+    file_format.CompiledModule.t :=
+  let code_unit := file_format.CodeUnit.default <|
+    file_format.CodeUnit.code := code
+  |> in
+  let fun_def := file_format.FunctionDefinition.default <|
+    file_format.FunctionDefinition.code := Some code_unit
+  |> in
+  let fun_handle := {|
+    file_format.FunctionHandle.module := file_format.ModuleHandleIndex.Build_t 0;
+    file_format.FunctionHandle.name := file_format.IdentifierIndex.Build_t 0;
+    file_format.FunctionHandle.parameters := file_format.SignatureIndex.Build_t 0;
+    file_format.FunctionHandle.return_ := file_format.SignatureIndex.Build_t 1;
+    file_format.FunctionHandle.type_parameters := []
+  |} in
+  file_format.empty_module <|
+    file_format.CompiledModule.function_handles := [fun_handle]
+  |> <|
+    file_format.CompiledModule.function_defs := [fun_def]
+  |> <|
+    file_format.CompiledModule.signatures := [
+      file_format.Signature.Build_t [];
+      file_format.Signature.Build_t [return_];
+      file_format.Signature.Build_t []
+    ]
+  |>.
+
+(*
+fn make_module(code: Vec<Bytecode>) -> CompiledModule {
+    make_module_with_ret(code, SignatureToken::U32)
+}
+*)
+Definition make_module (code : list file_format.Bytecode.t) : file_format.CompiledModule.t :=
+  make_module_with_ret code file_format.SignatureToken.U32.
+
+(*
+fn get_fun_context(module: &CompiledModule) -> FunctionContext {
+    FunctionContext::new(
+        &module,
+        FunctionDefinitionIndex(0),
+        module.function_defs[0].code.as_ref().unwrap(),
+        &module.function_handles[0],
+    )
+}
+*)
+Definition get_fun_context (module : file_format.CompiledModule.t) :
+    Panic.t string type_safety.FunctionContext.t :=
+  match
+    module.(file_format.CompiledModule.function_defs),
+    module.(file_format.CompiledModule.function_handles)
+  with
+  | function_def :: _, function_handle :: _ =>
+    match function_def.(file_format.FunctionDefinition.code) with
+    | Some code =>
+      return!? $ type_safety.FunctionContext.new
+        module
+        (file_format.FunctionDefinitionIndex.Build_t 0)
+        code
+        function_handle
+    | None => panic!? "function def does not have code"
+    end
+  | _, _ => panic!? "cannot get the first function def/handle"
+  end.
+
+(** This function replaces the [verify] function in the test which depends on too many definitions
+    to be fully simulated. The only difference is that we give an explicit value for the offset
+    here. *)
+Definition test_verify
+    (module : file_format.CompiledModule.t)
+    (fun_context : type_safety.FunctionContext.t) :
+    M!? string (type_safety.PartialVMResult.t unit) :=
+  let dummy_bounds := move_bytecode_verifier_meter.lib.Bounds.Build_t "dummy" 0 None in
+  let dummy_meter :=
+    move_bytecode_verifier_meter.lib.Meter.BoundMeter.Build_t
+      dummy_bounds dummy_bounds dummy_bounds in
+  let verifier :=
+    type_safety.TypeSafetyChecker.Impl_TypeSafetyChecker.new module fun_context in
+  (* Here we take an offset as zero. This is a value that seems to work. Normally the offset is
+     calculated but the function doing that is very complex and would take time to write a
+     simulation for. *)
+  let offset := 0 in
+  let instr :=
+    List.nth
+      (Z.to_nat offset)
+      verifier
+        .(type_safety.TypeSafetyChecker.function_context)
+        .(absint.FunctionContext.code)
+        .(file_format.CodeUnit.code)
+      file_format.Bytecode.Nop in
+  fst $ type_safety.verify_instr instr offset (verifier, dummy_meter).
+
+(*
+#[test]
+fn test_br_true_false_correct_type() {
+    for instr in vec![Bytecode::BrTrue(0), Bytecode::BrFalse(0)] {
+        let code = vec![Bytecode::LdTrue, instr];
+        let module = make_module(code);
+        let fun_context = get_fun_context(&module);
+        let result = type_safety::verify(&module, &fun_context, &mut DummyMeter);
+        assert!(result.is_ok());
+    }
+}
+*)
+(** This function should return [Panic.Value tt] if the test succeeds, or an error message which
+    is the reason of the failure in case of error. *)
+Definition test_br_true_false_correct_type_BrTrue : Panic.t string unit :=
+  let code := [file_format.Bytecode.LdTrue; file_format.Bytecode.BrTrue 0] in
+  let module := make_module code in
+  let!? fun_context := get_fun_context module in
+  let result := test_verify module fun_context in
+  match result with
+  | Panic.Value (Result.Ok _) => return!? tt
+  | _ => panic!? "assert failed"
+  end.
+
+Goal test_br_true_false_correct_type_BrTrue = return!? tt.
+Proof. reflexivity. Qed.

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -169,7 +169,8 @@ Module Meter.
   Class Trait (Self : Set) : Set := { }.
 
   Module DummyMeter.
-    Record t : Set := { }.
+    Inductive t : Set :=
+    | Make.
 
     (* impl Meter for DummyMeter  *)
     Module Impl_DummyMeter.

--- a/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
+++ b/CoqOfRust/move_sui/simulations/move_bytecode_verifier_meter/lib.v
@@ -98,7 +98,7 @@ Module Bounds.
     }
     *)
 
-    Definition add (units : Z) : MS? State string (PartialVMResult.t unit) :=
+    Definition add (units : Z) : MS? State (PartialVMResult.t unit) :=
       letS? self := readS? in
       match self.(max) with
       | Some max => 
@@ -257,7 +257,7 @@ Module Meter.
       }
       *)
       Definition get_bounds_mut (scope : Scope.t) :
-        LensPanic.t string State Bounds.State := {|
+        LensPanic.t State Bounds.State := {|
           LensPanic.read boundmeter := 
             match scope with
             | Scope.Package     => return!? (boundmeter.(pkg_bounds))
@@ -281,7 +281,7 @@ Module Meter.
           bounds.units = 0;
       }
       *)
-      Definition enter_scope (name : string) (scope : Scope.t) : MS? State string unit :=
+      Definition enter_scope (name : string) (scope : Scope.t) : MS? State unit :=
         liftS?of!? (get_bounds_mut scope) (
           letS? bounds := readS? in
           let   bounds := bounds <| Bounds.name  := name |> in
@@ -296,7 +296,7 @@ Module Meter.
       }
       *)
       Definition add (scope : Scope.t) (units : Z) 
-        : MS? State string (PartialVMResult.t unit) :=
+        : MS? State (PartialVMResult.t unit) :=
         liftS?of!? (get_bounds_mut scope) (
           letS? bounds := readS? in
           Bounds.Impl_Bounds.add 
@@ -310,7 +310,7 @@ Module Meter.
       }
       *)
       Definition transfer (from : Scope.t) (to : Scope.t) (factor : Z) 
-        : MS? State string (PartialVMResult.t unit) :=
+        : MS? State (PartialVMResult.t unit) :=
         letS? bounds := liftS?of!? (get_bounds_mut from) (readS?) in 
         letS? self := readS? in
         let units := Z.mul bounds.(Bounds.units) factor in
@@ -332,12 +332,11 @@ Module Meter.
       }
       *)
       Definition add_items (scope : Scope.t) (units_per_item items : Z) 
-        : MS? State string (PartialVMResult.t unit) :=
+        : MS? State (PartialVMResult.t unit) :=
         if items =? 0
         then returnS? $ Result.Ok tt
         else letS? self := readS? in
         add scope $ saturating_mul units_per_item items.
-      
     End Impl_BoundMeter.
   End BoundMeter.
 End Meter.

--- a/CoqOfRust/move_sui/simulations/move_vm_runtime/interpreter.v
+++ b/CoqOfRust/move_sui/simulations/move_vm_runtime/interpreter.v
@@ -260,7 +260,7 @@ Module Stack.
         }
     }
     *)
-    Definition push (value : Value.t) : MS? Self string (PartialVMResult.t unit) :=
+    Definition push (value : Value.t) : MS? Self (PartialVMResult.t unit) :=
       letS? self := readS? in
       let '(Build_t self_value) := self in
       if (Z.of_nat $ List.length self_value) <? OPERAND_STACK_SIZE_LIMIT
@@ -279,7 +279,7 @@ Module Stack.
             .ok_or_else(|| PartialVMError::new(StatusCode::EMPTY_VALUE_STACK))
     }
     *)
-    Definition pop : MS? Self string (PartialVMResult.t Value.t) :=
+    Definition pop : MS? Self (PartialVMResult.t Value.t) :=
       letS? self := readS? in
       (* We check manually if we can pop an element *)
       let '(Build_t self_value) := self in 
@@ -305,7 +305,7 @@ Module Stack.
     *)
     Definition pop_as (result_type : Set)
       `{!VMValueCast.Trait Value.t result_type}
-      : MS? Self string (PartialVMResult.t result_type) :=
+      : MS? Self (PartialVMResult.t result_type) :=
       letS?? v := pop in
       returnS? $ (VMValueCast.cast v).
 
@@ -321,7 +321,7 @@ Module Stack.
         Ok(args)
     }
     *)
-    Definition pop_n : MS? Self string (PartialVMResult.t (list Value.t)). Admitted.
+    Definition pop_n : MS? Self (PartialVMResult.t (list Value.t)). Admitted.
 
   End Impl_Stack.
 End Stack.
@@ -612,7 +612,7 @@ Definition debug_execute_instruction (pc : Z)
   (function : Function.t) (resolver : Resolver.t)
   (interpreter : Interpreter.t) (* (gas_meter : GasMeter.t) *) (* NOTE: We ignore gas since it's never implemented *)
   (instruction : Bytecode.t)
-  : MS? State string (PartialVMResult.t InstrRet.t) :=
+  : MS? State (PartialVMResult.t InstrRet.t) :=
   letS? '(pc, locals, interpreter) := readS? in
   match instruction with
   (* fill debugging content here *)
@@ -634,7 +634,7 @@ Definition execute_instruction (pc : Z)
   (function : Function.t) (resolver : Resolver.t)
   (interpreter : Interpreter.t) (* (gas_meter : GasMeter.t) *) (* NOTE: We ignore gas since it's never implemented *)
   (instruction : Bytecode.t)
-  : MS? State string (PartialVMResult.t InstrRet.t) :=
+  : MS? State (PartialVMResult.t InstrRet.t) :=
   letS? '(pc, locals, interpreter) := readS? in
   (* NOTE: We ignore the macro since it' only used for charging gas
   macro_rules! make_ty {

--- a/CoqOfRust/move_sui/simulations/move_vm_types/values/values_impl.v
+++ b/CoqOfRust/move_sui/simulations/move_vm_types/values/values_impl.v
@@ -560,7 +560,7 @@ Module Locals.
       end.
 
     Definition swap_loc (idx : Z) (violation_check : bool) 
-      : MS? (Self * Value.t) string (PartialVMResult.t Value.t) :=
+      : MS? (Self * Value.t) (PartialVMResult.t Value.t) :=
       letS? '(v, x) := readS? in
       if Z.of_nat $ List.length v <=? idx
       then returnS? $ Result.Err $ 
@@ -588,7 +588,7 @@ Module Locals.
     }
     *)
     Definition move_loc (idx : Z) (violation_check : bool) 
-      : MS? Self string (PartialVMResult.t Value.t) :=
+      : MS? Self (PartialVMResult.t Value.t) :=
       letS?? result := liftS? (Lens.lens_self_self_value ValueImpl.Invalid) 
         $ swap_loc idx violation_check in
       match result with
@@ -609,7 +609,7 @@ Module Locals.
     }
     *)
     Definition store_loc (idx : Z) (violation_check : bool) 
-      : MS? (Self * Value.t) string (PartialVMResult.t unit) :=
+      : MS? (Self * Value.t) (PartialVMResult.t unit) :=
       letS?? result := swap_loc idx violation_check in
         returnS? $ Result.Ok tt.
 


### PR DESCRIPTION
In addition to adding an example of simulation for one of the tests, this pull request removes the `string` parameter from the error monad to represent panics.

This should simplify the use of this monad a bit, and it allows to make a panic with a richer payload than a string for debugging purposes.