### PR TITLE
Minor change for bitwise

### DIFF
--- a/CoqOfRust/revm/links/dependencies.v
+++ b/CoqOfRust/revm/links/dependencies.v
@@ -68,6 +68,7 @@ Module ruint.
         (array.t U8.t BYTES).
     Admitted.
   End Impl_Uint.
+
   Module Impl_from_Uint.
     Definition Self (BITS LIMBS : Usize.t) : Set :=
       ruint.Uint.t BITS LIMBS.
@@ -86,10 +87,11 @@ Module ruint.
         (from BITS LIMBS).
     Admitted.
   
-    Parameter run_from :
+    Global Instance run_from :
       forall (BITS LIMBS : Usize.t) (value : Usize.t),
-      {{ from (φ BITS) (φ LIMBS) [] [] [ φ value ] 🔽 Self BITS LIMBS }}.
-    End Impl_from_Uint.
+      Run.Trait (from (φ BITS) (φ LIMBS)) [] [] [ φ value ] (Self BITS LIMBS).
+    Admitted.
+  End Impl_from_Uint.
 
     Module Impl_PartialOrd_for_Uint.
       Definition Self (BITS LIMBS : Value.t) : Ty.t :=

--- a/CoqOfRust/revm/revm_interpreter/instructions/links/bitwise.v
+++ b/CoqOfRust/revm/revm_interpreter/instructions/links/bitwise.v
@@ -10,24 +10,14 @@ Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.instructions.bitwise.
 
-Import Run.
+Import Impl_Gas.
+
 (*
 pub fn lt<WIRE: InterpreterTypes, H: Host + ?Sized>(
     interpreter: &mut Interpreter<WIRE>,
     _host: &mut H,
 )
 *)
-
-Ltac solve_one_branch e :=
-  constructor;
-  cbn;
-  eapply Run.Rewrite; [
-    repeat erewrite IsTraitAssociatedType_eq by apply e;
-    reflexivity
-  |
-  ];
-  run_symbolic.
-
 Instance run_lt
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
@@ -50,9 +40,7 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct gas as [gas [H_gas run_gas]].
   destruct set_instruction_result as [set_instruction_result [H_set_instruction_result run_set_instruction_result]].
-  run_symbolic. {
-    repeat solve_one_branch run_InterpreterTypes_for_WIRE.
-  }
+  run_symbolic.
   eapply Run.CallPrimitiveGetTraitMethod.
   - eapply IsTraitMethod.Defined.
     + specialize (Impl_PartialOrd_for_Uint.Implements


### PR DESCRIPTION
I added a minor change that helped a bit in the beginning. By doing:

```coq
Import Impl_Gas.
```

we import the `Instance` that we need to execute the gas function at the beginning.