### PR TITLE
Automate lia more

### DIFF
--- a/CoqOfRust/lib/lib.v
+++ b/CoqOfRust/lib/lib.v
@@ -72,6 +72,7 @@ Module Integer.
     | IntegerKind.I128 => -2^127
     | IntegerKind.Isize => -2^63
     end.
+  Global Hint Unfold min : coq_of_rust_z.
 
   Definition max (kind : IntegerKind.t) : Z :=
     match kind with
@@ -88,6 +89,7 @@ Module Integer.
     | IntegerKind.I128 => 2^127 - 1
     | IntegerKind.Isize => 2^63 - 1
     end.
+  Global Hint Unfold max : coq_of_rust_z.
 
   Definition normalize_wrap (kind : IntegerKind.t) (z : Z) : Z :=
     match kind with

--- a/CoqOfRust/lib/proofs/lib.v
+++ b/CoqOfRust/lib/proofs/lib.v
@@ -31,10 +31,15 @@ Ltac step :=
     destruct_match_in e
   end.
 
+Ltac Zify.zify_pre_hook ::=
+  autounfold with coq_of_rust_z in *;
+  trivial.
+
 Module Integer.
   Module Valid.
     Definition t (kind : IntegerKind.t) (z : Z) : Prop :=
       Integer.min kind <= z <= Integer.max kind.
+    Global Hint Unfold t : coq_of_rust_z.
   End Valid.
 
   Lemma normalize_wrap_is_valid (kind : IntegerKind.t) (z : Z) :

--- a/CoqOfRust/move_sui/proofs/move_abstract_stack/lib.v
+++ b/CoqOfRust/move_sui/proofs/move_abstract_stack/lib.v
@@ -66,11 +66,7 @@ Module AbstractStack.
     { unfold "liftS!", "liftS!of!", "liftS!of?", StatePanic.bind; cbn.
       destruct H.(Eq.eqb); cbn.
       { constructor; cbn.
-        { inversion_clear H_values.
-          constructor.
-          { unfold Integer.Valid.t; cbn; lia. }
-          { assumption. }
-        }
+        { inversion_clear H_values; constructor; lia. }
         { split; [hauto lq: on|].
           (* FIX *)
           admit.
@@ -97,9 +93,7 @@ Module AbstractStack.
     | _ => True
     end.
   Proof.
-    apply push_n_is_valid.
-    { unfold Integer.Valid.t. cbn. lia. }
-    { assumption. }
+    apply push_n_is_valid; lia.
   Qed.
 
   Lemma pop_eq_n_is_valid {A : Set} `{Eq.Trait A}
@@ -127,9 +121,7 @@ Module AbstractStack.
     | _ => True
     end.
   Proof.
-    apply pop_eq_n_is_valid.
-    { unfold Integer.Valid.t. cbn. lia. }
-    { assumption. }
+    apply pop_eq_n_is_valid; lia.
   Qed.
 
   Lemma pop_any_n_helper_is_valid {A : Set}
@@ -152,10 +144,8 @@ Module AbstractStack.
       destruct (rem >? 0); cbn; trivial.
       destruct a as [count last].
       destruct (count <=? rem) eqn:?; cbn; trivial.
-      { apply IHvalues; [trivial|lia]. }
-      { constructor; trivial.
-        unfold Integer.Valid.t in *.
-        cbn in *. lia. }
+      { apply IHvalues; lia. }
+      { constructor; lia. }
     }
   Qed.
 
@@ -171,10 +161,7 @@ Module AbstractStack.
   Proof.
     revert rem H_rem.
     induction values as [|[count last] values]; intros; cbn.
-    { step.
-      { cbn. trivial. }
-      { cbn. lia. }
-    }
+    { step; cbn; lia. }
     { step; cbn.
       { step; cbn.
         { assert(H_values' : Stack.Valid.t values). {
@@ -214,23 +201,19 @@ Module AbstractStack.
       { destruct H_stack as [H_values H_len].
         assumption.
       }
-      { unfold Integer.Valid.t in H_n.
-        cbn in H_n.
-        lia.
-      }
+      { lia. }
     }
     { split.
       { unfold Integer.Valid.t; cbn.
         unfold Integer.Valid.t in H_n; cbn in H_n.
         destruct H_stack as [H_values H_len].
-        unfold Integer.Valid.t in H_len; cbn in H_len.
         lia.
       }
       { unfold Stack.get_length in H_pop_any_n_helper'.
         rewrite H_pop_any_n_helper'.
         { sauto lq: on rew: off. }
         { apply H_stack. }
-        { destruct H_n. unfold Integer.min in H0. lia. }
+        { lia. }
       }
     }
   Qed.


### PR DESCRIPTION
Avoid needing to do `unfold Interger.Valid.t` or `cbn` before `lia`.