### PR TITLE
Update Revm v103 memory expansion macro simulate

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
@@ -633,30 +633,46 @@ Definition resize_memory_macro {WIRE K : Set} `{Link WIRE}
       .(InterpreterTypes.LoopControl_for_Control)
       .(LoopControl.gas) in
   let gas := ref_gas.(RefStub.projection) interpreter.(Interpreter.control) in
-  let '(extension_result, gas) := Impl_Gas.record_memory_expansion gas words_num in
-  let interpreter :=
-    interpreter <| Interpreter.control :=
-      ref_gas.(RefStub.injection) interpreter.(Interpreter.control) gas
-    |> in
-  match extension_result with
-  | MemoryExtensionResult.Extended =>
-    let '(_, memory) :=
-      IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory).(MemoryTrait.resize)
-        interpreter.(Interpreter.memory) (words_num *i 32) in
-    let interpreter := interpreter <| Interpreter.memory := memory |> in
-    k interpreter
-  | MemoryExtensionResult.OutOfGas =>
-    let control :=
-      IInterpreterTypes
-          .(InterpreterTypes.LoopControl_for_Control)
-          .(LoopControl.set_instruction_result)
-        interpreter.(Interpreter.control)
-        instruction_result.InstructionResult.MemoryOOG in
-    let interpreter := interpreter <| Interpreter.control := control |> in
-    k_exit interpreter
-  | MemoryExtensionResult.Same =>
-    k interpreter
-  end.
+  if i[words_num] >? i[gas.(Gas.memory).(MemoryGas.words_num)] then
+    let '(cost, memory_gas) := Impl_MemoryGas.record_new_len gas.(Gas.memory) words_num in
+    let gas := gas <| Gas.memory := memory_gas |> in
+    match cost with
+    | None =>
+      let control := ref_gas.(RefStub.injection) interpreter.(Interpreter.control) gas in
+      let control :=
+        IInterpreterTypes
+            .(InterpreterTypes.LoopControl_for_Control)
+            .(LoopControl.set_instruction_result)
+          control
+          instruction_result.InstructionResult.MemoryOOG in
+      let interpreter := interpreter <| Interpreter.control := control |> in
+      k_exit interpreter
+    | Some cost =>
+      match Impl_Gas.record_cost gas cost with
+      | None =>
+        let control := ref_gas.(RefStub.injection) interpreter.(Interpreter.control) gas in
+        let control :=
+          IInterpreterTypes
+              .(InterpreterTypes.LoopControl_for_Control)
+              .(LoopControl.set_instruction_result)
+            control
+            instruction_result.InstructionResult.MemoryOOG in
+        let interpreter := interpreter <| Interpreter.control := control |> in
+        k_exit interpreter
+      | Some gas =>
+        let interpreter :=
+          interpreter <| Interpreter.control :=
+            ref_gas.(RefStub.injection) interpreter.(Interpreter.control) gas
+          |> in
+        let '(_, memory) :=
+          IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory).(MemoryTrait.resize)
+            interpreter.(Interpreter.memory) (words_num *i 32) in
+        let interpreter := interpreter <| Interpreter.memory := memory |> in
+        k interpreter
+      end
+    end
+  else
+    k interpreter.
 
 Ltac resize_memory_macro_eq InterpreterTypesEq :=
   unfold resize_memory_macro;


### PR DESCRIPTION
Updates the Revm v103 memory expansion simulate macro.

The old macro still called the removed gas-level `record_memory_expansion` helper. This now follows the current v103 flow directly: compare the requested memory size with the cached memory-gas word count, update `MemoryGas` with `record_new_len`, charge the cost with `record_cost`, and resize memory only if the gas charge succeeds.

This PR intentionally changes only the macro file because this was the failing target.