### PR TITLE
Put all the links in Global Opaque

### DIFF
--- a/RocqOfRust/alloc/links/boxed.v
+++ b/RocqOfRust/alloc/links/boxed.v
@@ -41,5 +41,6 @@ Module Impl_Box.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_new.
 End Impl_Box.
 Export Impl_Box.

--- a/RocqOfRust/alloc/links/raw_vec.v
+++ b/RocqOfRust/alloc/links/raw_vec.v
@@ -38,6 +38,7 @@ Module Impl_RawVec_T_A.
       (raw_vec.Impl_alloc_raw_vec_RawVec_T_A.new_in (Φ T) (Φ A)) [] [] [φ alloc]
       (Self T A).
   Admitted.
+  Global Opaque run_new_in.
 End Impl_RawVec_T_A.
 Export Impl_RawVec_T_A.
 
@@ -51,5 +52,6 @@ Module Impl_RawVec_T.
   Instance run_new {T : Set} `{Link T} :
     Run.Trait (raw_vec.Impl_alloc_raw_vec_RawVec_T_alloc_alloc_Global.new (Φ T)) [] [] [] (Self T).
   Admitted.
+  Global Opaque run_new.
 End Impl_RawVec_T.
 Export Impl_RawVec_T.

--- a/RocqOfRust/alloc/links/slice.v
+++ b/RocqOfRust/alloc/links/slice.v
@@ -12,5 +12,6 @@ Module Impl_Slice.
   Instance run_to_vec (T : Set) `{Link T} (self : Ref.t Pointer.Kind.Ref (Self T)) :
     Run.Trait (slice.Impl_slice_T.to_vec (Φ T)) [] [] [φ self] (Vec.t T Global.t).
   Admitted.
+  Global Opaque run_to_vec.
 End Impl_Slice.
 Export Impl_Slice.

--- a/RocqOfRust/alloc/vec/links/mod.v
+++ b/RocqOfRust/alloc/vec/links/mod.v
@@ -131,6 +131,7 @@ Module Impl_Vec_T.
       repeat smpl of_value.
     }
   Defined.
+  Global Opaque run_new.
 
   (* pub fn with_capacity(capacity: usize) -> Self *)
   Instance run_with_capacity {T : Set} `{Link T} (capacity : Usize.t) :
@@ -138,6 +139,7 @@ Module Impl_Vec_T.
       (vec.Impl_alloc_vec_Vec_T_alloc_alloc_Global.with_capacity (Φ T)) [] [] [φ capacity]
       (Self T).
   Admitted.
+  Global Opaque run_with_capacity.
 End Impl_Vec_T.
 Export Impl_Vec_T.
 
@@ -151,21 +153,25 @@ Module Impl_Vec_T_A.
   Instance run_len {T A : Set} `{Link T} `{Link A} (self : Ref.t Pointer.Kind.Ref (Self T A)) :
     Run.Trait (vec.Impl_alloc_vec_Vec_T_A.len (Φ T) (Φ A)) [] [] [φ self] Usize.t.
   Admitted.
+  Global Opaque run_len.
 
   (* pub const fn is_empty(&self) -> bool *)
   Instance run_is_empty {T A : Set} `{Link T} `{Link A} (self : Ref.t Pointer.Kind.Ref (Self T A)) :
     Run.Trait (vec.Impl_alloc_vec_Vec_T_A.is_empty (Φ T) (Φ A)) [] [] [φ self] bool.
   Admitted.
+  Global Opaque run_is_empty.
 
   (* pub fn pop(&mut self) -> Option<T> *)
   Instance run_pop {T A : Set} `{Link T} `{Link A} (self : Ref.t Pointer.Kind.MutRef (Self T A)) :
     Run.Trait (vec.Impl_alloc_vec_Vec_T_A.pop (Φ T) (Φ A)) [] [] [φ self] (option T).
   Admitted.
+  Global Opaque run_pop.
 
   (* pub const fn capacity(&self) -> usize *)
   Instance run_capacity {T A : Set} `{Link T} `{Link A} (self : Ref.t Pointer.Kind.Ref (Self T A)) :
     Run.Trait (vec.Impl_alloc_vec_Vec_T_A.capacity (Φ T) (Φ A)) [] [] [φ self] Usize.t.
   Admitted.
+  Global Opaque run_capacity.
 
   (* pub fn push(&mut self, value: T) *)
   Instance run_push {T A : Set} `{Link T} `{Link A}
@@ -173,12 +179,13 @@ Module Impl_Vec_T_A.
       (value : T) :
     Run.Trait (vec.Impl_alloc_vec_Vec_T_A.push (Φ T) (Φ A)) [] [] [φ self; φ value] unit.
   Admitted.
+  Global Opaque run_push.
 End Impl_Vec_T_A.
 Export Impl_Vec_T_A.
 
 Module Impl_Index_for_Vec_T_A.
   Definition Self := Vec.t.
-  
+
   Instance run (T I A Output : Set) `{Link T} `{Link I} `{Link A} `{Link Output} :
     index.Index.Run (Self T A) I Output.
   Admitted.

--- a/RocqOfRust/alloy_primitives/bits/links/address.v
+++ b/RocqOfRust/alloy_primitives/bits/links/address.v
@@ -30,6 +30,7 @@ Module Impl_Address.
       bits.address.Impl_alloy_primitives_bits_address_Address.from_word [] [] [ φ word ]
       Self.
   Admitted.
+  Global Opaque run_from_word.
 
   (* pub fn into_word(&self) -> FixedBytes<32> *)
   Instance run_into_word (self : Ref.t Pointer.Kind.Ref Self) :
@@ -37,6 +38,7 @@ Module Impl_Address.
       bits.address.Impl_alloy_primitives_bits_address_Address.into_word [] [] [ φ self ]
       (FixedBytes.t {| Integer.value := 32 |}).
   Admitted.
+  Global Opaque run_into_word.
 
   (*
   pub fn create2<S, H>(&self, salt: S, init_code_hash: H) -> Self
@@ -56,5 +58,6 @@ Module Impl_Address.
         [] [ Φ S; Φ H ] [ φ self; φ salt; φ init_code_hash ]
       Self.
   Admitted.
+  Global Opaque run_create2.
 End Impl_Address.
 Export Impl_Address.

--- a/RocqOfRust/alloy_primitives/bits/links/fixed.v
+++ b/RocqOfRust/alloy_primitives/bits/links/fixed.v
@@ -22,6 +22,7 @@ Module Impl_FixedBytes.
   Proof.
     constructor.
   Admitted.
+  Global Opaque run_zero.
 
   (* pub fn new(bytes: [u8; N]) -> Self *)
   Instance run_new (N : Usize.t) (bytes: array.t U8.t N) :
@@ -32,6 +33,7 @@ Module Impl_FixedBytes.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_new.
 End Impl_FixedBytes.
 Export Impl_FixedBytes.
 
@@ -72,6 +74,7 @@ Module Impl_From_U256_for_FixedBytes_32.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_from.
 
   Definition Run_from : From.Run_from Self aliases.U256.t.
   Proof.

--- a/RocqOfRust/alloy_primitives/bits/simulate/address.v
+++ b/RocqOfRust/alloy_primitives/bits/simulate/address.v
@@ -21,5 +21,4 @@ Module Impl_Address.
       )
     }}.
   Admitted.
-  Global Opaque Impl_Address.run_from_word.
 End Impl_Address.

--- a/RocqOfRust/alloy_primitives/bits/simulate/fixed.v
+++ b/RocqOfRust/alloy_primitives/bits/simulate/fixed.v
@@ -21,5 +21,4 @@ Module Impl_From_U256_for_FixedBytes_32.
       )
     }}.
   Admitted.
-  Global Opaque Impl_From_U256_for_FixedBytes_32.run_from.
 End Impl_From_U256_for_FixedBytes_32.

--- a/RocqOfRust/alloy_primitives/bytes/links/mod.v
+++ b/RocqOfRust/alloy_primitives/bytes/links/mod.v
@@ -102,6 +102,7 @@ Module Impl_Bytes.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_new.
 
   (* pub fn copy_from_slice(data: &[u8]) -> Self *)
   Instance run_copy_from_slice (data : Ref.t Pointer.Kind.Ref (list U8.t)) :
@@ -110,6 +111,7 @@ Module Impl_Bytes.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_copy_from_slice.
 End Impl_Bytes.
 Export Impl_Bytes.
 

--- a/RocqOfRust/alloy_primitives/log/links/mod.v
+++ b/RocqOfRust/alloy_primitives/log/links/mod.v
@@ -115,5 +115,6 @@ Module Impl_LogData.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_new.
 End Impl_LogData.
 Export Impl_LogData.

--- a/RocqOfRust/alloy_primitives/utils/links/mod.v
+++ b/RocqOfRust/alloy_primitives/utils/links/mod.v
@@ -14,3 +14,4 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_keccak256.

--- a/RocqOfRust/bytes/links/bytes.v
+++ b/RocqOfRust/bytes/links/bytes.v
@@ -36,6 +36,7 @@ Module Impl_Bytes.
       bytes.Impl_bytes_bytes_Bytes.len [] [] [ φ self ]
       Usize.t.
   Admitted.
+  Global Opaque run_len.
 
   (* pub fn clear(&mut self) *)
   Instance run_clear (self : Ref.t Pointer.Kind.MutRef Self) :
@@ -44,6 +45,7 @@ Module Impl_Bytes.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_clear.
 End Impl_Bytes.
 Export Impl_Bytes.
 

--- a/RocqOfRust/core/array/links/mod.v
+++ b/RocqOfRust/core/array/links/mod.v
@@ -53,6 +53,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_from_fn.
 
 (*
 impl<'a, T, const N: usize> TryFrom<&'a [T]> for &'a [T; N] {

--- a/RocqOfRust/core/fmt/links/mod.v
+++ b/RocqOfRust/core/fmt/links/mod.v
@@ -38,6 +38,7 @@ Module Impl_Arguments.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_new_const.
 
   (*
     pub fn new_v1<const P: usize, const A: usize>(
@@ -54,5 +55,6 @@ Module Impl_Arguments.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_new_v1.
 End Impl_Arguments.
 Export Impl_Arguments.

--- a/RocqOfRust/core/fmt/links/rt.v
+++ b/RocqOfRust/core/fmt/links/rt.v
@@ -34,5 +34,6 @@ Module Impl_Argument.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_none.
 End Impl_Argument.
 Export Impl_Argument.

--- a/RocqOfRust/core/intrinsics/links/mod.v
+++ b/RocqOfRust/core/intrinsics/links/mod.v
@@ -9,6 +9,7 @@ Instance run_three_way_compare (integer_kind : IntegerKind.t) (x y : Integer.t i
     Ordering.t.
 Proof.
 Admitted.
+Global Opaque run_three_way_compare.
 
 Instance run_saturating_add (integer_kind : IntegerKind.t) (x y : Integer.t integer_kind) :
   Run.Trait
@@ -16,6 +17,7 @@ Instance run_saturating_add (integer_kind : IntegerKind.t) (x y : Integer.t inte
     (Integer.t integer_kind).
 Proof.
 Admitted.
+Global Opaque run_saturating_add.
 
 Instance run_saturating_sub (integer_kind : IntegerKind.t) (x y : Integer.t integer_kind) :
   Run.Trait
@@ -23,6 +25,7 @@ Instance run_saturating_sub (integer_kind : IntegerKind.t) (x y : Integer.t inte
     (Integer.t integer_kind).
 Proof.
 Admitted.
+Global Opaque run_saturating_sub.
 
 Instance run_sub_with_overflow
   (x y : Integer.t IntegerKind.U64) :
@@ -34,6 +37,7 @@ Instance run_sub_with_overflow
     (Integer.t IntegerKind.U64 * bool).
 Proof.
 Admitted.
+Global Opaque run_sub_with_overflow.
 
 (* pub const unsafe fn transmute<Src, Dst>(_src: Src) -> Dst *)
 Instance run_transmute (Src Dst : Set) `{Link Src} `{Link Dst} (src : Src) :
@@ -41,12 +45,14 @@ Instance run_transmute (Src Dst : Set) `{Link Src} `{Link Dst} (src : Src) :
     intrinsics.transmute [] [ Φ Src; Φ Dst ] [ φ src ] Dst.
 Proof.
 Admitted.
+Global Opaque run_transmute.
 
 Instance run_discriminant_value (ref : Ref.t Pointer.Kind.Ref Ordering.t) :
   Run.Trait intrinsics.discriminant_value [] [Φ Ordering.t] [φ ref]
              (Integer.t IntegerKind.I8).
 Proof.
 Admitted.
+Global Opaque run_discriminant_value.
 
 (* pub const unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize) *)
 Instance run_copy_nonoverlapping {T : Set} `{Link T}
@@ -58,3 +64,4 @@ Instance run_copy_nonoverlapping {T : Set} `{Link T}
     unit.
 Proof.
 Admitted.
+Global Opaque run_copy_nonoverlapping.

--- a/RocqOfRust/core/links/array.v
+++ b/RocqOfRust/core/links/array.v
@@ -332,3 +332,4 @@ Instance run_pointer_coercion_unsize_array_to_slice
     [ φ source ]
     Target.
 Admitted.
+Global Opaque run_pointer_coercion_unsize_array_to_slice.

--- a/RocqOfRust/core/links/cmp.v
+++ b/RocqOfRust/core/links/cmp.v
@@ -16,13 +16,13 @@ pub trait PartialEq<Rhs: ?Sized = Self> {
 Module PartialEq.
   Definition trait (Self Rhs : Set) `{Link Self} `{Link Rhs} : TraitMethod.Header.t :=
     ("core::cmp::PartialEq", [], [ Φ Rhs ], Φ Self).
-    
+
   Definition Run_eq (Self Rhs : Set) `{Link Self} `{Link Rhs} : Set :=
     TraitMethod.C (trait Self Rhs) "eq" (fun method =>
       forall (self other : Ref.t Pointer.Kind.Ref Self),
       Run.Trait method [] [] [ φ self; φ other ] bool
     ).
-    
+
   Definition Run_ne (Self Rhs : Set) `{Link Self} `{Link Rhs} : Set :=
     TraitMethod.C (trait Self Rhs) "ne" (fun method =>
       forall (self other : Ref.t Pointer.Kind.Ref Self),
@@ -67,6 +67,7 @@ Proof.
   destruct Run_FnOnce_for_F.
   run_symbolic.
 Defined.
+Global Opaque run_max_by.
 
 (*
     pub trait Ord: Eq + PartialOrd<Self> {
@@ -122,6 +123,7 @@ Module Ord.
   Run.Trait (cmp.cmp.Ord.min (Φ Self)) [] [] [ φ self; φ other ] Self.
   Proof.
   Admitted.
+  Global Opaque run_min.
 
   Instance run_max {Self : Set} `{Link Self} (self other : Self)
       (run_cmp : Run_cmp Self) :
@@ -136,12 +138,14 @@ Module Ord.
         (Function2.of_run run_cmp.(TraitMethod.run))
     ).
   Defined.
+  Global Opaque run_max.
 
   Instance run_clamp {Self : Set} `{Link Self} (self min max : Self)
       (H_cmp : Run_cmp Self) :
     Run.Trait (cmp.cmp.Ord.clamp (Φ Self)) [] [] [ φ self; φ min; φ max ] Self.
   Proof.
   Admitted.
+  Global Opaque run_clamp.
 End Ord.
 
 Instance run_min {T : Set} `{Link T} `{Ord.Run T} (v1 v2 : T) :
@@ -151,6 +155,7 @@ Proof.
   destruct_all (Ord.Run T).
   run_symbolic.
 Defined.
+Global Opaque run_min.
 
 (* pub fn max<T: Ord>(v1: T, v2: T) -> T *)
 Instance run_max {T : Set} `{Link T} `{Ord.Run T} (v1 v2 : T) :
@@ -160,6 +165,7 @@ Proof.
   destruct_all (Ord.Run T).
   run_symbolic.
 Defined.
+Global Opaque run_max.
 
 Module Impl_Ord_for_u64.
   Definition Self : Set := U64.t.

--- a/RocqOfRust/core/links/hint.v
+++ b/RocqOfRust/core/links/hint.v
@@ -9,3 +9,4 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_unreachable_unchecked.

--- a/RocqOfRust/core/links/option.v
+++ b/RocqOfRust/core/links/option.v
@@ -98,6 +98,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_unwrap_failed.
 
 (* const fn expect_failed(msg: &str) -> ! *)
 Instance run_expect_failed (msg : Ref.t Pointer.Kind.Ref string) :
@@ -108,6 +109,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_expect_failed.
 
 Module Impl_Option.
   Definition Self (T : Set) `{Link T} : Set := option T.
@@ -133,6 +135,7 @@ Module Impl_Option.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_ok_or.
 
   (* pub const fn unwrap(self) -> T *)
   Instance run_unwrap {T : Set} `{Link T}
@@ -144,6 +147,7 @@ Module Impl_Option.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_unwrap.
 
   (* pub const unsafe fn unwrap_unchecked(self) -> T *)
   Instance run_unwrap_unchecked {T : Set} `{Link T}
@@ -155,6 +159,7 @@ Module Impl_Option.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_unwrap_unchecked.
 
   (*
     pub fn unwrap_or_default(self) -> T
@@ -172,6 +177,7 @@ Module Impl_Option.
     destruct run_Default_for_T.
     run_symbolic.
   Defined.
+  Global Opaque run_unwrap_or_default.
 
   (* pub fn unwrap_or(self, default: T) -> T *)
   Instance run_unwrap_or {T : Set} `{Link T}
@@ -183,6 +189,7 @@ Module Impl_Option.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_unwrap_or.
 
   (* pub const fn expect(self, msg: &str) -> T *)
   Instance run_expect {T : Set} `{Link T}
@@ -194,6 +201,7 @@ Module Impl_Option.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_expect.
 End Impl_Option.
 Export Impl_Option.
 

--- a/RocqOfRust/core/links/panicking.v
+++ b/RocqOfRust/core/links/panicking.v
@@ -86,3 +86,4 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_assert_failed.

--- a/RocqOfRust/core/links/panickingAux.v
+++ b/RocqOfRust/core/links/panickingAux.v
@@ -10,6 +10,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_panic_fmt.
 
 (* pub const fn panic(expr: &'static str) -> ! *)
 Instance run_panic (expr : Ref.t Pointer.Kind.Ref string) :
@@ -18,6 +19,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_panic.
 
 (* pub const fn panic_display<T: fmt::Display>(x: &T) -> ! *)
 Instance run_panic_display {T : Set} `{Link T}
@@ -29,3 +31,4 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_panic_display.

--- a/RocqOfRust/core/links/ptr.v
+++ b/RocqOfRust/core/links/ptr.v
@@ -9,4 +9,4 @@ Definition run_write_volatile (T: Set) `{Link T} (dst: Ref.t Pointer.Kind.MutRef
         write_volatile [] [] [φ dst] unit.
 Proof.
 Admitted.
-
+Global Opaque run_write_volatile.

--- a/RocqOfRust/core/links/result.v
+++ b/RocqOfRust/core/links/result.v
@@ -134,7 +134,7 @@ Module Impl_Result_T_E.
     constructor.
     run_symbolic.
   Defined.
-
+  Global Opaque run_unwrap_or.
   (*
   pub fn expect(self, msg: &str) -> T
   where
@@ -147,5 +147,6 @@ Module Impl_Result_T_E.
     Run.Trait
       (result.Impl_core_result_Result_T_E.expect (Φ T) (Φ E)) [] [] [ φ self; φ msg ] T.
   Admitted.
+  Global Opaque run_expect.
 End Impl_Result_T_E.
 Export Impl_Result_T_E.

--- a/RocqOfRust/core/mem/links/mod.v
+++ b/RocqOfRust/core/mem/links/mod.v
@@ -13,3 +13,4 @@ Instance run_swap {T : Set} `{Link T} (x y : Ref.t Pointer.Kind.MutRef T) :
   Run.Trait mem.swap [] [ Φ T ] [ φ x; φ y ] unit.
 Proof.
 Admitted.
+Global Opaque run_swap.

--- a/RocqOfRust/core/num/links/mod.v
+++ b/RocqOfRust/core/num/links/mod.v
@@ -15,6 +15,7 @@ Module Impl_u16.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_to_be_bytes.
 End Impl_u16.
 Export Impl_u16.
 
@@ -28,6 +29,7 @@ Module Impl_u64.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_min.
 
   (* pub const MAX: Self *)
   Instance run_max :
@@ -36,6 +38,7 @@ Module Impl_u64.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_max.
 
   (* pub const fn saturating_add(self, rhs: Self) -> Self *)
   Instance run_saturating_add (self rhs: Self) :
@@ -44,6 +47,7 @@ Module Impl_u64.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_saturating_add.
 
   (* pub const fn saturating_sub(self, rhs: Self) -> Self *)
   Instance run_saturating_sub (self rhs: Self) :
@@ -52,17 +56,20 @@ Module Impl_u64.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_saturating_sub.
 
   Instance run_saturating_mul (self rhs: Self) :
     Run.Trait num.Impl_u64.saturating_mul [] [] [ φ self; φ rhs ] Self.
   Proof.
   Admitted.
+  Global Opaque run_saturating_mul.
 
   (* pub const fn overflowing_sub(self, rhs: Self) -> (Self, bool) *)
   Instance run_overflowing_sub (self rhs: Self) :
     Run.Trait num.Impl_u64.overflowing_sub [] [] [ φ self; φ rhs ] (Self * bool).
   Proof.
   Admitted.
+  Global Opaque run_overflowing_sub.
 
   (* pub const fn from_be_bytes(bytes: [u8; 8]) -> Self *)
   Instance run_from_be_bytes (bytes: array.t U8.t {| Integer.value := 8 |}) :
@@ -71,6 +78,7 @@ Module Impl_u64.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_from_be_bytes.
 End Impl_u64.
 Export Impl_u64.
 
@@ -84,6 +92,7 @@ Module Impl_usize.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_min.
 
   (* pub const MAX: Self *)
   Instance run_max :
@@ -92,6 +101,7 @@ Module Impl_usize.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_max.
 
   (* pub const fn checked_sub(self, rhs: Self) -> Option<Self> *)
   Instance run_checked_sub (self rhs: Self) :
@@ -100,6 +110,7 @@ Module Impl_usize.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_checked_sub.
 
   (* pub const fn saturating_add(self, rhs: Self) -> Self *)
   Instance run_saturating_add (self rhs: Self) :
@@ -108,17 +119,20 @@ Module Impl_usize.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_saturating_add.
 
   Instance run_saturating_mul (self rhs: Self) :
     Run.Trait num.Impl_usize.saturating_mul [] [] [ φ self; φ rhs ] Self.
   Proof.
   Admitted.
+  Global Opaque run_saturating_mul.
 
   (* pub const fn overflowing_sub(self, rhs: Self) -> (Self, bool) *)
   Instance run_overflowing_sub (self rhs: Self) :
     Run.Trait num.Impl_usize.overflowing_sub [] [] [ φ self; φ rhs ] (Self * bool).
   Proof.
   Admitted.
+  Global Opaque run_overflowing_sub.
 End Impl_usize.
 Export Impl_usize.
 
@@ -134,6 +148,7 @@ Module Impl_isize.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_max.
 
   (* pub const MIN: Self *)
   Instance run_min :
@@ -142,6 +157,7 @@ Module Impl_isize.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_min.
 
   (* pub const fn saturating_add(self, rhs: Self) -> Self *)
   Instance run_saturating_add (self rhs: Self) :
@@ -150,16 +166,19 @@ Module Impl_isize.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_saturating_add.
 
   Instance run_saturating_mul (self rhs: Self) :
     Run.Trait num.Impl_isize.saturating_mul [] [] [ φ self; φ rhs ] Self.
   Proof.
   Admitted.
+  Global Opaque run_saturating_mul.
 
   (* pub const fn overflowing_sub(self, rhs: Self) -> (Self, bool) *)
   Instance run_overflowing_sub (self rhs: Self) :
     Run.Trait num.Impl_isize.overflowing_sub [] [] [ φ self; φ rhs ] (Self * bool).
   Proof.
   Admitted.
+  Global Opaque run_overflowing_sub.
 End Impl_isize.
 Export Impl_isize.

--- a/RocqOfRust/core/ops/links/range.v
+++ b/RocqOfRust/core/ops/links/range.v
@@ -89,6 +89,7 @@ Module Impl_Range.
       (ops.range.Impl_core_ops_range_Range_Idx.is_empty (Φ Idx)) [] [] [ φ self ]
       bool.
   Admitted.
+  Global Opaque run_is_empty.
 End Impl_Range.
 Export Impl_Range.
 

--- a/RocqOfRust/core/ptr/links/const_ptr.v
+++ b/RocqOfRust/core/ptr/links/const_ptr.v
@@ -15,5 +15,6 @@ Module Impl_pointer_const_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_add.
 End Impl_pointer_const_T.
 Export Impl_pointer_const_T.

--- a/RocqOfRust/core/ptr/links/mut_ptr.v
+++ b/RocqOfRust/core/ptr/links/mut_ptr.v
@@ -16,6 +16,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_is_null.
 
   (* pub const fn cast<U>(self) -> *mut U *)
   Instance run_cast
@@ -27,6 +28,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_cast.
 
   (* pub const fn with_addr(self, addr: usize) -> Self *)
   Instance run_with_addr
@@ -38,6 +40,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_with_addr.
 
   (* pub const unsafe fn as_mut<'a>(self) -> Option<&'a mut T> *)
   Instance run_as_mut
@@ -49,6 +52,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_as_mut.
 
   (* pub const unsafe fn as_uninit_mut<'a>(self) -> Option<&'a mut MaybeUninit<T>> *)
   Instance run_as_uninit_mut
@@ -60,6 +64,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_as_uninit_mut.
 
   (* pub const fn guaranteed_eq(self, other: *mut T) -> Option<bool> *)
   Instance run_guaranteed_eq
@@ -72,6 +77,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_guaranteed_eq.
 
   (* pub const fn guaranteed_ne(self, other: *mut T) -> Option<bool> *)
   Instance run_guaranteed_ne
@@ -84,6 +90,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_guaranteed_ne.
 
   (* pub const unsafe fn offset(self, count: isize) -> *mut T *)
   Instance run_offset
@@ -95,6 +102,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_offset.
 
   (* pub const fn wrapping_offset(self, count: isize) -> *mut T *)
   Instance run_wrapping_offset
@@ -106,6 +114,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_wrapping_offset.
 
   (* pub const fn wrapping_byte_offset(self, count: isize) -> *mut T *)
   Instance run_wrapping_byte_offset
@@ -117,6 +126,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_wrapping_byte_offset.
 
   (* pub fn mask(self, mask: usize) -> *mut T *)
   Instance run_mask
@@ -128,6 +138,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_mask.
 
   (* pub const unsafe fn as_mut_unchecked<'a>(self) -> &'a mut T *)
   Instance run_as_mut_unchecked
@@ -139,6 +150,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_as_mut_unchecked.
 
   (* pub const unsafe fn add(self, count: usize) -> Self *)
   Instance run_add
@@ -150,6 +162,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_add.
 
   (* pub const fn wrapping_add(self, count: usize) -> Self *)
   Instance run_wrapping_add
@@ -161,6 +174,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_wrapping_add.
 
   (* pub const unsafe fn sub(self, count: usize) -> Self *)
   Instance run_sub
@@ -172,6 +186,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_sub.
 
   (* pub const fn wrapping_sub(self, count: usize) -> Self *)
   Instance run_wrapping_sub
@@ -183,6 +198,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_wrapping_sub.
 
   (* pub const fn addr(self) -> usize *)
   Instance run_addr
@@ -193,6 +209,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_addr.
 
   (* pub const fn cast_const(self) -> *const T *)
   Instance run_cast_const
@@ -204,6 +221,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_cast_const.
 
   (* pub const fn with_metadata_of<U>(self, val: *mut U) -> *mut U *)
   Instance run_with_metadata_of
@@ -217,6 +235,7 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_with_metadata_of.
 
   (* pub const unsafe fn write(self, val: T) *)
   Instance run_write
@@ -242,5 +261,6 @@ Module Impl_pointer_mut_T.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_write_bytes.
 End Impl_pointer_mut_T.
 Export Impl_pointer_mut_T.

--- a/RocqOfRust/core/simulate/result.v
+++ b/RocqOfRust/core/simulate/result.v
@@ -48,8 +48,7 @@ Module Impl_Result_T_E.
       )
     }}.
   Proof.
-    unfold run_unwrap_or; cbn.
+    with_strategy transparent [run_unwrap_or] cbn.
     destruct self; cbn; apply Run.Pure.
   Qed.
-  Global Opaque run_unwrap_or.
 End Impl_Result_T_E.

--- a/RocqOfRust/core/slice/links/iter.v
+++ b/RocqOfRust/core/slice/links/iter.v
@@ -106,6 +106,7 @@ Module Impl_ChunksExact.
     Run.Trait (slice.iter.Impl_core_slice_iter_ChunksExact_T.remainder (Φ T)) [] [] [φ self]
       (Ref.t Pointer.Kind.Ref (list T)).
   Admitted.
+  Global Opaque run_remainder.
 End Impl_ChunksExact.
 Export Impl_ChunksExact.
 
@@ -164,6 +165,7 @@ Module Impl_RChunksExact.
       (slice.iter.Impl_core_slice_iter_RChunksExact_T.remainder (Φ T)) [] [] [φ self]
       (Ref.t Pointer.Kind.Ref (list T)).
   Admitted.
+  Global Opaque run_remainder.
 End Impl_RChunksExact.
 Export Impl_RChunksExact.
 

--- a/RocqOfRust/core/slice/links/mod.v
+++ b/RocqOfRust/core/slice/links/mod.v
@@ -23,6 +23,7 @@ Module Impl_Slice.
     Run.Trait (slice.Impl_slice_T.get (Φ T)) [] [Φ I] [φ self; φ index]
       (option (Ref.t Pointer.Kind.Ref Output)).
   Admitted.
+  Global Opaque run_get.
 
   (*
     pub unsafe fn get_unchecked_mut<I>(&mut self, index: I) -> &mut I::Output
@@ -39,6 +40,7 @@ Module Impl_Slice.
     Run.Trait (slice.Impl_slice_T.get_unchecked_mut (Φ T)) [] [Φ I] [φ self; φ index]
       (Ref.t Pointer.Kind.MutRef Output).
   Admitted.
+  Global Opaque run_get_unchecked_mut.
 
   (* pub const fn len(&self) -> usize *)
   Instance run_len
@@ -47,6 +49,7 @@ Module Impl_Slice.
     Run.Trait (slice.Impl_slice_T.len (Φ T)) [] [] [φ self]
       Usize.t.
   Admitted.
+  Global Opaque run_len.
 
   (* pub const fn is_empty(&self) -> bool *)
   Instance run_is_empty
@@ -58,6 +61,7 @@ Module Impl_Slice.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_is_empty.
 
   (* pub fn iter(&self) -> Iter<'_, T> *)
   Instance run_iter
@@ -66,6 +70,7 @@ Module Impl_Slice.
     Run.Trait (slice.Impl_slice_T.iter (Φ T)) [] [] [φ self]
       (Iter.t T).
   Admitted.
+  Global Opaque run_iter.
 
   (* pub fn iter_mut(&mut self) -> IterMut<'_, T> *)
   Instance run_iter_mut
@@ -74,6 +79,7 @@ Module Impl_Slice.
     Run.Trait (slice.Impl_slice_T.iter_mut (Φ T)) [] [] [φ self]
       (IterMut.t T).
   Admitted.
+  Global Opaque run_iter_mut.
 
   (* pub const fn as_ptr(&self) -> *const T *)
   Instance run_as_ptr
@@ -82,6 +88,7 @@ Module Impl_Slice.
     Run.Trait (slice.Impl_slice_T.as_ptr (Φ T)) [] [] [φ self]
       (Ref.t Pointer.Kind.ConstPointer T).
   Admitted.
+  Global Opaque run_as_ptr.
 
   (* pub const fn as_mut_ptr(&mut self) -> *mut T *)
   Instance run_as_mut_ptr
@@ -90,6 +97,7 @@ Module Impl_Slice.
     Run.Trait (slice.Impl_slice_T.as_mut_ptr (Φ T)) [] [] [φ self]
       (Ref.t Pointer.Kind.MutPointer T).
   Admitted.
+  Global Opaque run_as_mut_ptr.
 
   (* pub fn chunks_exact(&self, chunk_size: usize) -> ChunksExact<'_, T> *)
   Instance run_chunks_exact
@@ -99,6 +107,7 @@ Module Impl_Slice.
     Run.Trait (slice.Impl_slice_T.chunks_exact (Φ T)) [] [] [φ self; φ chunk_size]
       (ChunksExact.t T).
   Admitted.
+  Global Opaque run_chunks_exact.
 
   (* pub fn rchunks_exact(&self, chunk_size: usize) -> RChunksExact<'_, T> *)
   Instance run_rchunks_exact
@@ -108,6 +117,7 @@ Module Impl_Slice.
     Run.Trait (slice.Impl_slice_T.rchunks_exact (Φ T)) [] [] [φ self; φ chunk_size]
       (RChunksExact.t T).
   Admitted.
+  Global Opaque run_rchunks_exact.
 
   (*
   pub const fn copy_from_slice(&mut self, src: &[T])
@@ -121,5 +131,6 @@ Module Impl_Slice.
     Run.Trait (slice.Impl_slice_T.copy_from_slice (Φ T)) [] [] [φ self; φ src]
       unit.
   Admitted.
+  Global Opaque run_copy_from_slice.
 End Impl_Slice.
 Export Impl_Slice.

--- a/RocqOfRust/examples/default/examples/custom/links/loops_free.v
+++ b/RocqOfRust/examples/default/examples/custom/links/loops_free.v
@@ -9,18 +9,21 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_max2.
 
 Instance run_abs_i32 (x : I32.t) : Run.Trait abs_i32 [] [] [φ x] I32.t.
 Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_abs_i32.
 
 Instance run_bool_and (a b : bool) : Run.Trait bool_and [] [] [φ a; φ b] bool.
 Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_bool_and.
 
 (* pub fn get_or_zero(xs: &[u32; 4], i: usize) -> u32 *)
 Instance run_get_or_zero
@@ -31,6 +34,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_get_or_zero.
 
 (* pub fn eq2(a: &[u32; 2], b: &[u32; 2]) -> bool *)
 Instance run_eq2
@@ -41,6 +45,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_eq2.
 
 (* pub fn eq_pair(x: (u32, u32), y: (u32, u32)) -> bool *)
 Instance run_eq_pair
@@ -51,6 +56,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_eq_pair.
 
 (* pub fn min3(a: u32, b: u32, c: u32) -> u32 *)
 Instance run_min3 (a b c : U32.t) : Run.Trait min3 [] [] [φ a; φ b; φ c] U32.t.
@@ -58,6 +64,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_min3.
 
 (* pub fn choose_ref<'a>(choice: bool, a: &'a u32, b: &'a u32) -> &'a u32 *)
 Instance run_choose_ref (choice : bool) (a b : Ref.t Pointer.Kind.Ref U32.t) :
@@ -66,3 +73,4 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_choose_ref.

--- a/RocqOfRust/examples/default/examples/custom/links/mutations.v
+++ b/RocqOfRust/examples/default/examples/custom/links/mutations.v
@@ -112,6 +112,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_get_a_ref.
 
 (* fn get_b_mut(numbers: &mut Numbers) -> &mut u64 *)
 Instance run_get_b_mut (numbers : Ref.t Pointer.Kind.MutRef Numbers.t) :
@@ -120,6 +121,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_get_b_mut.
 
 (* fn duplicate(a: &u64, b: &mut u64, c: &mut u64) *)
 Instance run_duplicate
@@ -131,6 +133,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_duplicate.
 
 (* fn apply_duplicate(numbers: &mut Numbers) *)
 Instance run_apply_duplicate (numbers : Ref.t Pointer.Kind.MutRef Numbers.t) :
@@ -139,3 +142,4 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_apply_duplicate.

--- a/RocqOfRust/examples/default/examples/custom/simulate/loops_free.v
+++ b/RocqOfRust/examples/default/examples/custom/simulate/loops_free.v
@@ -26,7 +26,6 @@ Proof.
     destruct (_ <? _)
   ).
 Qed.
-Global Opaque run_max2.
 
 Definition abs_i32 (x : I32.t) : I32.t :=
   if x.(Integer.value) <? 0 then
@@ -52,7 +51,6 @@ Proof.
   }
   { apply Run.Pure. }
 Qed.
-Global Opaque run_abs_i32.
 
 Definition bool_and (a b : bool) : bool :=
   if a
@@ -75,7 +73,6 @@ Proof.
     destruct b
   ).
 Qed.
-Global Opaque run_bool_and.
 
 Definition get_or_zero (xs : array.t U32.t {| Integer.value := 4 |}) (i : Usize.t) : U32.t :=
   let i := i.(Integer.value) in
@@ -126,7 +123,6 @@ Proof.
     apply Run.Pure.
   }
 Qed.
-Global Opaque run_get_or_zero.
 
 Definition eq2 (a b : array.t U32.t {| Integer.value := 2 |}) : bool :=
   let '(tt, x1, x0) := ArrayPairs.to_tuple_rev a.(array.value) in
@@ -162,7 +158,6 @@ Proof.
     apply Run.Pure.
   }
 Qed.
-Global Opaque run_eq2.
 
 Definition eq_pair (x y : U32.t * U32.t) : bool :=
   let '(x0, x1) := x in
@@ -190,7 +185,6 @@ Proof.
     apply Run.Pure.
   }
 Qed.
-Global Opaque run_eq_pair.
 
 Definition min3 (a b c : U32.t) : U32.t :=
   let m := if a.(Integer.value) <? b.(Integer.value) then a else b in
@@ -226,7 +220,6 @@ Proof.
     { apply Run.Pure. }
   }
 Qed.
-Global Opaque run_min3.
 
 Definition choose_ref (choice : bool) (a b : U32.t) : U32.t :=
   if choice then
@@ -256,4 +249,3 @@ Proof.
     apply Run.Pure.
   }
 Qed.
-Global Opaque run_choose_ref.

--- a/RocqOfRust/examples/default/examples/custom/simulate/mutations.v
+++ b/RocqOfRust/examples/default/examples/custom/simulate/mutations.v
@@ -41,6 +41,11 @@ Lemma apply_duplicate_eq (numbers : Numbers.t) :
     (Output.Success tt, [apply_duplicate numbers]%stack)
   }}.
 Proof.
+  with_strategy transparent [
+    run_apply_duplicate
+    run_get_a_ref
+    run_get_b_mut
+  ] cbn.
   repeat (
     cbn ||
     get_can_access ||
@@ -65,4 +70,3 @@ Proof.
     apply Run.Pure
   ).
 Qed.
-Global Opaque run_duplicate.

--- a/RocqOfRust/legacy/openvm/version_v1_2_0/extensions/rv32im/circuit/branch_eq/links/core.v
+++ b/RocqOfRust/legacy/openvm/version_v1_2_0/extensions/rv32im/circuit/branch_eq/links/core.v
@@ -302,5 +302,6 @@ Module Impl_VmCoreAir_for_BranchEqualCoreAir.
       all: admit.
     }
   Admitted.
+  Global Opaque run_eval.
 End Impl_VmCoreAir_for_BranchEqualCoreAir.
 Export Impl_VmCoreAir_for_BranchEqualCoreAir.

--- a/RocqOfRust/legacy/plonky3/commit_539bbc84/air/links/utils.v
+++ b/RocqOfRust/legacy/plonky3/commit_539bbc84/air/links/utils.v
@@ -20,6 +20,7 @@ Instance run_pack_bits_le
     R.
 Proof.
 Admitted.
+Global Opaque run_pack_bits_le.
 
 (* 
 pub fn add2<AB: AirBuilder>(
@@ -42,7 +43,8 @@ pub fn add2<AB: AirBuilder>(
     air.utils.run_add2 [] [ Φ AB ] [ φ builder; φ a; φ b; φ c ]
     unit.
 Proof.
-Admitted. *)
+Admitted.
+Global Opaque run_add2. *)
 
 (* 
 pub fn xor_32_shift<AB: AirBuilder>(
@@ -67,4 +69,5 @@ pub fn xor_32_shift<AB: AirBuilder>(
     air.utils.run_add2 [] [ Φ AB ] [ φ builder; φ a; φ b; φ c; φ shift ]
     unit.
 Proof.
-Admitted. *)
+Admitted.
+Global Opaque run_xor_32_shift. *)

--- a/RocqOfRust/legacy/plonky3/commit_539bbc84/blake3_air/links/air.v
+++ b/RocqOfRust/legacy/plonky3/commit_539bbc84/blake3_air/links/air.v
@@ -44,6 +44,7 @@ Module Impl_Blake3Air.
     run_symbolic.
     (* "rand_core::SeedableRng::seed_from_u64" *)
   Admitted.
+  Global Opaque run_generate_trace_rows.
 
   (* 
   fn quarter_round_function<AB: AirBuilder>(
@@ -75,6 +76,7 @@ Module Impl_Blake3Air.
     (* p3_air::utils::add2 *)
     (* p3_air::utils::xor_32_shift *)
   Admitted.
+  Global Opaque run_quarter_round_function.
 
   (* 
   const fn full_round_to_column_quarter_round<'a, T: Copy, U>(
@@ -103,6 +105,7 @@ Module Impl_Blake3Air.
     (* p3_blake3_air::columns::Blake3State::row0
     Seems like Coq cannot recognize our current definition in struct is a link... *)
   Admitted.
+  Global Opaque run_full_round_to_column_quarter_round.
 
   (* 
   const fn full_round_to_diagonal_quarter_round<'a, T: Copy, U>(
@@ -128,6 +131,7 @@ Module Impl_Blake3Air.
     run_symbolic.
     (* Stuck at using FullRound::state_middle? *)
   Admitted.
+  Global Opaque run_full_round_to_diagonal_quarter_round.
 
   (* 
   fn verify_round<AB: AirBuilder>(
@@ -161,6 +165,7 @@ Module Impl_Blake3Air.
     `Impl_Air_for_Blake3Air` *)
     run_symbolic.
   Admitted.
+  Global Opaque run_verify_round.
 End Impl_Blake3Air.
 
 (* impl<F> BaseAir<F> for Blake3Air { *)

--- a/RocqOfRust/legacy/plonky3/commit_539bbc84/blake3_air/links/generation.v
+++ b/RocqOfRust/legacy/plonky3/commit_539bbc84/blake3_air/links/generation.v
@@ -19,4 +19,5 @@ pub fn generate_trace_rows<F: PrimeField64>(
     generation.generate_trace_rows [] [ Φ F ] [ φ inputs; φ extra_capacity_bits ]
     RowMajorMatrix.t F.
 Proof.
-Admitted. *)
+Admitted.
+Global Opaque run_generate_trace_rows. *)

--- a/RocqOfRust/legacy/plonky3/commit_539bbc84/keccak_air/links/columns.v
+++ b/RocqOfRust/legacy/plonky3/commit_539bbc84/keccak_air/links/columns.v
@@ -310,6 +310,7 @@ Module Impl_KeccakCols.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_b.
 
   (* pub fn a_prime_prime_prime(&self, y: usize, x: usize, limb: usize) -> T *)
   Instance run_a_prime_prime_prime {T : Set} `{Link T}
@@ -324,6 +325,7 @@ Module Impl_KeccakCols.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_a_prime_prime_prime.
 End Impl_KeccakCols.
 
 (* impl<T> Borrow<KeccakCols<T>> for [T] *)

--- a/RocqOfRust/legacy/plonky3/commit_539bbc84/keccak_air/links/constants.v
+++ b/RocqOfRust/legacy/plonky3/commit_539bbc84/keccak_air/links/constants.v
@@ -38,6 +38,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_value_R.
 
 (*
 pub const RC: [u64; 24] = [
@@ -107,6 +108,7 @@ Proof.
   { exact RC. }
   { reflexivity. }
 Defined.
+Global Opaque run_value_RC.
 
 (* const RC_BITS: [[u8; 64]; 24] *)
 Definition RC_BITS : array.t (array.t U8.t {| Integer.value := 64 |}) {| Integer.value := 24 |} :=
@@ -133,6 +135,7 @@ Proof.
   { exact RC_BITS. }
   { reflexivity. }
 Defined.
+Global Opaque run_value_RC_BITS.
 
 (* pub(crate) const fn rc_value_bit(round: usize, bit_index: usize) -> u8 *)
 Instance run_value_rc_value_bit (round bit_index : Usize.t) :
@@ -141,3 +144,4 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_value_rc_value_bit.

--- a/RocqOfRust/legacy/plonky3/commit_539bbc84/keccak_air/links/lib.v
+++ b/RocqOfRust/legacy/plonky3/commit_539bbc84/keccak_air/links/lib.v
@@ -12,6 +12,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_value_NUM_ROUNDS.
 
 (* const BITS_PER_LIMB: usize = 16; *)
 Definition BITS_PER_LIMB : Usize.t :=
@@ -23,6 +24,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_value_BITS_PER_LIMB.
 
 (* pub const U64_LIMBS: usize = 64 / BITS_PER_LIMB; *)
 Definition U64_LIMBS : Usize.t :=
@@ -34,6 +36,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_value_U64_LIMBS.
 
 (* const RATE_BITS: usize = 1088; *)
 Definition RATE_BITS : Usize.t :=
@@ -45,6 +48,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_value_RATE_BITS.
 
 (* const RATE_LIMBS: usize = RATE_BITS / BITS_PER_LIMB; *)
 Definition RATE_LIMBS : Usize.t :=
@@ -56,3 +60,4 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_value_RATE_LIMBS.

--- a/RocqOfRust/legacy/plonky3/commit_539bbc84/keccak_air/links/round_flags.v
+++ b/RocqOfRust/legacy/plonky3/commit_539bbc84/keccak_air/links/round_flags.v
@@ -32,3 +32,4 @@ Proof.
   }
   run_symbolic.
 Admitted.
+Global Opaque run_eval_round_flags.

--- a/RocqOfRust/pinocchio/entrypoint/links/lazy.v
+++ b/RocqOfRust/pinocchio/entrypoint/links/lazy.v
@@ -53,6 +53,7 @@ Module Impl_InstructionContext.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_new.
 
   Instance run_new_unchecked
     (input : Ref.t Pointer.Kind.Raw U8.t) :
@@ -62,6 +63,7 @@ Module Impl_InstructionContext.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_new_unchecked.
 
   Instance run_next_account
     (self : Ref.t Pointer.Kind.Ref Self) :
@@ -71,6 +73,7 @@ Module Impl_InstructionContext.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_next_account.
 
   Instance run_next_account_unchecked
     (self : Ref.t Pointer.Kind.Ref Self) :
@@ -80,6 +83,7 @@ Module Impl_InstructionContext.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_next_account_unchecked.
 
   Instance run_remaining
     (self : Ref.t Pointer.Kind.Ref Self) :
@@ -89,6 +93,7 @@ Module Impl_InstructionContext.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_remaining.
 
   Instance run_instruction_data
     (self : Ref.t Pointer.Kind.Ref Self) :
@@ -98,6 +103,7 @@ Module Impl_InstructionContext.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_instruction_data.
 
   Instance run_instruction_data_unchecked
     (self : Ref.t Pointer.Kind.Ref Self) :
@@ -107,6 +113,7 @@ Module Impl_InstructionContext.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_instruction_data_unchecked.
 
   Instance run_program_id
     (self : Ref.t Pointer.Kind.Ref Self) :
@@ -116,6 +123,7 @@ Module Impl_InstructionContext.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_program_id.
 
   Instance run_program_id_unchecked
     (self : Ref.t Pointer.Kind.Ref Self) :
@@ -125,17 +133,19 @@ Module Impl_InstructionContext.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_program_id_unchecked.
 End Impl_InstructionContext.
 
 Module Impl_MaybeAccount.
-    Definition Self : Set := MaybeAccount.t.
-  
-    Instance run_assume_account
-      (self : Self) :
-      Run.Trait
-       pinocchio.entrypoint.lazy.entrypoint.lazy.Impl_pinocchio_entrypoint_lazy_MaybeAccount.assume_account
-        [] [] [φ self] AccountInfo.t.
-    Proof.
-      constructor. admit.
-    Admitted.
+  Definition Self : Set := MaybeAccount.t.
+
+  Instance run_assume_account
+    (self : Self) :
+    Run.Trait
+      pinocchio.entrypoint.lazy.entrypoint.lazy.Impl_pinocchio_entrypoint_lazy_MaybeAccount.assume_account
+      [] [] [φ self] AccountInfo.t.
+  Proof.
+    constructor. admit.
+  Admitted.
+  Global Opaque run_assume_account.
 End Impl_MaybeAccount.

--- a/RocqOfRust/pinocchio/entrypoint/links/mod.v
+++ b/RocqOfRust/pinocchio/entrypoint/links/mod.v
@@ -28,6 +28,7 @@ Module entrypoint.
       - admit.
       - admit.
     Admitted.
+    Global Opaque run_deserialize.
   End deserialize.
 
   Module parse.
@@ -52,5 +53,6 @@ Module entrypoint.
       - admit.
       - admit. 
     Admitted.
+    Global Opaque run.
   End parse.
 End entrypoint.

--- a/RocqOfRust/pinocchio/links/account_info.v
+++ b/RocqOfRust/pinocchio/links/account_info.v
@@ -316,6 +316,7 @@ Module Impl_AccountInfo.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_key.
 
   Instance run_is_signer 
       (self : Ref.t Pointer.Kind.Ref Self) :
@@ -326,6 +327,7 @@ Module Impl_AccountInfo.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_is_signer.
 
   Instance run_owner
       (self : Ref.t Pointer.Kind.Ref Self) :
@@ -336,6 +338,7 @@ Module Impl_AccountInfo.
     constructor.
     run_symbolic.
   Defined. 
+  Global Opaque run_owner.
 
   Instance run_is_writable
       (self : Ref.t Pointer.Kind.Ref Self) :
@@ -346,6 +349,7 @@ Module Impl_AccountInfo.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_is_writable.
 
   Instance run_executable
       (self : Ref.t Pointer.Kind.Ref Self) :
@@ -356,6 +360,7 @@ Module Impl_AccountInfo.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_executable.
 
   Instance run_data_len
       (self : Ref.t Pointer.Kind.Ref Self) :
@@ -366,6 +371,7 @@ Module Impl_AccountInfo.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_data_len.
 
   Instance run_lamports
       (self : Ref.t Pointer.Kind.Ref Self) :
@@ -376,6 +382,7 @@ Module Impl_AccountInfo.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_lamports.
 
   Instance run_data_is_empty
       (self : Ref.t Pointer.Kind.Ref Self) :
@@ -386,7 +393,8 @@ Module Impl_AccountInfo.
     constructor.
     run_symbolic.
   Defined.
-  
+  Global Opaque run_data_is_empty.
+
   Instance run_is_owned_by
       (self : Ref.t Pointer.Kind.Ref Self) 
       (program : Ref.t Pointer.Kind.Ref Pubkey.t):
@@ -399,7 +407,8 @@ Module Impl_AccountInfo.
     destruct (core.links.cmp.Impl_PartialEq_for_Ref.run (array.t U8.t {| Integer.value := 32 |}) (array.t U8.t {| Integer.value := 32 |})).
     admit.
   Admitted.
-  
+  Global Opaque run_is_owned_by.
+
   Instance run_assign
     (self : Ref.t Pointer.Kind.Ref Self) 
     (new_owner : Ref.t Pointer.Kind.Ref Pubkey.t):
@@ -411,6 +420,7 @@ Module Impl_AccountInfo.
     run_symbolic.
     admit.
   Admitted.
+  Global Opaque run_assign.
 
   Instance run_is_borrowed
         (self : Ref.t Pointer.Kind.Ref Self) 
@@ -422,4 +432,5 @@ Module Impl_AccountInfo.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_is_borrowed.
 End Impl_AccountInfo.

--- a/RocqOfRust/pinocchio/links/cpi.v
+++ b/RocqOfRust/pinocchio/links/cpi.v
@@ -19,6 +19,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_MAX_CPI_ACCOUNTS.
 
 (*
 pub fn invoke<const ACCOUNTS: usize>(
@@ -43,6 +44,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_invoke.
 
 (*
 pub fn invoke_with_bounds<const MAX_ACCOUNTS: usize>(
@@ -67,6 +69,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_invoke_with_bounds.
 
 (*
 pub fn slice_invoke(instruction: &Instruction, account_infos: &[&AccountInfo]) -> ProgramResult {
@@ -88,6 +91,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_slice_invoke.
 
 (*
 pub fn invoke_signed<const ACCOUNTS: usize>(
@@ -114,6 +118,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_invoke_signed.
 
 (*
 pub fn invoke_signed_with_bounds<const MAX_ACCOUNTS: usize>(
@@ -140,6 +145,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_invoke_signed_with_bounds.
 
 (*
 pub fn slice_invoke_signed(
@@ -166,6 +172,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_slice_invoke_signed.
 
 (*
 unsafe fn inner_invoke_signed_with_bounds<const MAX_ACCOUNTS: usize>(
@@ -192,6 +199,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_inner_invoke_signed_with_bounds.
 
 (*
 pub unsafe fn invoke_unchecked(instruction: &Instruction, accounts: &[Account]) {
@@ -213,6 +221,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_invoke_unchecked.
 
 (*
 pub unsafe fn invoke_signed_unchecked(
@@ -241,6 +250,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_invoke_signed_unchecked.
 
 (* pub fn set_return_data(data: &[u8]) {
     #[cfg(target_os = "solana")]
@@ -265,6 +275,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_set_return_data.
 
 (*
 pub fn get_return_data() -> Option<ReturnData> {
@@ -279,6 +290,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_MAX_RETURN_DATA.
 
 (*
 pub struct ReturnData {
@@ -322,6 +334,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_get_return_data.
 
 (*
 impl ReturnData {
@@ -351,6 +364,7 @@ Module Impl_ReturnData.
     run_symbolic.
     admit.
   Admitted.
+  Global Opaque run_program_id.
 
   Instance run_as_slice
     (self : Ref.t Pointer.Kind.Ref Self) :
@@ -364,6 +378,7 @@ Module Impl_ReturnData.
     run_symbolic.
     admit.
   Admitted.
+  Global Opaque run_as_slice.
 End Impl_ReturnData.
 
 (* 
@@ -389,6 +404,7 @@ Module Impl_Deref_for_ReturnData.
     { constructor.
       admit. }
   Admitted.
+  Global Opaque run_deref.
 
   Instance run
     : Deref.Run ReturnData.t (list (Integer.t IntegerKind.U8)) :=

--- a/RocqOfRust/pinocchio/links/instruction.v
+++ b/RocqOfRust/pinocchio/links/instruction.v
@@ -149,6 +149,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_offset.
 
 Module Impl_AccountMeta.
   Definition Self : Set := AccountMeta.t.
@@ -167,6 +168,7 @@ Module Impl_AccountMeta.
     run_symbolic.
     admit.
   Admitted.
+  Global Opaque run_new.
 
   Instance run_readonly
     (pubkey : Ref.t Pointer.Kind.Ref Pubkey.t) :
@@ -180,6 +182,7 @@ Module Impl_AccountMeta.
     run_symbolic.
     admit.
   Admitted.
+  Global Opaque run_readonly.
 
   Instance run_writable
     (pubkey : Ref.t Pointer.Kind.Ref Pubkey.t) :
@@ -193,6 +196,7 @@ Module Impl_AccountMeta.
     run_symbolic.
     admit.
   Admitted.
+  Global Opaque run_writable.
 
   Instance run_readonly_signer
     (pubkey : Ref.t Pointer.Kind.Ref Pubkey.t) :
@@ -205,6 +209,7 @@ Module Impl_AccountMeta.
     constructor.
     admit.
   Admitted.
+  Global Opaque run_readonly_signer.
 
   Instance run_writable_signer
     (pubkey : Ref.t Pointer.Kind.Ref Pubkey.t) :
@@ -218,6 +223,7 @@ Module Impl_AccountMeta.
     run_symbolic.
     admit.
   Admitted.
+  Global Opaque run_writable_signer.
 End Impl_AccountMeta.
 
 Module Impl_From_ref_AccountInfo_for_Account.

--- a/RocqOfRust/pinocchio/links/lib.v
+++ b/RocqOfRust/pinocchio/links/lib.v
@@ -14,6 +14,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_SUCCESS.
 
 Instance run_MAX_TX_ACCOUNTS :
   Run.Trait
@@ -26,12 +27,14 @@ Proof.
     + admit.
     + admit.
 Admitted.
+Global Opaque run_MAX_TX_ACCOUNTS.
 
 Instance run_BPF_ALIGN_OF_U128 :
   Run.Trait
     value_BPF_ALIGN_OF_U128 [] [] []
     (Ref.t Pointer.Kind.Raw Usize.t).
 Proof. constructor. run_symbolic. Defined.
+Global Opaque run_BPF_ALIGN_OF_U128.
 
 Instance run_NON_DUP_MARKER :
   Run.Trait
@@ -42,6 +45,7 @@ Proof. constructor. run_symbolic.
     + admit.
     + admit.
 Admitted.
+Global Opaque run_NON_DUP_MARKER.
 
 Module ProgramResult.
     Definition t : Set :=

--- a/RocqOfRust/pinocchio/links/log.v
+++ b/RocqOfRust/pinocchio/links/log.v
@@ -16,6 +16,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_sol_log.
 
 Instance run_sol_log_64
   (arg1 arg2 arg3 arg4 arg5 : U64.t) :
@@ -28,6 +29,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_sol_log_64.
 
 Instance run_sol_log_data
   (data : Ref.t Pointer.Kind.Ref (list (list (Integer.t IntegerKind.U8)))) :
@@ -40,6 +42,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_sol_log_data.
 
 Instance run_sol_log_slice
   (slice : Ref.t Pointer.Kind.Ref (list (Integer.t IntegerKind.U8))) :
@@ -52,6 +55,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_sol_log_slice.
 
 Instance run_sol_log_params
   (accounts : Ref.t Pointer.Kind.Ref (list AccountInfo.t))
@@ -65,6 +69,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_sol_log_params.
 
 Instance run_sol_log_compute_units :
   Run.Trait
@@ -75,3 +80,4 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_sol_log_compute_units.

--- a/RocqOfRust/pinocchio/links/memory.v
+++ b/RocqOfRust/pinocchio/links/memory.v
@@ -16,6 +16,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_sol_memcpy.
 
 Instance run_copy_val
   (A : Set) `{Link A}
@@ -30,6 +31,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_copy_val.
 
 Instance run_sol_memmove
   (dst : Ref.t Pointer.Kind.Raw U8.t)
@@ -44,6 +46,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_sol_memmove.
 
 Instance run_sol_memcmp
   (s1 : Ref.t Pointer.Kind.Ref (list (Integer.t IntegerKind.U8)))
@@ -58,6 +61,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_sol_memcmp.
 
 Instance run_sol_memset
   (s : Ref.t Pointer.Kind.Ref (list (Integer.t IntegerKind.U8)))
@@ -72,3 +76,4 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_sol_memset.

--- a/RocqOfRust/pinocchio/links/pubkey.v
+++ b/RocqOfRust/pinocchio/links/pubkey.v
@@ -29,6 +29,7 @@ Instance run_log
     run_symbolic.
     admit.
   Admitted.
+  Global Opaque run_log.
 
 Instance run_find_program_address
   (seeds : Ref.t Pointer.Kind.Ref (list (Ref.t Pointer.Kind.Ref (list (Integer.t IntegerKind.U8)))))
@@ -37,24 +38,26 @@ Run.Trait
   find_program_address [] [] [φ seeds; φ pubkey]
   (Ref.t Pointer.Kind.Ref Pubkey.t * U8.t).
 Proof.
-    constructor.
-    run_symbolic.
-    admit.
+  constructor.
+  run_symbolic.
+  admit.
 Admitted.
+Global Opaque run_find_program_address.
 
-Instance try_find_program_address
+Instance run_try_find_program_address
   (seeds : Ref.t Pointer.Kind.Ref (list (Ref.t Pointer.Kind.Ref (list (Integer.t IntegerKind.U8)))))
   (program_id : Ref.t Pointer.Kind.Ref Pubkey.t) :
 Run.Trait
   try_find_program_address [] [] [φ seeds; φ program_id]
   (option (Ref.t Pointer.Kind.Ref Pubkey.t * U8.t)).
 Proof.
-    constructor.
-    run_symbolic.
-    admit.
+  constructor.
+  run_symbolic.
+  admit.
 Admitted.
+Global Opaque run_try_find_program_address.
 
-Instance create_program_address
+Instance run_create_program_address
   (seeds : Ref.t Pointer.Kind.Ref (list (Ref.t Pointer.Kind.Ref (list (Integer.t IntegerKind.U8)))))
   (program_id : Ref.t Pointer.Kind.Ref Pubkey.t) :
   Run.Trait
@@ -65,8 +68,9 @@ Proof.
   run_symbolic.
   admit.
 Admitted.
+Global Opaque run_create_program_address.
 
-Instance checked_create_program_address
+Instance run_checked_create_program_address
   (seeds : Ref.t Pointer.Kind.Ref (list (Ref.t Pointer.Kind.Ref (list (Integer.t IntegerKind.U8)))))
   (program_id : Ref.t Pointer.Kind.Ref Pubkey.t) :
   Run.Trait
@@ -77,5 +81,4 @@ Proof.
   run_symbolic.
   admit.
 Admitted.
-
-
+Global Opaque run_checked_create_program_address.

--- a/RocqOfRust/pinocchio/sysvars/links/clock.v
+++ b/RocqOfRust/pinocchio/sysvars/links/clock.v
@@ -15,6 +15,7 @@ Proof.
   constructor.
   admit.
 Admitted.
+Global Opaque run_CLOCK_ID.
 
 Instance run_DEFAULT_TICKS_PER_SLOT :
   Run.Trait
@@ -24,6 +25,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_DEFAULT_TICKS_PER_SLOT.
 
 Instance run_DEFAULT_TICKS_PER_SECOND :
   Run.Trait
@@ -33,6 +35,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_DEFAULT_TICKS_PER_SECOND.
 
 Instance run_DEFAULT_MS_PER_SLOT :
   Run.Trait
@@ -42,6 +45,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_DEFAULT_MS_PER_SLOT.
 
 Module Clock.
   Record t : Set := {
@@ -76,6 +80,7 @@ Module Impl_Clock.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_LEN.
 
   Instance run_from_account_info
     (account_info : Ref.t Pointer.Kind.Ref AccountInfo.t) :
@@ -88,6 +93,7 @@ Module Impl_Clock.
     constructor.
     admit.
   Admitted.
+  Global Opaque run_from_account_info.
 
   Instance run_from_account_info_unchecked
     (account_info : Ref.t Pointer.Kind.Ref AccountInfo.t) :
@@ -100,6 +106,7 @@ Module Impl_Clock.
     constructor.
     admit.
   Admitted.
+  Global Opaque run_from_account_info_unchecked.
 
   Instance run_from_bytes
     (bytes : Ref.t Pointer.Kind.Ref (list (Integer.t IntegerKind.U8))) :
@@ -112,6 +119,7 @@ Module Impl_Clock.
     constructor.
     admit.
   Admitted.
+  Global Opaque run_from_bytes.
 
   Instance run_from_bytes_unchecked
     (bytes : Ref.t Pointer.Kind.Ref (list (Integer.t IntegerKind.U8))) :
@@ -124,4 +132,5 @@ Module Impl_Clock.
     constructor.
     admit.
   Admitted.
+  Global Opaque run_from_bytes_unchecked.
 End Impl_Clock.

--- a/RocqOfRust/pinocchio/sysvars/links/fees.v
+++ b/RocqOfRust/pinocchio/sysvars/links/fees.v
@@ -14,6 +14,7 @@ Instance run_DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE :
 Proof.
   constructor. run_symbolic.
 Defined.
+Global Opaque run_DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE.
 
 Instance run_DEFAULT_TARGET_SIGNATURES_PER_SLOT :
   Run.Trait
@@ -24,6 +25,7 @@ Proof.
   run_symbolic.
   admit.
 Admitted.
+Global Opaque run_DEFAULT_TARGET_SIGNATURES_PER_SLOT.
 
 Instance run_DEFAULT_BURN_PERCENT :
   Run.Trait
@@ -32,6 +34,7 @@ Instance run_DEFAULT_BURN_PERCENT :
 Proof.
   constructor. run_symbolic.
 Defined.
+Global Opaque run_DEFAULT_BURN_PERCENT.
 
 Module FeeCalculator.
   Record t : Set := {
@@ -100,6 +103,7 @@ Module Impl_FeeCalculator.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_new.
 End Impl_FeeCalculator.
 
 Module Impl_FeeRateGovernor.
@@ -114,6 +118,7 @@ Module Impl_FeeRateGovernor.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_default.
 
   Instance run_create_fee_calculator
     (self : Ref.t Pointer.Kind.Ref Self) :
@@ -125,6 +130,7 @@ Module Impl_FeeRateGovernor.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_create_fee_calculator.
 
   Instance run_burn
     (self : Ref.t Pointer.Kind.Ref Self)
@@ -137,6 +143,7 @@ Module Impl_FeeRateGovernor.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_burn.
 End Impl_FeeRateGovernor.
 
 Module Impl_Fees.
@@ -153,6 +160,7 @@ Module Impl_Fees.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_new.
 End Impl_Fees.
 
 Module Impl_Default_for_FeeCalculator.

--- a/RocqOfRust/pinocchio/sysvars/links/instructions.v
+++ b/RocqOfRust/pinocchio/sysvars/links/instructions.v
@@ -79,6 +79,7 @@ Module instruction.
   Proof.
     constructor. run_symbolic.
   Defined.
+  Global Opaque run_IS_SIGNER.
 
   Instance run_IS_WRITABLE :
     Run.Trait
@@ -88,6 +89,7 @@ Module instruction.
   Proof.
     constructor. run_symbolic.
   Defined.
+  Global Opaque run_IS_WRITABLE.
 
   (*
     pub const INSTRUCTIONS_ID: Pubkey = [...]
@@ -100,6 +102,8 @@ Module instruction.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_INSTRUCTIONS_ID.
+
   (*
     impl<T> Instructions<T> { unsafe fn new_unchecked(data: T) -> Self { ... } ... }
     We expose methods on our monomorphized Instructions.t
@@ -118,7 +122,8 @@ Module instruction.
     Proof.
       constructor. admit. 
     Admitted.
-  
+    Global Opaque run_new_unchecked.
+
     Instance run_load_current_index
       {T : Set} `{Link T}
       (run_Deref_for_T : Deref.Run T (list (Integer.t IntegerKind.U8)))
@@ -130,7 +135,8 @@ Module instruction.
     Proof.
       constructor. run_symbolic. admit.
     Admitted.
-  
+    Global Opaque run_load_current_index.
+
     Instance run_deserialize_instruction_unchecked
       {T : Set} `{Link T}
       (run_Deref_for_T : Deref.Run T (list (Integer.t IntegerKind.U8)))
@@ -143,7 +149,8 @@ Module instruction.
     Proof.
       constructor. run_symbolic. admit.
     Admitted.
-  
+    Global Opaque run_deserialize_instruction_unchecked.
+
     Instance run_load_instruction_at
       {T : Set} `{Link T}
       (run_Deref_for_T : Deref.Run T (list (Integer.t IntegerKind.U8)))
@@ -156,7 +163,8 @@ Module instruction.
     Proof.
       constructor. run_symbolic. admit.
     Admitted.
-  
+    Global Opaque run_load_instruction_at.
+
     Instance run_get_instruction_relative
       {T : Set} `{Link T}
       (run_Deref_for_T : Deref.Run T (list (Integer.t IntegerKind.U8)))
@@ -169,11 +177,12 @@ Module instruction.
     Proof.
       constructor. run_symbolic. admit.
     Admitted.
+    Global Opaque run_get_instruction_relative.
   End Impl_Instructions.
-  
+
   Module Impl_IntrospectedInstruction.
     Definition Self : Set := IntrospectedInstruction.t.
-  
+
     Instance run_get_account_meta_at_unchecked
       (self : Ref.t Pointer.Kind.Ref Self)
       (index : Usize.t) :
@@ -184,7 +193,8 @@ Module instruction.
     Proof.
       constructor. run_symbolic. admit.
     Admitted.
-  
+    Global Opaque run_get_account_meta_at_unchecked.
+
     Instance run_get_account_meta_at
       (self : Ref.t Pointer.Kind.Ref Self)
       (index : Usize.t) :
@@ -195,7 +205,8 @@ Module instruction.
     Proof.
       constructor. run_symbolic. admit.
     Admitted.
-  
+    Global Opaque run_get_account_meta_at.
+
     Instance run_get_program_id
       (self : Ref.t Pointer.Kind.Ref Self) :
       Run.Trait
@@ -205,7 +216,8 @@ Module instruction.
     Proof.
       constructor. run_symbolic. admit.
     Admitted.
-  
+    Global Opaque run_get_program_id.
+
     Instance run_get_instruction_data
       (self : Ref.t Pointer.Kind.Ref Self) :
       Run.Trait
@@ -215,11 +227,12 @@ Module instruction.
     Proof.
       constructor. run_symbolic. admit.
     Admitted.
+    Global Opaque run_get_instruction_data.
   End Impl_IntrospectedInstruction.
-  
+
   Module Impl_IntrospectedAccountMeta.
     Definition Self : Set := IntrospectedAccountMeta.t.
-  
+
     Instance run_is_writable
       (self : Ref.t Pointer.Kind.Ref Self) :
       Run.Trait
@@ -229,7 +242,8 @@ Module instruction.
     Proof.
       constructor. run_symbolic. admit.
     Admitted.
-  
+    Global Opaque run_is_writable.
+
     Instance run_is_signer
       (self : Ref.t Pointer.Kind.Ref Self) :
       Run.Trait
@@ -239,7 +253,8 @@ Module instruction.
     Proof.
       constructor. run_symbolic. admit.
     Admitted.
-  
+    Global Opaque run_is_signer.
+
     Instance run_to_account_meta
       (self : Ref.t Pointer.Kind.Ref Self) :
       Run.Trait
@@ -249,6 +264,7 @@ Module instruction.
     Proof.
       constructor. run_symbolic. admit.
     Admitted.
+    Global Opaque run_to_account_meta.
   End Impl_IntrospectedAccountMeta.
-  
+
 End instruction.

--- a/RocqOfRust/pinocchio/sysvars/links/mod.v
+++ b/RocqOfRust/pinocchio/sysvars/links/mod.v
@@ -54,6 +54,7 @@ Proof.
   - admit.
   - admit.
 Admitted.
+Global Opaque run_get_sysvar_unchecked.
 
 (*
 pub fn get_sysvar(dst: &mut [u8], sysvar_id: &Pubkey, offset: usize)
@@ -76,5 +77,5 @@ Proof.
   - admit.
   - admit.
 Admitted.
-
+Global Opaque run_get_sysvar.
 End sysvars.

--- a/RocqOfRust/pinocchio/sysvars/links/rent.v
+++ b/RocqOfRust/pinocchio/sysvars/links/rent.v
@@ -20,6 +20,7 @@ Proof.
   - admit.
   - admit.
 Admitted.
+Global Opaque run_RENT_ID.
 
 Instance run_DEFAULT_LAMPORTS_PER_BYTE_YEAR :
   Run.Trait
@@ -28,6 +29,7 @@ Instance run_DEFAULT_LAMPORTS_PER_BYTE_YEAR :
 Proof.
   constructor. run_symbolic.
 Defined.
+Global Opaque run_DEFAULT_LAMPORTS_PER_BYTE_YEAR.
 
 Instance run_DEFAULT_EXEMPTION_THRESHOLD :
   Run.Trait
@@ -36,6 +38,7 @@ Instance run_DEFAULT_EXEMPTION_THRESHOLD :
 Proof.
   constructor. admit.
 Admitted.
+Global Opaque run_DEFAULT_EXEMPTION_THRESHOLD.
 
 Instance run_DEFAULT_EXEMPTION_THRESHOLD_AS_U64 :
   Run.Trait
@@ -44,6 +47,7 @@ Instance run_DEFAULT_EXEMPTION_THRESHOLD_AS_U64 :
 Proof.
   constructor. run_symbolic.
 Defined.
+Global Opaque run_DEFAULT_EXEMPTION_THRESHOLD_AS_U64.
 
 Instance run_F64_EXEMPTION_THRESHOLD_AS_U64 :
   Run.Trait
@@ -52,14 +56,16 @@ Instance run_F64_EXEMPTION_THRESHOLD_AS_U64 :
 Proof.
   constructor. run_symbolic.
 Defined.
+Global Opaque run_F64_EXEMPTION_THRESHOLD_AS_U64.
 
-Instance run_DEFAULT_BURN_PERCENT_rent :
+Instance run_DEFAULT_BURN_PERCENT :
   Run.Trait
     pinocchio.sysvars.rent.sysvars.rent.value_DEFAULT_BURN_PERCENT [] [] []
     (Ref.t Pointer.Kind.Raw U8.t).
 Proof.
   constructor. run_symbolic.
 Defined.
+Global Opaque run_DEFAULT_BURN_PERCENT.
 
 Instance run_ACCOUNT_STORAGE_OVERHEAD :
   Run.Trait
@@ -68,6 +74,7 @@ Instance run_ACCOUNT_STORAGE_OVERHEAD :
 Proof.
   constructor. run_symbolic.
 Defined.
+Global Opaque run_ACCOUNT_STORAGE_OVERHEAD.
 
 Module Rent.
   Record t : Set := {
@@ -120,6 +127,7 @@ Module Impl_Rent.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_from_account_info.
 
   Instance run_from_account_info_unchecked
     (account_info : Ref.t Pointer.Kind.Ref AccountInfo.t) :
@@ -131,6 +139,7 @@ Module Impl_Rent.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_from_account_info_unchecked.
 
   Instance run_from_bytes
     (bytes : Ref.t Pointer.Kind.Ref (list (Integer.t IntegerKind.U8))) :
@@ -142,6 +151,7 @@ Module Impl_Rent.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_from_bytes.
 
   Instance run_from_bytes_unchecked
     (bytes : Ref.t Pointer.Kind.Ref (list (Integer.t IntegerKind.U8))) :
@@ -153,6 +163,7 @@ Module Impl_Rent.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_from_bytes_unchecked.
 
   Instance run_calculate_burn
     (self : Ref.t Pointer.Kind.Ref Self)
@@ -165,6 +176,7 @@ Module Impl_Rent.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_calculate_burn.
 
   Instance run_due
     (self : Ref.t Pointer.Kind.Ref Self)
@@ -179,6 +191,7 @@ Module Impl_Rent.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_due.
 
   Instance run_due_amount
     (self : Ref.t Pointer.Kind.Ref Self)
@@ -192,6 +205,7 @@ Module Impl_Rent.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_due_amount.
 
   Instance run_minimum_balance
     (self : Ref.t Pointer.Kind.Ref Self)
@@ -204,6 +218,7 @@ Module Impl_Rent.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_minimum_balance.
 
   Instance run_is_exempt
     (self : Ref.t Pointer.Kind.Ref Self)
@@ -217,6 +232,7 @@ Module Impl_Rent.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_is_exempt.
 
   Instance run_is_default_rent_threshold
     (self : Ref.t Pointer.Kind.Ref Self) :
@@ -228,6 +244,7 @@ Module Impl_Rent.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_is_default_rent_threshold.
 End Impl_Rent.
 
 Module Impl_RentDue.
@@ -243,6 +260,7 @@ Module Impl_RentDue.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_lamports.
 
   Instance run_is_exempt
     (self : Ref.t Pointer.Kind.Ref Self) :
@@ -254,6 +272,7 @@ Module Impl_RentDue.
   Proof.
     constructor. admit.
   Admitted.
+  Global Opaque run_is_exempt.
 End Impl_RentDue.
 
 Module Impl_Default_for_Rent.

--- a/RocqOfRust/revm/revm_bytecode/eof/links/body.v
+++ b/RocqOfRust/revm/revm_bytecode/eof/links/body.v
@@ -78,6 +78,7 @@ Module Impl_EofBody.
     destruct (vec.links.mod.Impl_Deref_for_Vec.run (T := Usize.t) (A := Global.t)).
     run_symbolic.
   Admitted.
+  Global Opaque run_code.
 
   (*
     pub fn encode(&self, buffer: &mut Vec<u8>)
@@ -88,6 +89,7 @@ Module Impl_EofBody.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_encode.
 
   (*
     pub fn into_eof(self) -> Eof
@@ -98,6 +100,7 @@ Module Impl_EofBody.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_into_eof.
 
   (*
     pub fn eof_code_section_start(&self, idx: usize) -> Option<usize> 
@@ -110,6 +113,7 @@ Module Impl_EofBody.
     destruct deref.
     run_symbolic.
   Admitted.
+  Global Opaque run_eof_code_section_start.
 
   (*
     pub fn decode(input: &Bytes, header: &EofHeader) -> Result<Self, EofDecodeError>
@@ -120,4 +124,5 @@ Module Impl_EofBody.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_decode.
 End Impl_EofBody.

--- a/RocqOfRust/revm/revm_bytecode/eof/links/header.v
+++ b/RocqOfRust/revm/revm_bytecode/eof/links/header.v
@@ -182,12 +182,14 @@ Module Impl_EofHeader.
   Instance run_size (self : Ref.t Pointer.Kind.Ref Self) : 
     Run.Trait header.eof.header.Impl_revm_bytecode_eof_header_EofHeader.size [] [] [φ self] Usize.t.
   Admitted.
+  Global Opaque run_size.
 
   (* pub fn eof_size(&self) -> usize *)
   Instance run_eof_size (self : Ref.t Pointer.Kind.Ref Self) :
     Run.Trait header.eof.header.Impl_revm_bytecode_eof_header_EofHeader.eof_size [] [] [φ self]
       Usize.t.
   Admitted.
+  Global Opaque run_eof_size.
 
   (*
     pub fn encode(&self, buffer: &mut Vec<u8>)
@@ -195,11 +197,13 @@ Module Impl_EofHeader.
   Instance run_encode (self : Ref.t Pointer.Kind.Ref Self) (buffer : Ref.t Pointer.Kind.MutPointer (Vec.t U8.t Global.t)) :
     Run.Trait header.eof.header.Impl_revm_bytecode_eof_header_EofHeader.encode [] [] [φ self; φ buffer] unit.
   Admitted.
+  Global Opaque run_encode.
 
   (* pub fn decode(input: &[u8]) -> Result<(Self, &[u8]), EofDecodeError> *)
   Instance run_decode (input : Ref.t Pointer.Kind.Ref (list U8.t)) :
     Run.Trait header.eof.header.Impl_revm_bytecode_eof_header_EofHeader.decode [] [] [φ input]
       (Result.t Self (Ref.t Pointer.Kind.Ref (list U8.t))).
   Admitted.
+  Global Opaque run_decode.
 End Impl_EofHeader.
 Export Impl_EofHeader.

--- a/RocqOfRust/revm/revm_bytecode/links/eof.v
+++ b/RocqOfRust/revm/revm_bytecode/links/eof.v
@@ -166,5 +166,6 @@ Module Impl_Eof.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_decode.
 End Impl_Eof.
 Export Impl_Eof.

--- a/RocqOfRust/revm/revm_bytecode/links/opcode.v
+++ b/RocqOfRust/revm/revm_bytecode/links/opcode.v
@@ -55,6 +55,7 @@ Module Impl_OpCode.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_STOP.
 
   Instance run_ADD :
     Run.Trait
@@ -64,6 +65,7 @@ Module Impl_OpCode.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_ADD.
 
   Instance run_BALANCE :
     Run.Trait
@@ -73,6 +75,7 @@ Module Impl_OpCode.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_BALANCE.
 End Impl_OpCode.
 
 Instance run_STOP :
@@ -83,6 +86,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_STOP.
 
 Instance run_ADD :
   Run.Trait
@@ -92,6 +96,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_ADD.
 
 Instance run_BALANCE :
   Run.Trait
@@ -101,3 +106,4 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_BALANCE.

--- a/RocqOfRust/revm/revm_context_interface/links/journaled_state.v
+++ b/RocqOfRust/revm/revm_context_interface/links/journaled_state.v
@@ -183,6 +183,7 @@ Module Impl_Eip7702CodeLoad.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_into_components.
 End Impl_Eip7702CodeLoad.
 Export Impl_Eip7702CodeLoad.
 

--- a/RocqOfRust/revm/revm_interpreter/gas/links/calc.v
+++ b/RocqOfRust/revm/revm_interpreter/gas/links/calc.v
@@ -19,6 +19,7 @@ Instance run_sstore_refund
 Proof.
   constructor.
 Admitted.
+Global Opaque run_sstore_refund.
 
 (* pub const fn create2_cost(len: usize) -> Option<u64> *)
 Instance run_create2_cost (len : Usize.t) :
@@ -29,6 +30,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_create2_cost.
 
 (* pub const fn log2floor(value: U256) -> u64 *)
 Instance run_log2floor (value : aliases.U256.t) :
@@ -39,6 +41,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_log2floor.
 
 (* pub fn exp_cost(spec_id: SpecId, power: U256) -> Option<u64> *)
 Instance run_exp_cost (spec_id : SpecId.t) (power : aliases.U256.t) :
@@ -49,6 +52,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_exp_cost.
 
 (* pub const fn copy_cost_verylow(len: usize) -> Option<u64> *)
 Instance run_copy_cost_verylow (len : Usize.t) :
@@ -59,6 +63,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_copy_cost_verylow.
 
 (* pub const fn extcodecopy_cost(
     spec_id: SpecId,
@@ -76,6 +81,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_extcodecopy_cost.
 
 (* pub const fn copy_cost(base_cost: u64, len: usize) -> Option<u64> *)
 Instance run_copy_cost (base_cost : U64.t) (len : Usize.t) :
@@ -86,6 +92,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_copy_cost.
 
 (* pub const fn log_cost(n: u8, len: u64) -> Option<u64> *)
 Instance run_log_cost (n : U8.t) (len : U64.t) :
@@ -96,6 +103,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_log_cost.
 
 (* pub const fn keccak256_cost(len: usize) -> Option<u64> *)
 Instance run_keccak256_cost (len : Usize.t) :
@@ -106,6 +114,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_keccak256_cost.
 
 (* pub const fn cost_per_word(len: usize, multiple: u64) -> Option<u64> *)
 Instance run_cost_per_word (len : Usize.t) (multiple : U64.t) :
@@ -116,6 +125,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_cost_per_word.
 
 (* pub const fn initcode_cost(len: usize) -> u64 *)
 Instance run_initcode_cost (len : Usize.t) :
@@ -126,6 +136,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_initcode_cost.
 
 (* pub const fn sload_cost(spec_id: SpecId, is_cold: bool) -> u64 *)
 Instance run_sload_cost (spec_id : SpecId.t) (is_cold : bool) :
@@ -136,6 +147,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_sload_cost.
 
 (* pub fn sstore_cost(spec_id: SpecId, vals: &SStoreResult, is_cold: bool) -> u64 *)
 Instance run_sstore_cost
@@ -149,6 +161,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_sstore_cost.
 
 (* pub const fn istanbul_sstore_cost<const SLOAD_GAS: u64, const SSTORE_RESET_GAS: u64>(
     vals: &SStoreResult,
@@ -161,6 +174,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_istanbul_sstore_cost.
 
 (* pub const fn frontier_sstore_cost(vals: &SStoreResult) -> u64 *)
 Instance run_frontier_sstore_cost (vals : Ref.t Pointer.Kind.Ref SStoreResult.t) :
@@ -171,6 +185,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_frontier_sstore_cost.
 
 (* pub const fn selfdestruct_cost(spec_id: SpecId, res: StateLoad<SelfDestructResult>) -> u64 *)
 Instance run_selfdestruct_cost
@@ -183,6 +198,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_selfdestruct_cost.
 
 (* pub const fn call_cost(spec_id: SpecId, transfers_value: bool, account_load: AccountLoad) -> u64 *)
 Instance run_call_cost
@@ -196,6 +212,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_call_cost.
 
 (* pub const fn warm_cold_cost(is_cold: bool) -> u64 *)
 Instance run_warm_cold_cost (is_cold : bool) :
@@ -206,6 +223,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_warm_cold_cost.
 
 (* pub const fn warm_cold_cost_with_delegation(load: Eip7702CodeLoad<()>) -> u64 *)
 Instance run_warm_cold_cost_with_delegation (load : Eip7702CodeLoad.t unit) :
@@ -216,6 +234,7 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_warm_cold_cost_with_delegation.
 
 (* pub const fn memory_gas(num_words: usize) -> u64 *)
 Instance run_memory_gas (num_words : Usize.t) :
@@ -226,6 +245,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_memory_gas.
 
 (* pub fn validate_initial_tx_gas<AccessListT: AccessListTrait>(
     spec_id: SpecId,
@@ -248,3 +268,4 @@ Instance run_validate_initial_tx_gas
 Proof.
   constructor.
 Admitted.
+Global Opaque run_validate_initial_tx_gas.

--- a/RocqOfRust/revm/revm_interpreter/gas/links/constants.v
+++ b/RocqOfRust/revm/revm_interpreter/gas/links/constants.v
@@ -11,6 +11,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_ZERO.
 
 Instance run_BASE :
   Run.Trait
@@ -20,6 +21,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_BASE.
 
 Instance run_VERYLOW :
   Run.Trait
@@ -39,6 +41,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_DATA_LOADN_GAS.
 
 Instance run_CONDITION_JUMP_GAS :
   Run.Trait
@@ -48,6 +51,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_CONDITION_JUMP_GAS.
 
 Instance run_RETF_GAS :
   Run.Trait
@@ -57,6 +61,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_RETF_GAS.
 
 Instance run_DATA_LOAD_GAS :
   Run.Trait
@@ -66,6 +71,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_DATA_LOAD_GAS.
 
 Instance run_LOW :
   Run.Trait
@@ -75,6 +81,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_LOW.
 
 Instance run_MID :
   Run.Trait
@@ -84,6 +91,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_MID.
 
 Instance run_HIGH :
   Run.Trait
@@ -93,6 +101,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_HIGH.
 
 Instance run_JUMPDEST :
   Run.Trait
@@ -102,6 +111,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_JUMPDEST.
 
 Instance run_SELFDESTRUCT :
   Run.Trait
@@ -111,6 +121,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_SELFDESTRUCT.
 
 Instance run_CREATE :
   Run.Trait
@@ -120,6 +131,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_CREATE.
 
 Instance run_CALLVALUE :
   Run.Trait
@@ -129,6 +141,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_CALLVALUE.
 
 Instance run_NEWACCOUNT :
   Run.Trait
@@ -138,6 +151,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_NEWACCOUNT.
 
 Instance run_EXP :
   Run.Trait
@@ -147,6 +161,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_EXP.
 
 Instance run_MEMORY :
   Run.Trait
@@ -156,6 +171,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_MEMORY.
 
 Instance run_LOG :
   Run.Trait
@@ -165,6 +181,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_LOG.
 
 Instance run_LOGDATA :
   Run.Trait
@@ -174,6 +191,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_LOGDATA.
 
 Instance run_LOGTOPIC :
   Run.Trait
@@ -183,6 +201,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_LOGTOPIC.
 
 Instance run_KECCAK256 :
   Run.Trait
@@ -192,6 +211,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_KECCAK256.
 
 Instance run_KECCAK256WORD :
   Run.Trait
@@ -201,6 +221,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_KECCAK256WORD.
 
 Instance run_COPY :
   Run.Trait
@@ -210,6 +231,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_COPY.
 
 Instance run_BLOCKHASH :
   Run.Trait
@@ -219,6 +241,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_BLOCKHASH.
 
 Instance run_CODEDEPOSIT :
   Run.Trait
@@ -228,6 +251,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_CODEDEPOSIT.
 
 Instance run_ISTANBUL_SLOAD_GAS :
   Run.Trait
@@ -237,6 +261,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_ISTANBUL_SLOAD_GAS.
 
 Instance run_SSTORE_SET :
   Run.Trait
@@ -246,6 +271,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_SSTORE_SET.
 
 Instance run_SSTORE_RESET :
   Run.Trait
@@ -255,6 +281,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_SSTORE_RESET.
 
 Instance run_REFUND_SSTORE_CLEARS :
   Run.Trait
@@ -264,6 +291,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_REFUND_SSTORE_CLEARS.
 
 Instance run_TRANSACTION_ZERO_DATA :
   Run.Trait
@@ -273,6 +301,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_TRANSACTION_ZERO_DATA.
 
 Instance run_TRANSACTION_NON_ZERO_DATA_INIT :
   Run.Trait
@@ -282,6 +311,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_TRANSACTION_NON_ZERO_DATA_INIT.
 
 Instance run_TRANSACTION_NON_ZERO_DATA_FRONTIER :
   Run.Trait
@@ -291,6 +321,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_TRANSACTION_NON_ZERO_DATA_FRONTIER.
 
 Instance run_EOF_CREATE_GAS :
   Run.Trait
@@ -300,6 +331,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_EOF_CREATE_GAS.
 
 Instance run_ACCESS_LIST_ADDRESS :
   Run.Trait
@@ -309,6 +341,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_ACCESS_LIST_ADDRESS.
 
 Instance run_ACCESS_LIST_STORAGE_KEY :
   Run.Trait
@@ -318,6 +351,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_ACCESS_LIST_STORAGE_KEY.
 
 Instance run_COLD_SLOAD_COST :
   Run.Trait
@@ -327,6 +361,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_COLD_SLOAD_COST.
 
 Instance run_COLD_ACCOUNT_ACCESS_COST :
   Run.Trait
@@ -336,6 +371,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_COLD_ACCOUNT_ACCESS_COST.
 
 Instance run_WARM_STORAGE_READ_COST :
   Run.Trait
@@ -345,6 +381,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_WARM_STORAGE_READ_COST.
 
 Instance run_WARM_SSTORE_RESET :
   Run.Trait
@@ -354,6 +391,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_WARM_SSTORE_RESET.
 
 Instance run_INITCODE_WORD_COST :
   Run.Trait
@@ -363,6 +401,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_INITCODE_WORD_COST.
 
 Instance run_CALL_STIPEND :
   Run.Trait
@@ -372,6 +411,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_CALL_STIPEND.
 
 Instance run_MIN_CALLEE_GAS :
   Run.Trait
@@ -381,3 +421,4 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_MIN_CALLEE_GAS.

--- a/RocqOfRust/revm/revm_interpreter/instructions/contract/links/call_helpers.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/contract/links/call_helpers.v
@@ -26,6 +26,7 @@ Instance run_get_memory_input_and_out_ranges
 Proof.
   constructor.
 Admitted.
+Global Opaque run_get_memory_input_and_out_ranges.
 
 (*
 pub fn resize_memory(
@@ -47,6 +48,7 @@ Instance run_resize_memory
 Proof.
   constructor.
 Admitted.
+Global Opaque run_resize_memory.
 
 (*
 pub fn calc_call_gas(
@@ -71,3 +73,4 @@ Instance run_calc_call_gas
 Proof.
   constructor.
 Admitted.
+Global Opaque run_calc_call_gas.

--- a/RocqOfRust/revm/revm_interpreter/instructions/contract/simulate/call_helpers.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/contract/simulate/call_helpers.v
@@ -36,7 +36,6 @@ Lemma get_memory_input_and_out_ranges_eq
   }}.
 Proof.
 Admitted.
-Global Opaque run_get_memory_input_and_out_ranges.
 
 Parameter calc_call_gas :
   forall
@@ -76,4 +75,3 @@ Lemma calc_call_gas_eq
   }}.
 Proof.
 Admitted.
-Global Opaque run_calc_call_gas.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
@@ -42,6 +42,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   run_symbolic.
 Defined.
+Global Opaque run_add.
 
 (*
 pub fn mul<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -69,6 +70,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   run_symbolic.
 Defined.
+Global Opaque run_mul.
 
 (*
 pub fn sub<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -92,6 +94,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   run_symbolic.
 Defined.
+Global Opaque run_sub.
 
 (*
 pub fn div<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -115,6 +118,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   run_symbolic.
 Defined.
+Global Opaque run_div.
 
 (*
 pub fn sdiv<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -138,6 +142,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   run_symbolic.
 Defined.
+Global Opaque run_sdiv.
 
 (*
 pub fn rem<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -161,6 +166,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   run_symbolic.
 Defined.
+Global Opaque run_rem.
 
 (*
 pub fn smod<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -184,6 +190,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   run_symbolic.
 Defined.
+Global Opaque run_smod.
 
 (*
 pub fn addmod<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -207,6 +214,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   run_symbolic.
 Defined.
+Global Opaque run_addmod.
 
 (*
 pub fn mulmod<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -230,6 +238,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   run_symbolic.
 Defined.
+Global Opaque run_mulmod.
 
 (*
 pub fn exp<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -254,6 +263,7 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   run_symbolic.
 Defined.
+Global Opaque run_exp.
 
 (*
 pub fn signextend<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -283,3 +293,4 @@ Proof.
   destruct (Impl_Not_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_signextend.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise.v
@@ -40,6 +40,7 @@ Proof.
   destruct (Impl_PartialOrd_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_lt.
 
 Instance run_gt
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -58,6 +59,7 @@ Proof.
   destruct (Impl_PartialOrd_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_gt.
 
 Instance run_slt
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -76,6 +78,7 @@ Proof.
   destruct Impl_PartialEq_for_Ordering.run.
   run_symbolic.
 Defined.
+Global Opaque run_slt.
 
 Instance run_sgt
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -94,6 +97,7 @@ Proof.
   destruct Impl_PartialEq_for_Ordering.run.
   run_symbolic.
 Defined.
+Global Opaque run_sgt.
 
 Instance run_bitwise_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -112,6 +116,7 @@ Proof.
   destruct (Impl_PartialEq_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_bitwise_eq.
 
 Instance run_bitwise_is_zero
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -129,6 +134,7 @@ Proof.
   destruct run_LoopControl_for_Control.
   run_symbolic.
 Defined.
+Global Opaque run_bitwise_is_zero.
 
 Instance run_bitwise_bitand
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -147,6 +153,7 @@ Proof.
   destruct (Impl_BitAnd_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_bitwise_bitand.
 
 Instance run_bitwise_bitor
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -165,6 +172,7 @@ Proof.
   destruct (Impl_BitOr_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_bitwise_bitor.
 
 Instance run_bitwise_bitxor
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -183,6 +191,7 @@ Proof.
   destruct (Impl_BitXor_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_bitwise_bitxor.
 
 Instance run_bitwise_not
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -201,6 +210,7 @@ Proof.
   destruct (Impl_Not_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_bitwise_not.
 
 Instance run_bitwise_sar
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -220,6 +230,7 @@ Proof.
   destruct Impl_TryFrom_u64_for_usize.run.
   run_symbolic.
 Defined.
+Global Opaque run_bitwise_sar.
 
 Instance run_bitwise_shl
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -240,6 +251,7 @@ Proof.
   destruct (Impl_Shl_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_bitwise_shl.
 
 Instance run_bitwise_shr
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -260,3 +272,4 @@ Proof.
   destruct (Impl_Shr_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_bitwise_shr.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
@@ -49,6 +49,7 @@ Proof.
   destruct run_Cfg_for_Cfg.
   run_symbolic.
 Defined.
+Global Opaque run_chainid.
 
 (*
 pub fn coinbase<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -79,6 +80,7 @@ Proof.
   destruct (Impl_Into_for_From_T.run Impl_From_FixedBytes_32_for_U256.run).
   run_symbolic.
 Defined.
+Global Opaque run_coinbase.
 
 (*
 pub fn timestamp<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -110,6 +112,7 @@ Proof.
   destruct run_Block_for_Block.
   run_symbolic.
 Defined.
+Global Opaque run_timestamp.
 
 (*
 pub fn block_number<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -141,6 +144,7 @@ Proof.
   destruct run_Block_for_Block.
   run_symbolic.
 Defined.
+Global Opaque run_block_number.
 
 (*
 pub fn difficulty<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -172,6 +176,7 @@ Proof.
   destruct Impl_IntoU256_for_B256.run.
   run_symbolic.
 Defined.
+Global Opaque run_difficulty.
 
 (*
 pub fn gaslimit<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -200,6 +205,7 @@ Proof.
   destruct run_Block_for_Block.
   run_symbolic.
 Defined.
+Global Opaque run_gaslimit.
 
 (*
 pub fn basefee<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -229,6 +235,7 @@ Proof.
   destruct run_Block_for_Block.
   run_symbolic.
 Defined.
+Global Opaque run_basefee.
 
 (*
 pub fn blob_basefee<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -258,3 +265,4 @@ Proof.
   destruct run_Block_for_Block.
   run_symbolic.
 Defined.
+Global Opaque run_blob_basefee.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/call.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/call.v
@@ -67,3 +67,4 @@ Proof.
   destruct Impl_IntoAddress_for_U256.run.
   run_symbolic.
 Defined.
+Global Opaque run_call.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/call_code.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/call_code.v
@@ -68,3 +68,4 @@ Proof.
   destruct (TryFrom_Uint_for_u64.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_call_code.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/create.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/create.v
@@ -71,3 +71,4 @@ Proof.
   destruct run_Deref_for_Synthetic1.
   run_symbolic.
 Defined.
+Global Opaque run_create.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/delegate_call.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/delegate_call.v
@@ -67,3 +67,4 @@ Proof.
   destruct (TryFrom_Uint_for_u64.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_delegate_call.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/eofcreate.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/eofcreate.v
@@ -71,3 +71,4 @@ Proof.
   destruct run_Deref_for_Synthetic.
   run_symbolic.
 Defined.
+Global Opaque run_eofcreate.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/extcall.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/extcall.v
@@ -67,3 +67,4 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   run_symbolic.
 Defined.
+Global Opaque run_extcall.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/extcall_gas_calc.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/extcall_gas_calc.v
@@ -71,3 +71,4 @@ Proof.
   destruct links.mod.Impl_DerefMut_for_Bytes.run.
   run_symbolic.
 Defined.
+Global Opaque run_extcall_gas_calc.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/extcall_input.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/extcall_input.v
@@ -64,3 +64,4 @@ Proof.
   destruct (Impl_Clone_for_Range.run Usize.t).
   run_symbolic.
 Defined.
+Global Opaque run_extcall_input.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/extdelegatecall.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/extdelegatecall.v
@@ -66,3 +66,4 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   run_symbolic.
 Defined.
+Global Opaque run_extdelegatecall.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/extstaticcall.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/extstaticcall.v
@@ -66,3 +66,4 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   run_symbolic.
 Defined.
+Global Opaque run_extstaticcall.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/pop_extcall_target_address.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/pop_extcall_target_address.v
@@ -79,3 +79,4 @@ Proof.
   epose proof (run_any' := run_any _ _ _ (Function1.of_run run_any_callback) _ _ _).
   typeclasses eauto.
 Defined.
+Global Opaque run_pop_extcall_target_address.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/return_contract.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/return_contract.v
@@ -70,3 +70,4 @@ Proof.
   destruct run_Deref_for_Synthetic1.
   Time run_symbolic.
 Admitted.
+Global Opaque run_return_contract.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/static_call.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/static_call.v
@@ -67,3 +67,4 @@ Proof.
   destruct (TryFrom_Uint_for_u64.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_static_call.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control.v
@@ -46,6 +46,7 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   run_symbolic.
 Defined.
+Global Opaque run_rjump.
 
 (*
 pub fn rjumpi<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -72,6 +73,7 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   run_symbolic.
 Defined.
+Global Opaque run_rjumpi.
 
 (*
 pub fn rjumpv<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -99,6 +101,7 @@ Proof.
   destruct Impl_TryFrom_u64_for_isize.run.
   run_symbolic.
 Defined.
+Global Opaque run_rjumpv.
 
 (* fn jump_inner<WIRE: InterpreterTypes>(interpreter: &mut Interpreter<WIRE>, target: U256) *)
 Instance run_jump_inner
@@ -117,6 +120,7 @@ Proof.
   destruct run_Jumps_for_Bytecode.
   run_symbolic.
 Defined.
+Global Opaque run_jump_inner.
 
 (*
 pub fn jump<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -140,6 +144,7 @@ Proof.
   destruct run_LoopControl_for_Control.
   run_symbolic.
 Defined.
+Global Opaque run_jump.
 
 (*
 pub fn jumpi<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -163,6 +168,7 @@ Proof.
   destruct run_LoopControl_for_Control.
   run_symbolic.
 Defined.
+Global Opaque run_jumpi.
 
 (*
 pub fn jumpdest_or_nop<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -185,6 +191,7 @@ Proof.
   destruct run_LoopControl_for_Control.
   run_symbolic.
 Defined.
+Global Opaque run_jumpdest_or_nop.
 
 (*
 pub fn callf<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -214,6 +221,7 @@ Proof.
   run_symbolic.
   destruct_all Empty_set.
 Defined.
+Global Opaque run_callf.
 
 (*
 pub fn retf<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -240,6 +248,7 @@ Proof.
   run_symbolic.
   destruct_all Empty_set.
 Defined.
+Global Opaque run_retf.
 
 (*
 pub fn jumpf<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -268,6 +277,7 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   run_symbolic.
 Defined.
+Global Opaque run_jumpf.
 
 (*
 pub fn pc<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -292,6 +302,7 @@ Proof.
   destruct run_Jumps_for_Bytecode.
   run_symbolic.
 Defined.
+Global Opaque run_pc.
 
 (*
 fn return_inner(
@@ -319,6 +330,7 @@ Proof.
   destruct (Impl_Into_for_From_T.run Impl_From_Vec_u8_for_Bytes.run).
   run_symbolic.
 Defined.
+Global Opaque run_return_inner.
 
 (*
 pub fn ret<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -339,6 +351,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_ret.
 
 (*
 pub fn revert<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -362,6 +375,7 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   run_symbolic.
 Defined.
+Global Opaque run_revert.
 
 (*
 pub fn stop<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -384,6 +398,7 @@ Proof.
   destruct run_LoopControl_for_Control.
   run_symbolic.
 Defined.
+Global Opaque run_stop.
 
 (*
 pub fn invalid<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -406,6 +421,7 @@ Proof.
   destruct run_LoopControl_for_Control.
   run_symbolic.
 Defined.
+Global Opaque run_invalid.
 
 (*
 pub fn unknown<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -433,3 +449,4 @@ Proof.
   destruct run_LoopControl_for_Control.
   run_symbolic.
 Defined.
+Global Opaque run_unknown.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/data.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/data.v
@@ -60,6 +60,7 @@ Proof.
   }
   run_symbolic.
 Defined.
+Global Opaque run_data_load.
 
 (*
 pub fn data_loadn<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -101,6 +102,7 @@ Proof.
   }
   run_symbolic.
 Defined.
+Global Opaque run_data_loadn.
 
 (*
 pub fn data_size<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -126,6 +128,7 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   run_symbolic.
 Defined.
+Global Opaque run_data_size.
 
 (*
 pub fn data_copy<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -153,3 +156,4 @@ Proof.
   destruct Impl_TryFrom_u64_for_usize.run.
   run_symbolic.
 Defined.
+Global Opaque run_data_copy.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/host.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/host.v
@@ -55,6 +55,7 @@ Proof.
   destruct Impl_IntoAddress_for_U256.run.
   run_symbolic.
 Defined.
+Global Opaque run_balance.
 
 (*
 pub fn selfbalance<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -83,6 +84,7 @@ Proof.
   destruct run_InputsTrait_for_Input.
   run_symbolic.
 Defined.
+Global Opaque run_selfbalance.
 
 (*
 pub fn extcodesize<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -112,6 +114,7 @@ Proof.
   destruct alloy_primitives.bytes.links.mod.Impl_Deref_for_Bytes.run.
   run_symbolic.
 Defined.
+Global Opaque run_extcodesize.
 
 (*
 pub fn extcodehash<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -141,6 +144,7 @@ Proof.
   destruct Impl_IntoAddress_for_U256.run.
   run_symbolic.
 Defined.
+Global Opaque run_extcodehash.
 
 (*
 pub fn extcodecopy<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -173,6 +177,7 @@ Proof.
   destruct links.mod.Impl_Deref_for_Bytes.run.
   run_symbolic.
 Defined.
+Global Opaque run_extcodecopy.
 
 (*
 pub fn blockhash<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -200,6 +205,7 @@ Proof.
   destruct run_LoopControl_for_Control.
   run_symbolic.
 Defined.
+Global Opaque run_blockhash.
 
 (*
 pub fn sload<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -228,6 +234,7 @@ Proof.
   destruct run_Host_for_H.
   run_symbolic.
 Defined.
+Global Opaque run_sload.
 
 (*
 pub fn sstore<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -256,6 +263,7 @@ Proof.
   destruct run_Host_for_H.
   run_symbolic.
 Defined.
+Global Opaque run_sstore.
 
 (*
 pub fn tstore<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -284,6 +292,7 @@ Proof.
   destruct run_Host_for_H.
   run_symbolic.
 Defined.
+Global Opaque run_tstore.
 
 (*
 pub fn tload<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -312,6 +321,7 @@ Proof.
   destruct run_Host_for_H.
   run_symbolic.
 Defined.
+Global Opaque run_tload.
 
 (*
 pub fn log<const N: usize, H: Host + ?Sized>(
@@ -362,6 +372,7 @@ Proof.
   change (Value.Closure _) with (φ (Function1.of_run run_from)).
   typeclasses eauto.
 Defined.
+Global Opaque run_log.
 
 (*
 pub fn selfdestruct<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -392,3 +403,4 @@ Proof.
   destruct (Impl_Deref_for_StateLoad.run SelfDestructResult.t).
   run_symbolic.
 Defined.
+Global Opaque run_selfdestruct.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/i256.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/i256.v
@@ -98,6 +98,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_MAX_POSITIVE_VALUE.
 
 (* pub const MIN_NEGATIVE_VALUE: U256 *)
 Instance run_MIN_NEGATIVE_VALUE :
@@ -107,6 +108,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_MIN_NEGATIVE_VALUE.
 
 (* const FLIPH_BITMASK_U64: u64 *)
 Instance run_FLIPH_BITMASK_U64 :
@@ -115,6 +117,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_FLIPH_BITMASK_U64.
 
 (* pub fn i256_sign(val: &U256) -> Sign *)
 Instance run_i256_sign (val : Ref.t Pointer.Kind.Ref aliases.U256.t) :
@@ -123,6 +126,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_i256_sign.
 
 (* pub fn two_compl(op: U256) -> U256 *)
 Instance run_two_compl (op : aliases.U256.t) :
@@ -131,6 +135,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_two_compl.
 
 (* pub fn two_compl_mut(op: &mut U256) *)
 Instance run_two_compl_mut (op : Ref.t Pointer.Kind.MutRef aliases.U256.t) :
@@ -139,6 +144,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_two_compl_mut.
 
 (* pub fn i256_sign_compl(val: &mut U256) -> Sign *)
 Instance run_i256_sign_compl (val : Ref.t Pointer.Kind.MutRef aliases.U256.t) :
@@ -148,6 +154,7 @@ Proof.
   destruct Impl_PartialEq_for_Sign.run.
   run_symbolic.
 Defined.
+Global Opaque run_i256_sign_compl.
 
 (* pub fn u256_remove_sign(val: &mut U256) *)
 Instance run_u256_remove_sign (val : Ref.t Pointer.Kind.MutRef aliases.U256.t) :
@@ -156,6 +163,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_u256_remove_sign.
 
 (* pub fn i256_cmp(first: &U256, second: &U256) -> Ordering *)
 Instance run_i256_cmp (first second : Ref.t Pointer.Kind.Ref aliases.U256.t) :
@@ -166,6 +174,7 @@ Proof.
   destruct (Impl_Ord_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_i256_cmp.
 
 (* pub fn i256_div(mut first: U256, mut second: U256) -> U256 *)
 Instance run_i256_div (first second : aliases.U256.t) :
@@ -177,6 +186,7 @@ Proof.
   destruct (Impl_Div_for_Uint_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_i256_div.
 
 (* pub fn i256_mod(mut first: U256, mut second: U256) -> U256 *)
 Instance run_i256_mod (first second : aliases.U256.t) :
@@ -187,3 +197,4 @@ Proof.
   destruct (Impl_Rem_for_Uint_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
 Defined.
+Global Opaque run_i256_mod.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/memory.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/memory.v
@@ -42,6 +42,7 @@ Proof.
   destruct (Impl_AsRef_for_Slice.run U8.t).
   run_symbolic.
 Defined.
+Global Opaque run_mload.
 
 (* pub fn mstore<WIRE: InterpreterTypes, H: Host + ?Sized>(
     interpreter: &mut Interpreter<WIRE>,
@@ -67,6 +68,7 @@ Proof.
   run_symbolic.
   (* pointer_coercion *)
 Admitted.
+Global Opaque run_mstore.
 
 (* pub fn mstore8<WIRE: InterpreterTypes, H: Host + ?Sized>(
     interpreter: &mut Interpreter<WIRE>,
@@ -92,6 +94,7 @@ Proof.
   run_symbolic.
   (* pointer_coercion *)
 Admitted.
+Global Opaque run_mstore8.
 
 (* pub fn msize<WIRE: InterpreterTypes, H: Host + ?Sized>(
     interpreter: &mut Interpreter<WIRE>,
@@ -116,6 +119,7 @@ Proof.
   destruct run_MemoryTrait_for_Memory.
   run_symbolic.
 Defined.
+Global Opaque run_msize.
 
 (* pub fn mcopy<WIRE: InterpreterTypes, H: Host + ?Sized>(
     interpreter: &mut Interpreter<WIRE>,
@@ -139,3 +143,4 @@ Proof.
   destruct run_MemoryTrait_for_Memory.
   run_symbolic.
 Defined.
+Global Opaque run_mcopy.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/stack.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/stack.v
@@ -33,6 +33,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   run_symbolic.
 Defined.
+Global Opaque run_pop.
 
 (*
 pub fn push0<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -57,6 +58,7 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   run_symbolic.
 Defined.
+Global Opaque run_push0.
 
 (*
 pub fn push<const N: usize, WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -83,6 +85,7 @@ Proof.
   destruct run_Immediates_for_Bytecode.
   run_symbolic.
 Defined.
+Global Opaque run_push.
 
 (*
 pub fn dup<const N: usize, WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -107,6 +110,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   run_symbolic.
 Defined.
+Global Opaque run_dup.
 
 (*
 pub fn swap<const N: usize, WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -131,6 +135,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   run_symbolic.
 Defined.
+Global Opaque run_swap.
 
 (*
 pub fn dupn<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -157,6 +162,7 @@ Proof.
   destruct run_Immediates_for_Bytecode.
   run_symbolic.
 Defined.
+Global Opaque run_dupn.
 
 (*
 pub fn swapn<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -183,6 +189,7 @@ Proof.
   destruct run_Immediates_for_Bytecode.
   run_symbolic.
 Defined.
+Global Opaque run_swapn.
 
 (*
 pub fn exchange<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -209,3 +216,4 @@ Proof.
   destruct run_Immediates_for_Bytecode.
   run_symbolic.
 Defined.
+Global Opaque run_exchange.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system.v
@@ -55,6 +55,7 @@ Proof.
   destruct (Impl_AsRef_for_Slice.run U8.t).
   run_symbolic.
 Defined.
+Global Opaque run_keccak256.
 
 (*
 pub fn address<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -80,6 +81,7 @@ Proof.
   destruct (Impl_Into_for_From_T.run Impl_From_FixedBytes_32_for_U256.run).
   run_symbolic.
 Defined.
+Global Opaque run_address.
 
 (*
 pub fn caller<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -105,6 +107,7 @@ Proof.
   destruct (Impl_Into_for_From_T.run Impl_From_FixedBytes_32_for_U256.run).
   run_symbolic.
 Defined.
+Global Opaque run_caller.
 
 (*
 pub fn codesize<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -129,6 +132,7 @@ Proof.
   destruct run_LegacyBytecode_for_Bytecode.
   run_symbolic.
 Defined.
+Global Opaque run_codesize.
 
 (*
 pub fn memory_resize(
@@ -154,6 +158,7 @@ Proof.
   destruct run_MemoryTrait_for_Memory.
   run_symbolic.
 Defined.
+Global Opaque run_memory_resize.
 
 (*
 pub fn codecopy<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -180,6 +185,7 @@ Proof.
   destruct Impl_TryFrom_u64_for_usize.run.
   run_symbolic.
 Defined.
+Global Opaque run_codecopy.
 
 (*
 pub fn calldataload<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -208,6 +214,7 @@ Proof.
   destruct Impl_Ord_for_usize.run.
   run_symbolic.
 Defined.
+Global Opaque run_calldataload.
 
 (*
 pub fn calldatasize<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -232,6 +239,7 @@ Proof.
   destruct run_InputsTrait_for_Input.
   run_symbolic.
 Defined.
+Global Opaque run_calldatasize.
 
 (*
 pub fn callvalue<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -256,6 +264,7 @@ Proof.
   destruct run_InputsTrait_for_Input.
   run_symbolic.
 Defined.
+Global Opaque run_callvalue.
 
 (*
 pub fn calldatacopy<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -282,6 +291,7 @@ Proof.
   destruct Impl_TryFrom_u64_for_usize.run.
   run_symbolic.
 Defined.
+Global Opaque run_calldatacopy.
 
 (*
 pub fn returndatasize<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -307,6 +317,7 @@ Proof.
   destruct run_ReturnData_for_ReturnData.
   run_symbolic.
 Defined.
+Global Opaque run_returndatasize.
 
 (*
 pub fn returndatacopy<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -334,6 +345,7 @@ Proof.
   destruct Impl_TryFrom_u64_for_usize.run.
   run_symbolic.
 Defined.
+Global Opaque run_returndatacopy.
 
 (*
 pub fn returndataload<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -384,6 +396,7 @@ Proof.
   }
   run_symbolic.
 Defined.
+Global Opaque run_returndataload.
 
 (*
 pub fn gas<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -407,3 +420,4 @@ Proof.
   destruct run_LoopControl_for_Control.
   run_symbolic.
 Defined.
+Global Opaque run_gas.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/tx_info.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/tx_info.v
@@ -49,6 +49,7 @@ Proof.
   destruct run_Transaction_for_Transaction.
   run_symbolic.
 Defined.
+Global Opaque run_gasprice.
 
 (*
 pub fn origin<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -78,6 +79,7 @@ Proof.
   run_symbolic.
   (* dyn type *)
 Admitted.
+Global Opaque run_origin.
 
 (*
 pub fn blob_hash<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -127,3 +129,4 @@ Proof.
         generalize Transaction_IsAssociated; clear; intros.
       } *)
 Admitted.
+Global Opaque run_blob_hash.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/utility.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/utility.v
@@ -41,6 +41,7 @@ Proof.
     run_symbolic.
   } *)
 Admitted.
+Global Opaque run_cast_slice_to_u256.
 
 (*
 pub trait IntoU256 {

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic.v
@@ -63,7 +63,6 @@ Proof.
   get_can_access.
   apply Run.Pure.
 Qed.
-Global Opaque run_add.
 
 Lemma mul_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -111,7 +110,6 @@ Proof.
   get_can_access.
   apply Run.Pure.
 Qed.
-Global Opaque run_mul.
 
 Lemma sub_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -159,7 +157,6 @@ Proof.
   get_can_access.
   apply Run.Pure.
 Qed.
-Global Opaque run_sub.
 
 Lemma div_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -236,4 +233,3 @@ Proof.
     apply Run.Pure.
   }
 Qed.
-Global Opaque run_div.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/contract/static_call.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/contract/static_call.v
@@ -96,7 +96,7 @@ Proof.
   intros.
   destruct InterpreterTypesEq as [[] [] [] []].
   destruct HostEq as [].
-  unfold run_static_call, static_call; cbn.
+  unfold static_call; cbn.
   check_macro_eq spec_id set_instruction_result.
   popn_macro_eq H IInterpreterTypes popn set_instruction_result.
   eapply Run.Call. {
@@ -186,4 +186,3 @@ Proof.
   get_can_access.
   eapply Run.Call. {
 Admitted.
-Global Opaque run_static_call.

--- a/RocqOfRust/revm/revm_interpreter/interpreter/links/shared_memory.v
+++ b/RocqOfRust/revm/revm_interpreter/interpreter/links/shared_memory.v
@@ -44,3 +44,4 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_num_words.

--- a/RocqOfRust/revm/revm_interpreter/interpreter/links/stack.v
+++ b/RocqOfRust/revm/revm_interpreter/interpreter/links/stack.v
@@ -80,6 +80,7 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_STACK_LIMIT.
 
 Module Impl_Stack.
   Definition Self : Set :=
@@ -92,6 +93,7 @@ Module Impl_Stack.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_self.
 
   (* pub fn len(&self) -> usize *)
   Instance run_len (self : Ref.t Pointer.Kind.Ref Self) :
@@ -102,6 +104,7 @@ Module Impl_Stack.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_len.
 
   (* pub fn is_empty(&self) -> bool *)
   Instance run_is_empty (self : Ref.t Pointer.Kind.Ref Self) :
@@ -112,6 +115,7 @@ Module Impl_Stack.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_is_empty.
 
   (* pub fn data(&self) -> &Vec<U256> *)
   Instance run_data (self : Ref.t Pointer.Kind.Ref Self) :
@@ -122,6 +126,7 @@ Module Impl_Stack.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_data.
 
   (* pub fn data_mut(&mut self) -> &mut Vec<U256> *)
   Instance run_data_mut (self : Ref.t Pointer.Kind.MutRef Self) :
@@ -132,6 +137,7 @@ Module Impl_Stack.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_data_mut.
 
   (* pub fn into_data(self) -> Vec<U256> *)
   Instance run_into_data (self : Self) :
@@ -142,6 +148,7 @@ Module Impl_Stack.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_into_data.
 
   (* pub fn pop(&mut self) -> Result<U256, InstructionResult> *)
   Instance run_pop (self : Ref.t Pointer.Kind.MutRef Self) :
@@ -152,6 +159,7 @@ Module Impl_Stack.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_pop.
 
   (* pub unsafe fn pop_unsafe(&mut self) -> U256 *)
   Instance run_pop_unsafe (self : Ref.t Pointer.Kind.MutRef Self) :
@@ -162,6 +170,7 @@ Module Impl_Stack.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_pop_unsafe.
 
   (* pub unsafe fn top_unsafe(&mut self) -> &mut U256 *)
   Instance run_top_unsafe (self : Ref.t Pointer.Kind.MutRef Self) :
@@ -173,6 +182,7 @@ Module Impl_Stack.
     destruct (Impl_DerefMut_for_Vec.run (T := aliases.U256.t) (A := Global.t)).
     run_symbolic.
   Defined.
+  Global Opaque run_top_unsafe.
 
   (* pub unsafe fn popn<const N: usize>(&mut self) -> [U256; N] *)
   Instance run_popn (N : Usize.t) (self : Ref.t Pointer.Kind.MutRef Self) :
@@ -184,6 +194,7 @@ Module Impl_Stack.
     destruct (Impl_IntoIterator_for_Iterator_I.run (IterMut.t aliases.U256.t) aliases.U256.t).
     run_symbolic.
   Admitted.
+  Global Opaque run_popn.
 
   (* pub unsafe fn popn_top<const POPN: usize>(&mut self) -> ([U256; POPN], &mut U256) *)
   Instance run_popn_top (self : Ref.t Pointer.Kind.MutRef Self) (POPN : Usize.t) :
@@ -194,6 +205,7 @@ Module Impl_Stack.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_popn_top.
 
   (* pub fn push(&mut self, value: U256) -> bool *)
   Instance run_push (self : Ref.t Pointer.Kind.MutRef Self) (value : aliases.U256.t) :
@@ -204,6 +216,7 @@ Module Impl_Stack.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_push.
 
   (* pub fn peek(&self, no_from_top: usize) -> Result<U256, InstructionResult> *)
   Instance run_peek (self : Ref.t Pointer.Kind.Ref Self) (no_from_top : Usize.t) :
@@ -216,6 +229,7 @@ Module Impl_Stack.
     destruct (Impl_Index_for_Vec_T_A.run aliases.U256.t Usize.t Global.t aliases.U256.t).
     run_symbolic.
   Admitted.
+  Global Opaque run_peek.
 
   (* pub fn dup(&mut self, n: usize) -> bool *)
   Instance run_dup (self : Ref.t Pointer.Kind.MutRef Self) (n : Usize.t) :
@@ -226,6 +240,7 @@ Module Impl_Stack.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_dup.
 
   (* pub fn exchange(&mut self, n: usize, m: usize) -> bool *)
   Instance run_exchange (self : Ref.t Pointer.Kind.MutRef Self) (n m : Usize.t) :
@@ -237,6 +252,7 @@ Module Impl_Stack.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_exchange.
 
   (* pub fn swap(&mut self, n: usize) -> bool *)
   Instance run_swap (self : Ref.t Pointer.Kind.MutRef Self) (n : Usize.t) :
@@ -247,6 +263,7 @@ Module Impl_Stack.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_swap.
 
   (* pub fn push_slice(&mut self, slice: &[u8]) -> Result<(), InstructionResult> *)
   Instance run_push_slice
@@ -259,6 +276,7 @@ Module Impl_Stack.
   Proof.
     constructor.
   Admitted.
+  Global Opaque run_push_slice.
 
   (* pub fn set(&mut self, no_from_top: usize, val: U256) -> Result<(), InstructionResult> *)
   Instance run_set
@@ -273,4 +291,5 @@ Module Impl_Stack.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_set.
 End Impl_Stack.

--- a/RocqOfRust/revm/revm_interpreter/interpreter_action/links/eof_create_inputs.v
+++ b/RocqOfRust/revm/revm_interpreter/interpreter_action/links/eof_create_inputs.v
@@ -82,5 +82,6 @@ Module Impl_EOFCreateInputs.
       [] [] [ φ caller; φ created_address; φ value; φ eof_init_code; φ gas_limit; φ input ]
       EOFCreateInputs.t.
   Admitted.
+  Global Opaque run_new_opcode.
 End Impl_EOFCreateInputs.
 Export Impl_EOFCreateInputs.

--- a/RocqOfRust/revm/revm_interpreter/links/gas.v
+++ b/RocqOfRust/revm/revm_interpreter/links/gas.v
@@ -126,6 +126,7 @@ Module Impl_MemoryGas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_new.
 
   (*
   pub fn record_new_len(&mut self, new_num: usize) -> Option<u64> {
@@ -150,6 +151,7 @@ Module Impl_MemoryGas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_record_new_len.
 End Impl_MemoryGas.
 Export Impl_MemoryGas.
 
@@ -407,6 +409,7 @@ Module Impl_Gas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_new.
 
   (*
       pub const fn new_spent(limit: u64) -> Self {
@@ -424,6 +427,7 @@ Module Impl_Gas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_new_spent.
 
   (*
       pub const fn limit(&self) -> u64 {
@@ -436,6 +440,7 @@ Module Impl_Gas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_limit.
 
   (*
       pub const fn memory(&self) -> u64 {
@@ -448,6 +453,7 @@ Module Impl_Gas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_memory.
 
   (*
       pub const fn refunded(&self) -> i64 {
@@ -460,6 +466,7 @@ Module Impl_Gas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_refunded.
 
   (*
       pub const fn spent(&self) -> u64 {
@@ -472,6 +479,7 @@ Module Impl_Gas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_spent.
 
   (*
       pub const fn remaining(&self) -> u64 {
@@ -484,6 +492,7 @@ Module Impl_Gas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_remaining.
 
   (*
       pub const fn remaining_63_of_64_parts(&self) -> u64 {
@@ -496,6 +505,7 @@ Module Impl_Gas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_remaining_63_of_64_parts.
 
   (*
       pub fn erase_cost(&mut self, returned: u64) {
@@ -508,6 +518,7 @@ Module Impl_Gas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_erase_cost.
 
   (*
       pub fn spend_all(&mut self) {
@@ -520,6 +531,7 @@ Module Impl_Gas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_spend_all.
 
   (*
       pub fn record_refund(&mut self, refund: i64) {
@@ -532,6 +544,7 @@ Module Impl_Gas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_record_refund.
 
   (*
       pub fn set_final_refund(&mut self, is_london: bool) {
@@ -546,6 +559,7 @@ Module Impl_Gas.
     pose cmp.Impl_Ord_for_u64.run_min.
     run_symbolic.
   Defined.
+  Global Opaque run_set_final_refund.
 
   (*
       pub fn set_refund(&mut self, refund: i64) {
@@ -558,6 +572,7 @@ Module Impl_Gas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_set_refund.
 
   (*
       pub fn record_cost(&mut self, cost: u64) -> bool {
@@ -575,6 +590,7 @@ Module Impl_Gas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_record_cost.
 
   (*
       pub fn record_memory_expansion(&mut self, new_len: usize) -> MemoryExtensionResult {
@@ -599,5 +615,6 @@ Module Impl_Gas.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_record_memory_expansion.
 End Impl_Gas.
 Export Impl_Gas.

--- a/RocqOfRust/revm/revm_interpreter/links/instruction_result.v
+++ b/RocqOfRust/revm/revm_interpreter/links/instruction_result.v
@@ -688,6 +688,7 @@ Module Impl_InstructionResult.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_is_ok.
 
   (* pub const fn is_ok_or_revert(self) -> bool *)
   Instance run_is_ok_or_revert (self : Self) :
@@ -699,6 +700,7 @@ Module Impl_InstructionResult.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_is_ok_or_revert.
 
   (* pub const fn is_continue(self) -> bool *)
   Instance run_is_continue (self : Self) :
@@ -711,6 +713,7 @@ Module Impl_InstructionResult.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_is_continue.
 
   (* pub const fn is_revert(self) -> bool *)
   Instance run_is_revert (self : Self) :
@@ -722,6 +725,7 @@ Module Impl_InstructionResult.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_is_revert.
 
   (* pub const fn is_error(self) -> bool *)
   Instance run_is_error (self : Self) :
@@ -733,5 +737,6 @@ Module Impl_InstructionResult.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_is_error.
 End Impl_InstructionResult.
 Export Impl_InstructionResult.

--- a/RocqOfRust/revm/revm_interpreter/links/instructions.v
+++ b/RocqOfRust/revm/revm_interpreter/links/instructions.v
@@ -56,6 +56,7 @@ Proof.
     now pose proof (run_pointer_coercion_intrinsic_reify_fn_pointer F).
   }
 Defined.
+Global Opaque run_instruction_table.
 
 (*
 pub const fn instruction<WIRE: InterpreterTypes, H: Host + ?Sized>(
@@ -76,3 +77,4 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_instruction.

--- a/RocqOfRust/revm/revm_interpreter/links/interpreter.v
+++ b/RocqOfRust/revm/revm_interpreter/links/interpreter.v
@@ -47,6 +47,7 @@ Module Impl_Interpreter.
     destruct run_CustomInstruction_for_FN.
     run_symbolic.
   Defined.
+  Global Opaque run_step.
 
   (*
   pub fn run<FN, H: Host>(
@@ -79,4 +80,5 @@ Module Impl_Interpreter.
     (* now eapply run_step.
   Defined. *)
   Admitted.
+  Global Opaque run_run.
 End Impl_Interpreter.

--- a/RocqOfRust/revm/revm_interpreter/links/interpreter_action.v
+++ b/RocqOfRust/revm/revm_interpreter/links/interpreter_action.v
@@ -246,6 +246,7 @@ Module Impl_InterpreterAction.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_is_call.
 
   (* pub fn is_create(&self) -> bool *)
   Instance run_is_create (self : Ref.t Pointer.Kind.Ref Self) :
@@ -257,6 +258,7 @@ Module Impl_InterpreterAction.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_is_create.
 
   (* pub fn is_return(&self) -> bool *)
   Instance run_is_return (self : Ref.t Pointer.Kind.Ref Self) :
@@ -268,6 +270,7 @@ Module Impl_InterpreterAction.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_is_return.
 
   (* pub fn is_none(&self) -> bool *)
   Instance run_is_none (self : Ref.t Pointer.Kind.Ref Self) :
@@ -279,6 +282,7 @@ Module Impl_InterpreterAction.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_is_none.
 
   (* pub fn is_some(&self) -> bool *)
   Instance run_is_some (self : Ref.t Pointer.Kind.Ref Self) :
@@ -290,6 +294,7 @@ Module Impl_InterpreterAction.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_is_some.
 
   (* pub fn into_result_return(self) -> Option<InterpreterResult> *)
   Instance run_into_result_return (self : Self) :
@@ -303,5 +308,6 @@ Module Impl_InterpreterAction.
     (* The failure is probably dues to the phantom type on the [None] constructor. TODO: make a
        general fix. *)
   Admitted.
+  Global Opaque run_into_result_return.
 End Impl_InterpreterAction.
 Export Impl_InterpreterAction.

--- a/RocqOfRust/revm/revm_interpreter/simulate/gas.v
+++ b/RocqOfRust/revm/revm_interpreter/simulate/gas.v
@@ -24,7 +24,6 @@ Module Impl_MemoryGas.
   Proof.
     apply Run.Pure.
   Qed.
-  Global Opaque Impl_MemoryGas.run_new.
 End Impl_MemoryGas.
 
 Module Impl_Gas.
@@ -52,7 +51,6 @@ Module Impl_Gas.
     cbn.
     apply Run.Pure.
   Qed.
-  Global Opaque Impl_Gas.run_new.
 
   (*
       pub const fn limit(&self) -> u64 {
@@ -71,11 +69,10 @@ Module Impl_Gas.
       (Output.Success (limit self), [self]%stack)
     }}.
   Proof.
-    cbn.
-    repeat get_can_access.
+    with_strategy transparent [run_limit] cbn.
+    progress repeat get_can_access.
     apply Run.Pure.
   Qed.
-  Global Opaque Impl_Gas.run_limit.
 
   (*
       pub fn erase_cost(&mut self, returned: u64) {
@@ -103,8 +100,8 @@ Module Impl_Gas.
       (Output.Success tt, [erase_cost self returned]%stack)
     }}.
   Proof.
-    cbn.
-    repeat get_can_access.
+    with_strategy transparent [run_erase_cost] cbn.
+    progress repeat get_can_access.
     eapply Run.Call. {
       apply Run.Pure.
     }
@@ -112,7 +109,6 @@ Module Impl_Gas.
     repeat get_can_access.
     apply Run.Pure.
   Qed.
-  Global Opaque Impl_Gas.run_erase_cost.
 
   Parameter u64_overflowing_sub : forall (self other : U64.t), U64.t * bool.
 
@@ -179,7 +175,8 @@ Module Impl_Gas.
   Proof.
     intros.
     apply Run.remove_extra_stack1.
-    unfold record_cost in *; cbn.
+    unfold record_cost in *.
+    with_strategy transparent [run_record_cost] cbn.
     progress repeat get_can_access.
     eapply Run.Call. {
       apply u64_overflowing_sub_eq.
@@ -196,7 +193,6 @@ Module Impl_Gas.
     { apply Run.Pure. }
     { apply Run.Pure. }
   Qed.
-  Global Opaque Impl_Gas.run_record_cost.
 
   (*Lemma record_cost_eq'
       {WIRE : Set} `{Link WIRE}
@@ -281,7 +277,6 @@ Module Impl_Gas.
     { apply Run.Pure. }
     { apply Run.Pure. }
   Qed.
-  Global Opaque Impl_Gas.run_record_cost.
 
   Lemma record_cost_eq'
       {WIRE : Set} `{Link WIRE}
@@ -380,5 +375,5 @@ Module Impl_Gas.
     { apply Run.Pure. }
     { apply Run.Pure. }
   Qed.
-  Global Opaque Impl_Gas.run_record_cost. *)
+  *)
 End Impl_Gas.

--- a/RocqOfRust/revm/revm_primitives/links/lib.v
+++ b/RocqOfRust/revm/revm_primitives/links/lib.v
@@ -14,3 +14,4 @@ Proof.
   constructor.
   run_symbolic.
 Admitted.
+Global Opaque run_KECCAK_EMPTY.

--- a/RocqOfRust/revm/revm_specification/links/hardfork.v
+++ b/RocqOfRust/revm/revm_specification/links/hardfork.v
@@ -423,6 +423,7 @@ Module Impl_SpecId.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_n.
 
   Instance run_try_from_u8 (spec_id : U8.t) :
     Run.Trait
@@ -432,6 +433,7 @@ Module Impl_SpecId.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_try_from_u8.
 
   Instance run_is_enabled_in (self other : Self) :
     Run.Trait
@@ -447,5 +449,6 @@ Module Impl_SpecId.
     }
     run_symbolic.
   Defined.
+  Global Opaque run_is_enabled_in.
 End Impl_SpecId.
 Export (hints) Impl_SpecId.

--- a/RocqOfRust/revm/revm_specification/simulate/hardfork.v
+++ b/RocqOfRust/revm/revm_specification/simulate/hardfork.v
@@ -29,5 +29,4 @@ Module Impl_SpecId.
     do 2 rewrite get_discriminant_mod_256_eq.
     apply Run.Pure.
   Qed.
-  Global Opaque Impl_SpecId.run_is_enabled_in.
 End Impl_SpecId.

--- a/RocqOfRust/ruint/links/add.v
+++ b/RocqOfRust/ruint/links/add.v
@@ -17,6 +17,7 @@ Module Impl_Uint.
       (add.Impl_ruint_Uint_BITS_LIMBS.wrapping_add (φ BITS) (φ LIMBS)) [] [] [ φ x1; φ x2 ]
       (Self BITS LIMBS).
   Admitted.
+  Global Opaque run_wrapping_add.
 
   (* pub const fn wrapping_neg(self) -> Self *)
   Instance run_wrapping_neg
@@ -26,6 +27,7 @@ Module Impl_Uint.
     (add.Impl_ruint_Uint_BITS_LIMBS.wrapping_neg (φ BITS) (φ LIMBS)) [] [] [ φ x ]
     (Self BITS LIMBS).
   Admitted.
+  Global Opaque run_wrapping_neg.
 
   (* pub const fn wrapping_sub(self, rhs: Self) -> Self *)
   Instance run_wrapping_sub
@@ -35,6 +37,7 @@ Module Impl_Uint.
     (add.Impl_ruint_Uint_BITS_LIMBS.wrapping_sub (φ BITS) (φ LIMBS)) [] [] [ φ x1; φ x2 ]
     (Self BITS LIMBS).
   Admitted.
+  Global Opaque run_wrapping_sub.
 End Impl_Uint.
 Export Impl_Uint.
 

--- a/RocqOfRust/ruint/links/bits.v
+++ b/RocqOfRust/ruint/links/bits.v
@@ -17,6 +17,7 @@ Module Impl_Uint.
       (bits.Impl_ruint_Uint_BITS_LIMBS.bit (φ BITS) (φ LIMBS)) [] [] [ φ self; φ index ]
       bool.
   Admitted.
+  Global Opaque run_bit.
 
   (* pub const fn byte(&self, index: usize) -> u8 *)
   Instance run_byte
@@ -27,6 +28,7 @@ Module Impl_Uint.
       (bits.Impl_ruint_Uint_BITS_LIMBS.byte (φ BITS) (φ LIMBS)) [] [] [ φ x; φ index ]
       U8.t.
   Admitted.
+  Global Opaque run_byte.
 
   (* pub fn arithmetic_shr(self, rhs: usize) -> Self *)
   Instance run_arithmetic_shr
@@ -37,6 +39,7 @@ Module Impl_Uint.
       (bits.Impl_ruint_Uint_BITS_LIMBS.arithmetic_shr (φ BITS) (φ LIMBS)) [] [] [ φ self; φ rhs ]
       (Self BITS LIMBS).
   Admitted.
+  Global Opaque run_arithmetic_shr.
 End Impl_Uint.
 Export Impl_Uint.
 

--- a/RocqOfRust/ruint/links/bytes.v
+++ b/RocqOfRust/ruint/links/bytes.v
@@ -18,6 +18,7 @@ Module Impl_Uint.
       (bytes.Impl_ruint_Uint_BITS_LIMBS.to_be_bytes (φ BITS) (φ LIMBS)) [ φ BYTES ] [] [ φ x ]
       (array.t U8.t BYTES).
   Admitted.
+  Global Opaque run_to_be_bytes.
 
   (* pub const fn from_be_bytes<const BYTES: usize>(bytes: [u8; BYTES]) -> Self *)
   Instance run_from_be_bytes
@@ -27,6 +28,7 @@ Module Impl_Uint.
       (bytes.Impl_ruint_Uint_BITS_LIMBS.from_be_bytes (φ BITS) (φ LIMBS)) [ φ BYTES ] [] [ φ bytes ]
       (Self BITS LIMBS).
   Admitted.
+  Global Opaque run_from_be_bytes.
 
   (* pub const fn try_from_be_slice(bytes: &[u8]) -> Option<Self> *)
   Instance run_try_from_be_slice
@@ -36,5 +38,6 @@ Module Impl_Uint.
       (bytes.Impl_ruint_Uint_BITS_LIMBS.try_from_be_slice (φ BITS) (φ LIMBS)) [] [] [ φ bytes ]
       (option (Self BITS LIMBS)).
   Admitted.
+  Global Opaque run_try_from_be_slice.
 End Impl_Uint.
 Export Impl_Uint.

--- a/RocqOfRust/ruint/links/cmp.v
+++ b/RocqOfRust/ruint/links/cmp.v
@@ -17,6 +17,7 @@ Module Impl_Uint.
       (cmp.Impl_ruint_Uint_BITS_LIMBS.is_zero (φ BITS) (φ LIMBS)) [] [] [ φ self ]
       bool.
   Admitted.
+  Global Opaque run_is_zero.
 End Impl_Uint.
 Export Impl_Uint.
 

--- a/RocqOfRust/ruint/links/div.v
+++ b/RocqOfRust/ruint/links/div.v
@@ -16,6 +16,7 @@ Module Impl_Uint.
       (div.Impl_ruint_Uint_BITS_LIMBS.wrapping_div (φ BITS) (φ LIMBS)) [] [] [ φ x1; φ x2 ]
       (Self BITS LIMBS).
   Admitted.
+  Global Opaque run_wrapping_div.
 
   (* pub fn wrapping_rem(self, rhs: Self) -> Self *)
   Instance run_wrapping_rem
@@ -25,5 +26,6 @@ Module Impl_Uint.
       (div.Impl_ruint_Uint_BITS_LIMBS.wrapping_rem (φ BITS) (φ LIMBS)) [] [] [ φ x1; φ x2 ]
       (Self BITS LIMBS).
   Admitted.
+  Global Opaque run_wrapping_rem.
 End Impl_Uint.
 Export Impl_Uint.

--- a/RocqOfRust/ruint/links/from.v
+++ b/RocqOfRust/ruint/links/from.v
@@ -25,6 +25,7 @@ Module Impl_Uint.
       (from.Impl_ruint_Uint_BITS_LIMBS.from (φ BITS) (φ LIMBS)) [] [ Φ T ] [ φ value ]
       (Self BITS LIMBS).
   Admitted.
+  Global Opaque run_from.
 End Impl_Uint.
 Export Impl_Uint.
 
@@ -69,6 +70,7 @@ Module TryFrom_Uint_for_u64.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_try_from.
 
   Definition Run_try_from (BITS LIMBS : Usize.t) :
     TryFrom.Run_try_from Self (Impl_Uint.Self BITS LIMBS) (FromUintError.t U64.t).

--- a/RocqOfRust/ruint/links/lib.v
+++ b/RocqOfRust/ruint/links/lib.v
@@ -57,6 +57,7 @@ Module Impl_Uint.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_from_limbs.
 
   (* pub const BITS: usize *)
   Instance run_BITS (BITS LIMBS : Usize.t) :
@@ -67,6 +68,7 @@ Module Impl_Uint.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_BITS.
 
   (* pub const ZERO: Self *)
   Instance run_ZERO (BITS LIMBS : Usize.t) :
@@ -84,6 +86,7 @@ Module Impl_Uint.
     }
     apply Run.run_f.
   Defined.
+  Global Opaque run_ZERO.
 
   (* pub const MIN: Self *)
   Instance run_MIN (BITS LIMBS : Usize.t) :
@@ -94,6 +97,7 @@ Module Impl_Uint.
     constructor.
     run_symbolic.
   Defined.
+  Global Opaque run_MIN.
 
   (* pub const MAX: Self *)
   Instance run_MAX (BITS LIMBS : Usize.t) :
@@ -104,6 +108,7 @@ Module Impl_Uint.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_MAX.
 
   (* pub const fn as_limbs(&self) -> &[u64; LIMBS] *)
   Instance run_as_limbs
@@ -116,6 +121,7 @@ Module Impl_Uint.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_as_limbs.
 
   (* pub unsafe fn as_limbs_mut(&mut self) -> &mut [u64; LIMBS] *)
   Instance run_as_limbs_mut
@@ -128,5 +134,6 @@ Module Impl_Uint.
     constructor.
     run_symbolic.
   Admitted.
+  Global Opaque run_as_limbs_mut.
 End Impl_Uint.
 Export Impl_Uint.

--- a/RocqOfRust/ruint/links/modular.v
+++ b/RocqOfRust/ruint/links/modular.v
@@ -17,6 +17,7 @@ Module Impl_Uint.
       (modular.Impl_ruint_Uint_BITS_LIMBS.add_mod (φ BITS) (φ LIMBS)) [] [] [ φ x1; φ x2; φ x3 ]
       (Self BITS LIMBS).
   Admitted.
+  Global Opaque run_add_mod.
 
   (* pub fn mul_mod(self, rhs: Self, modulus: Self) -> Self *)
   Instance run_mul_mod
@@ -26,6 +27,7 @@ Module Impl_Uint.
       (modular.Impl_ruint_Uint_BITS_LIMBS.mul_mod (φ BITS) (φ LIMBS)) [] [] [ φ x1; φ x2; φ x3 ]
       (Self BITS LIMBS).
   Admitted.
+  Global Opaque run_mul_mod.
 
   (* pub fn pow_mod(self, exp: Self, modulus: Self) -> Self *)
   Instance run_pow_mod
@@ -35,5 +37,6 @@ Module Impl_Uint.
       (modular.Impl_ruint_Uint_BITS_LIMBS.pow_mod (φ BITS) (φ LIMBS)) [] [] [ φ x1; φ x2; φ x3 ]
       (Self BITS LIMBS).
   Admitted.
+  Global Opaque run_pow_mod.
 End Impl_Uint.
 Export Impl_Uint.

--- a/RocqOfRust/ruint/links/mul.v
+++ b/RocqOfRust/ruint/links/mul.v
@@ -16,5 +16,6 @@ Module Impl_Uint.
       (mul.Impl_ruint_Uint_BITS_LIMBS.wrapping_mul (φ BITS) (φ LIMBS)) [] [] [ φ x1; φ x2 ]
       (Self BITS LIMBS).
   Admitted.
+  Global Opaque run_wrapping_mul.
 End Impl_Uint.
 Export Impl_Uint.

--- a/RocqOfRust/ruint/links/pow.v
+++ b/RocqOfRust/ruint/links/pow.v
@@ -16,6 +16,7 @@ Module Impl_Uint.
     (pow.Impl_ruint_Uint_BITS_LIMBS.pow (φ BITS) (φ LIMBS)) [] [] [ φ x1; φ x2 ]
     (Self BITS LIMBS).
   Admitted.
+  Global Opaque run_pow.
 
   (* pub fn wrapping_pow(mut self, mut exp: Self) -> Self *)
   Instance run_wrapping_pow
@@ -25,5 +26,6 @@ Module Impl_Uint.
     (pow.Impl_ruint_Uint_BITS_LIMBS.wrapping_pow (φ BITS) (φ LIMBS)) [] [] [ φ x1; φ x2 ]
     (Self BITS LIMBS).
   Admitted.
+  Global Opaque run_wrapping_pow.
 End Impl_Uint.
 Export Impl_Uint.

--- a/RocqOfRust/ruint/simulate/div.v
+++ b/RocqOfRust/ruint/simulate/div.v
@@ -21,5 +21,4 @@ Module Impl_Uint.
       )
     }}.
   Admitted.
-  Global Opaque Impl_Uint.run_wrapping_div.
 End Impl_Uint.

--- a/RocqOfRust/ruint/simulate/from.v
+++ b/RocqOfRust/ruint/simulate/from.v
@@ -24,5 +24,4 @@ Module TryFrom_Uint_for_u64.
       )
     }}.
   Admitted.
-  Global Opaque TryFrom_Uint_for_u64.run_try_from.
 End TryFrom_Uint_for_u64.


### PR DESCRIPTION
This optimizes how the goals are rendered when writing the simulations. Instead of unfolding the bodies of the called functions, we clearly see their name, so:

- less content is printed;
- it is easier to find them from their name, to add a simulation for them.