### PR TITLE
Update Revm v103 memory resize simulate

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/memory_resize.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/memory_resize.v
@@ -42,9 +42,28 @@ Instance run_memory_resize
     (option usize).
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
+  pose proof run_MemoryTrait_for_Memory as run_MemoryTrait_for_Memory_copy.
   destruct run_MemoryTrait_for_Memory.
   run_symbolic.
+  all: match goal with
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_oog _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt_oog
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt
+  | |- Run.Trait
+      shared_memory.interpreter.shared_memory.resize_memory
+      _ _ _ _ =>
+      eapply (@shared_memory.run_resize_memory _ _ _ _ _ _ run_MemoryTrait_for_Memory_copy)
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_memory_oog _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt_memory_oog
+  end.
 Defined.
 Global Opaque run_memory_resize.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
@@ -57,6 +57,43 @@ Ltac require_non_staticcall_macro_eq InterpreterTypesEq :=
     s
   |].
 
+Definition halt {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (result : instruction_result.InstructionResult.t) :
+    Interpreter.t WIRE WIRE_types :=
+  let action :=
+    interpreter_action.InterpreterAction.Return {|
+      InterpreterResult.result := result;
+      InterpreterResult.output := Impl_Bytes.new;
+      InterpreterResult.gas := interpreter.(Interpreter.gas);
+    |} in
+  interpreter
+    <| Interpreter.bytecode :=
+      IInterpreterTypes
+        .(InterpreterTypes.LoopControl_for_Bytecode)
+        .(LoopControl.set_action)
+        interpreter.(Interpreter.bytecode)
+        action
+    |>.
+
+Definition halt_oog {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (interpreter : Interpreter.t WIRE WIRE_types) :
+    Interpreter.t WIRE WIRE_types :=
+  halt
+    (interpreter <| Interpreter.gas := Impl_Gas.spend_all interpreter.(Interpreter.gas) |>)
+    instruction_result.InstructionResult.OutOfGas.
+
+Definition halt_memory_oog {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (interpreter : Interpreter.t WIRE WIRE_types) :
+    Interpreter.t WIRE WIRE_types :=
+  halt interpreter instruction_result.InstructionResult.MemoryOOG.
+
 Definition gas_macro {WIRE K : Set} `{Link WIRE}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
@@ -65,69 +102,11 @@ Definition gas_macro {WIRE K : Set} `{Link WIRE}
     (k_exit : Interpreter.t WIRE WIRE_types -> K)
     (k : Interpreter.t WIRE WIRE_types -> K) :
     K :=
-  let gas :=
-    IInterpreterTypes
-        .(InterpreterTypes.LoopControl_for_Control)
-        .(LoopControl.gas)
-        .(RefStub.projection)
-      interpreter.(Interpreter.control) in
-  match Impl_Gas.record_cost gas cost with
+  match Impl_Gas.record_cost interpreter.(Interpreter.gas) cost with
   | None =>
-    let control :=
-      IInterpreterTypes
-          .(InterpreterTypes.LoopControl_for_Control)
-          .(LoopControl.set_instruction_result)
-        interpreter.(Interpreter.control)
-        instruction_result.InstructionResult.OutOfGas in
-    let interpreter := interpreter
-      <| Interpreter.control := control |> in
-    k_exit interpreter
+    k_exit (halt_oog interpreter)
   | Some gas =>
-    let control :=
-      IInterpreterTypes
-          .(InterpreterTypes.LoopControl_for_Control)
-          .(LoopControl.gas)
-          .(RefStub.injection)
-        interpreter.(Interpreter.control) gas in
-    let interpreter :=
-      interpreter
-        <| Interpreter.control := control |> in
-    k interpreter
-  end.
-
-Ltac gas_macro_eq gas_eq :=
-  match goal with
-  | InterpreterTypesEq : InterpreterTypes.Eq.t _ _ _ _ |- _ =>
-  unfold gas_macro;
-  s; [
-    apply InterpreterTypesEq
-      .(InterpreterTypes.Eq.LoopControl_for_Control)
-      .(LoopControl.Eq.gas)
-  |];
-  gas_eq;
-  s; [
-    apply Impl_Gas.record_cost_eq
-  |];
-  destruct Impl_Gas.record_cost;
-  (
-    eapply Run.Call; [
-      apply Run.Pure
-    |]
-  );
-  cbn;
-  [|
-    eapply Run.Call; [
-      apply Run.Pure
-    |];
-    apply Run.LetUnfold;
-    eapply Run.Call; [
-      apply InterpreterTypesEq
-        .(InterpreterTypes.Eq.LoopControl_for_Control)
-        .(LoopControl.Eq.set_instruction_result)
-    |];
-    cbn;
-    apply Run.Pure
-  ]
+    k (interpreter <| Interpreter.gas := gas |>)
   end.
 
 Definition gas_or_fail_macro {WIRE K : Set} `{Link WIRE}
@@ -140,29 +119,9 @@ Definition gas_or_fail_macro {WIRE K : Set} `{Link WIRE}
     K :=
   match gas_opt with
   | None =>
-    let control :=
-      IInterpreterTypes
-          .(InterpreterTypes.LoopControl_for_Control)
-          .(LoopControl.set_instruction_result)
-        interpreter.(Interpreter.control)
-        instruction_result.InstructionResult.OutOfGas in
-    let interpreter := interpreter
-      <| Interpreter.control := control |> in
-    k_exit interpreter
+    k_exit (halt_oog interpreter)
   | Some gas_used =>
     gas_macro interpreter gas_used k_exit k
-  end.
-
-Ltac gas_or_fail_macro_eq :=
-  match goal with
-  | InterpreterTypesEq : InterpreterTypes.Eq.t _ _ _ _ |- _ =>
-  step; [
-    gas_macro_eq idtac |
-    s; [
-      apply InterpreterTypesEq
-    |];
-    s
-  ]
   end.
 
 Definition popn_macro {WIRE K : Set} `{Link WIRE}
@@ -332,6 +291,116 @@ Proof.
     repeat rewrite stack_dealloc_cons_alloc_unit;
     reflexivity.
 Qed.
+
+Lemma halt_oog_eq {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (InterpreterTypesEq :
+      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (stack_rest : Stack.t) :
+  let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+  {{
+    SimulateM.eval_f
+      (Impl_Interpreter.run_halt_oog WIRE ref_interpreter)
+      (interpreter :: stack_rest)%stack 🌲
+    (
+      Output.Success tt,
+      (halt_oog interpreter :: stack_rest)%stack
+    )
+  }}.
+Proof.
+  intros.
+  unfold halt_oog, halt.
+  with_strategy transparent [
+    Impl_Interpreter.run_halt_oog
+    Impl_Interpreter.run_halt
+  ] unfold Impl_Interpreter.run_halt_oog, Impl_Interpreter.run_halt.
+  cbn.
+  s.
+  - apply Impl_Gas.spend_all_interpreter_eq.
+  - repeat s.
+    + apply Impl_Bytes.new_eq.
+    + apply InterpreterTypesEq
+        .(InterpreterTypes.Eq.LoopControl_for_Bytecode)
+        .(LoopControl.BytecodeEq.set_action).
+    + repeat rewrite Stack.dealloc_alloc_eq;
+      repeat rewrite stack_dealloc_cons_alloc_unit;
+      reflexivity.
+Qed.
+
+Lemma halt_memory_oog_eq {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (InterpreterTypesEq :
+      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (stack_rest : Stack.t) :
+  let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+  {{
+    SimulateM.eval_f
+      (Impl_Interpreter.run_halt_memory_oog WIRE ref_interpreter)
+      (interpreter :: stack_rest)%stack 🌲
+    (
+      Output.Success tt,
+      (halt_memory_oog interpreter :: stack_rest)%stack
+    )
+  }}.
+Proof.
+  intros.
+  unfold halt_memory_oog, halt.
+  with_strategy transparent [
+    Impl_Interpreter.run_halt_memory_oog
+    Impl_Interpreter.run_halt
+  ] unfold Impl_Interpreter.run_halt_memory_oog, Impl_Interpreter.run_halt.
+  cbn.
+  repeat s.
+  - apply Impl_Bytes.new_eq.
+  - apply InterpreterTypesEq
+      .(InterpreterTypes.Eq.LoopControl_for_Bytecode)
+      .(LoopControl.BytecodeEq.set_action).
+  - repeat rewrite Stack.dealloc_alloc_eq;
+    repeat rewrite stack_dealloc_cons_alloc_unit;
+    reflexivity.
+Qed.
+
+Ltac gas_macro_eq gas_eq :=
+  unfold gas_macro;
+  gas_eq;
+  s; [
+    apply Impl_Gas.record_cost_interpreter_eq
+  |];
+  destruct Impl_Gas.record_cost;
+  (
+    eapply Run.Call; [
+      apply Run.Pure
+    |]
+  );
+  cbn;
+  [|
+    eapply Run.Call; [
+      apply Run.Pure
+    |];
+    apply Run.LetUnfold;
+    s; [
+      eapply halt_oog_eq;
+      try eassumption
+    |];
+    cbn;
+    apply Run.Pure
+  ].
+
+Ltac gas_or_fail_macro_eq :=
+  step; [
+    gas_macro_eq idtac |
+    s; [
+      eapply halt_oog_eq;
+      try eassumption
+    |];
+    s
+  ].
 
 Lemma halt_underflow_eq {WIRE : Set} `{Link WIRE}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
@@ -627,67 +696,55 @@ Definition resize_memory_macro {WIRE K : Set} `{Link WIRE}
     (k_exit : Interpreter.t WIRE WIRE_types -> K)
     (k : Interpreter.t WIRE WIRE_types -> K) :
     K :=
-  let words_num := num_words (Impl_usize.saturating_add offset len) in
-  let ref_gas :=
-    IInterpreterTypes
-      .(InterpreterTypes.LoopControl_for_Control)
-      .(LoopControl.gas) in
-  let gas := ref_gas.(RefStub.projection) interpreter.(Interpreter.control) in
-  if i[words_num] >? i[gas.(Gas.memory).(MemoryGas.words_num)] then
-    let '(cost, memory_gas) := Impl_MemoryGas.record_new_len gas.(Gas.memory) words_num in
-    let gas := gas <| Gas.memory := memory_gas |> in
-    match cost with
-    | None =>
-      let control := ref_gas.(RefStub.injection) interpreter.(Interpreter.control) gas in
-      let control :=
-        IInterpreterTypes
-            .(InterpreterTypes.LoopControl_for_Control)
-            .(LoopControl.set_instruction_result)
-          control
-          instruction_result.InstructionResult.MemoryOOG in
-      let interpreter := interpreter <| Interpreter.control := control |> in
-      k_exit interpreter
-    | Some cost =>
-      match Impl_Gas.record_cost gas cost with
-      | None =>
-        let control := ref_gas.(RefStub.injection) interpreter.(Interpreter.control) gas in
-        let control :=
-          IInterpreterTypes
-              .(InterpreterTypes.LoopControl_for_Control)
-              .(LoopControl.set_instruction_result)
-            control
-            instruction_result.InstructionResult.MemoryOOG in
-        let interpreter := interpreter <| Interpreter.control := control |> in
-        k_exit interpreter
-      | Some gas =>
-        let interpreter :=
-          interpreter <| Interpreter.control :=
-            ref_gas.(RefStub.injection) interpreter.(Interpreter.control) gas
-          |> in
-        let '(_, memory) :=
-          IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory).(MemoryTrait.resize)
-            interpreter.(Interpreter.memory) (words_num *i 32) in
-        let interpreter := interpreter <| Interpreter.memory := memory |> in
-        k interpreter
-      end
-    end
+  let '(success, (gas, memory)) :=
+    @shared_memory.resize_memory
+      WIRE_types.(InterpreterTypes.Types.Memory)
+      WIRE_types.(InterpreterTypes.Types.Memory_Synthetic)
+      WIRE_types.(InterpreterTypes.Types.Memory_Synthetic1)
+      H0.(InterpreterTypes.Types.H_Memory)
+      H0.(InterpreterTypes.Types.H_Memory_Synthetic)
+      H0.(InterpreterTypes.Types.H_Memory_Synthetic1)
+      IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory)
+      interpreter.(Interpreter.gas)
+      interpreter.(Interpreter.memory)
+      offset
+      len in
+  let interpreter :=
+    interpreter
+      <| Interpreter.gas := gas |>
+      <| Interpreter.memory := memory |> in
+  if success then
+    k interpreter
   else
-    k interpreter.
+    k_exit (halt_memory_oog interpreter).
 
 Ltac resize_memory_macro_eq InterpreterTypesEq :=
   unfold resize_memory_macro;
   cbn;
-  repeat (apply Run.LetUnfold || cbn);
+  repeat (apply Run.LetUnfold || cbn || get_can_access);
   eapply Run.Call; [
-    apply Impl_usize.saturating_add_eq
+    eapply shared_memory.resize_memory_eq;
+    try eassumption
   |];
   cbn;
-  s; [
-    apply num_words_eq
-  |];
-  s; [
-    apply InterpreterTypesEq
-  |];
-  s; [
-    apply InterpreterTypesEq
-  |].
+  let success := fresh "success" in
+  let gas' := fresh "gas" in
+  let memory' := fresh "memory" in
+  match goal with
+  | |- context[shared_memory.resize_memory ?gas ?memory ?offset ?len] =>
+    destruct (shared_memory.resize_memory gas memory offset len) as [success [gas' memory']] eqn:?
+  end;
+  destruct success;
+  cbn;
+  repeat s;
+  try (eapply halt_memory_oog_eq; try eassumption);
+  repeat s;
+  try apply Impl_Bytes.new_eq;
+  try apply InterpreterTypesEq
+    .(InterpreterTypes.Eq.LoopControl_for_Bytecode)
+    .(LoopControl.BytecodeEq.set_action);
+  try (
+    repeat rewrite Stack.dealloc_alloc_eq;
+    repeat rewrite stack_dealloc_cons_alloc_unit;
+    reflexivity
+  ).

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
@@ -213,57 +213,6 @@ Ltac gas_or_fail_macro_eq :=
     s
   ].
 
-Lemma halt_underflow_eq {WIRE : Set} `{Link WIRE}
-    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
-    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
-    (InterpreterTypesEq :
-      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
-    (interpreter : Interpreter.t WIRE WIRE_types)
-    (stack_rest : Stack.t) :
-  let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
-  let action :=
-    interpreter_action.InterpreterAction.Return {|
-      InterpreterResult.result := instruction_result.InstructionResult.StackUnderflow;
-      InterpreterResult.output := Impl_Bytes.new;
-      InterpreterResult.gas := interpreter.(Interpreter.gas);
-    |} in
-  {{
-    SimulateM.eval_f
-      (Impl_Interpreter.run_halt_underflow WIRE ref_interpreter)
-      (interpreter :: stack_rest)%stack 🌲
-    (
-      Output.Success tt,
-      (
-        interpreter
-          <| Interpreter.bytecode :=
-            IInterpreterTypes
-              .(InterpreterTypes.LoopControl_for_Bytecode)
-              .(LoopControl.set_action)
-              interpreter.(Interpreter.bytecode)
-              action
-          |>
-        :: stack_rest
-      )%stack
-    )
-  }}.
-Proof.
-  intros.
-  with_strategy transparent [
-    Impl_Interpreter.run_halt_underflow
-    Impl_Interpreter.run_halt
-  ] unfold Impl_Interpreter.run_halt_underflow, Impl_Interpreter.run_halt.
-  cbn.
-  repeat s.
-  - apply Impl_Bytes.new_eq.
-  - apply InterpreterTypesEq
-      .(InterpreterTypes.Eq.LoopControl_for_Bytecode)
-      .(LoopControl.BytecodeEq.set_action).
-  - repeat rewrite Stack.dealloc_alloc_eq;
-    repeat rewrite stack_dealloc_cons_alloc_unit;
-    reflexivity.
-Qed.
-
 Ltac popn_top_macro_eq InterpreterTypesEq :=
   unfold popn_top_macro;
   s; [
@@ -512,9 +461,7 @@ Definition resize_memory_macro {WIRE K : Set} `{Link WIRE}
       WIRE_types.(InterpreterTypes.Types.Memory)
       WIRE_types.(InterpreterTypes.Types.Memory_Synthetic)
       WIRE_types.(InterpreterTypes.Types.Memory_Synthetic1)
-      H0.(InterpreterTypes.Types.H_Memory)
-      H0.(InterpreterTypes.Types.H_Memory_Synthetic)
-      H0.(InterpreterTypes.Types.H_Memory_Synthetic1)
+      _ _ _
       IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory)
       interpreter.(Interpreter.gas)
       interpreter.(Interpreter.memory)

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
@@ -457,12 +457,7 @@ Definition resize_memory_macro {WIRE K : Set} `{Link WIRE}
     (k : Interpreter.t WIRE WIRE_types -> K) :
     K :=
   let '(success, (gas, memory)) :=
-    @shared_memory.resize_memory
-      WIRE_types.(InterpreterTypes.Types.Memory)
-      WIRE_types.(InterpreterTypes.Types.Memory_Synthetic)
-      WIRE_types.(InterpreterTypes.Types.Memory_Synthetic1)
-      _ _ _
-      IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory)
+    shared_memory.resize_memory
       interpreter.(Interpreter.gas)
       interpreter.(Interpreter.memory)
       offset

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
@@ -11,6 +11,7 @@ Require Import revm.revm_interpreter.links.interpreter_action.
 Require Import revm.revm_interpreter.links.interpreter_InterpreterResult.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.gas.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import revm.revm_primitives.simulate.hardfork.
@@ -56,43 +57,6 @@ Ltac require_non_staticcall_macro_eq InterpreterTypesEq :=
     |];
     s
   |].
-
-Definition halt {WIRE : Set} `{Link WIRE}
-    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
-    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
-    (interpreter : Interpreter.t WIRE WIRE_types)
-    (result : instruction_result.InstructionResult.t) :
-    Interpreter.t WIRE WIRE_types :=
-  let action :=
-    interpreter_action.InterpreterAction.Return {|
-      InterpreterResult.result := result;
-      InterpreterResult.output := Impl_Bytes.new;
-      InterpreterResult.gas := interpreter.(Interpreter.gas);
-    |} in
-  interpreter
-    <| Interpreter.bytecode :=
-      IInterpreterTypes
-        .(InterpreterTypes.LoopControl_for_Bytecode)
-        .(LoopControl.set_action)
-        interpreter.(Interpreter.bytecode)
-        action
-    |>.
-
-Definition halt_oog {WIRE : Set} `{Link WIRE}
-    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
-    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
-    (interpreter : Interpreter.t WIRE WIRE_types) :
-    Interpreter.t WIRE WIRE_types :=
-  halt
-    (interpreter <| Interpreter.gas := Impl_Gas.spend_all interpreter.(Interpreter.gas) |>)
-    instruction_result.InstructionResult.OutOfGas.
-
-Definition halt_memory_oog {WIRE : Set} `{Link WIRE}
-    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
-    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
-    (interpreter : Interpreter.t WIRE WIRE_types) :
-    Interpreter.t WIRE WIRE_types :=
-  halt interpreter instruction_result.InstructionResult.MemoryOOG.
 
 Definition gas_macro {WIRE K : Set} `{Link WIRE}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
@@ -212,159 +176,6 @@ Definition popn_top_macro {WIRE K : Set} `{Link WIRE}
 	    | None =>
 	      k_exit interpreter
 	    end.
-
-Lemma stack_dealloc_cons_alloc_unit
-    (A : Set)
-    (value : A)
-    (stack : Stack.t) :
-  Stack.dealloc (value :: Stack.alloc stack tt)%stack =
-  (value :: stack)%stack.
-Proof.
-  revert A value.
-  induction stack as [|B head stack IH]; intros A value; cbn.
-  { reflexivity. }
-  {
-    replace
-      (match Stack.alloc stack tt with
-       | []%stack => []%stack
-       | (_ :: _)%stack => (head :: Stack.dealloc (Stack.alloc stack tt))%stack
-       end)
-      with (head :: stack)%stack.
-    - specialize (IH B head).
-      cbn in IH.
-      rewrite IH.
-      reflexivity.
-    - specialize (IH B head).
-      cbn in IH.
-      symmetry.
-      exact IH.
-  }
-Qed.
-
-Lemma halt_eq {WIRE : Set} `{Link WIRE}
-    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
-    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
-    (InterpreterTypesEq :
-      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
-    (interpreter : Interpreter.t WIRE WIRE_types)
-    (stack_rest : Stack.t)
-    (result : instruction_result.InstructionResult.t) :
-  let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
-  let action :=
-    interpreter_action.InterpreterAction.Return {|
-      InterpreterResult.result := result;
-      InterpreterResult.output := Impl_Bytes.new;
-      InterpreterResult.gas := interpreter.(Interpreter.gas);
-    |} in
-  {{
-    SimulateM.eval_f
-      (Impl_Interpreter.run_halt WIRE ref_interpreter result)
-      (interpreter :: stack_rest)%stack 🌲
-    (
-      Output.Success tt,
-      (
-        interpreter
-          <| Interpreter.bytecode :=
-            IInterpreterTypes
-              .(InterpreterTypes.LoopControl_for_Bytecode)
-              .(LoopControl.set_action)
-              interpreter.(Interpreter.bytecode)
-              action
-          |>
-        :: stack_rest
-      )%stack
-    )
-  }}.
-Proof.
-  intros.
-  with_strategy transparent [
-    Impl_Interpreter.run_halt
-  ] unfold Impl_Interpreter.run_halt.
-  cbn.
-  repeat s.
-  - apply Impl_Bytes.new_eq.
-  - apply InterpreterTypesEq
-      .(InterpreterTypes.Eq.LoopControl_for_Bytecode)
-      .(LoopControl.BytecodeEq.set_action).
-  - repeat rewrite Stack.dealloc_alloc_eq;
-    repeat rewrite stack_dealloc_cons_alloc_unit;
-    reflexivity.
-Qed.
-
-Lemma halt_oog_eq {WIRE : Set} `{Link WIRE}
-    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
-    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
-    (InterpreterTypesEq :
-      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
-    (interpreter : Interpreter.t WIRE WIRE_types)
-    (stack_rest : Stack.t) :
-  let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
-  {{
-    SimulateM.eval_f
-      (Impl_Interpreter.run_halt_oog WIRE ref_interpreter)
-      (interpreter :: stack_rest)%stack 🌲
-    (
-      Output.Success tt,
-      (halt_oog interpreter :: stack_rest)%stack
-    )
-  }}.
-Proof.
-  intros.
-  unfold halt_oog, halt.
-  with_strategy transparent [
-    Impl_Interpreter.run_halt_oog
-    Impl_Interpreter.run_halt
-  ] unfold Impl_Interpreter.run_halt_oog, Impl_Interpreter.run_halt.
-  cbn.
-  s.
-  - apply Impl_Gas.spend_all_interpreter_eq.
-  - repeat s.
-    + apply Impl_Bytes.new_eq.
-    + apply InterpreterTypesEq
-        .(InterpreterTypes.Eq.LoopControl_for_Bytecode)
-        .(LoopControl.BytecodeEq.set_action).
-    + repeat rewrite Stack.dealloc_alloc_eq;
-      repeat rewrite stack_dealloc_cons_alloc_unit;
-      reflexivity.
-Qed.
-
-Lemma halt_memory_oog_eq {WIRE : Set} `{Link WIRE}
-    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
-    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
-    (InterpreterTypesEq :
-      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
-    (interpreter : Interpreter.t WIRE WIRE_types)
-    (stack_rest : Stack.t) :
-  let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
-  {{
-    SimulateM.eval_f
-      (Impl_Interpreter.run_halt_memory_oog WIRE ref_interpreter)
-      (interpreter :: stack_rest)%stack 🌲
-    (
-      Output.Success tt,
-      (halt_memory_oog interpreter :: stack_rest)%stack
-    )
-  }}.
-Proof.
-  intros.
-  unfold halt_memory_oog, halt.
-  with_strategy transparent [
-    Impl_Interpreter.run_halt_memory_oog
-    Impl_Interpreter.run_halt
-  ] unfold Impl_Interpreter.run_halt_memory_oog, Impl_Interpreter.run_halt.
-  cbn.
-  repeat s.
-  - apply Impl_Bytes.new_eq.
-  - apply InterpreterTypesEq
-      .(InterpreterTypes.Eq.LoopControl_for_Bytecode)
-      .(LoopControl.BytecodeEq.set_action).
-  - repeat rewrite Stack.dealloc_alloc_eq;
-    repeat rewrite stack_dealloc_cons_alloc_unit;
-    reflexivity.
-Qed.
 
 Ltac gas_macro_eq gas_eq :=
   unfold gas_macro;

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/memory_resize.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/memory_resize.v
@@ -60,5 +60,4 @@ Proof.
   destruct (_ =? 0); [s|].
   as_usize_or_fail_macro_eq InterpreterTypesEq.
   resize_memory_macro_eq InterpreterTypesEq.
-  s; now destruct _.(MemoryTrait.resize).
 Qed.

--- a/RocqOfRust/revm/revm_interpreter/interpreter/simulate/shared_memory.v
+++ b/RocqOfRust/revm/revm_interpreter/interpreter/simulate/shared_memory.v
@@ -1,6 +1,12 @@
 Require Import simulate.RocqOfRust.
+Require Import core.simulate.option.
 Require Import core.num.simulate.mod.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
+Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.interpreter.
+Require Import revm.revm_interpreter.links.interpreter_types.
+Require Import revm.revm_interpreter.simulate.gas.
+Require Import revm.revm_interpreter.simulate.interpreter_types.
 
 Definition num_words (len : usize) : usize :=
   Impl_usize.saturating_add len 31 /i 32.
@@ -17,3 +23,98 @@ Proof.
   }
   s.
 Qed.
+
+Definition resize_memory_cold
+    {Memory Synthetic Synthetic1 : Set}
+    `{Link Memory} `{Link Synthetic} `{Link Synthetic1}
+    {IMemoryTrait : MemoryTrait.C Memory Synthetic Synthetic1}
+    (gas : Gas.t)
+    (memory : Memory)
+    (new_num_words : usize) :
+    bool * (Gas.t * Memory) :=
+  let '(cost, memory_gas) :=
+    Impl_MemoryGas.record_new_len gas.(Gas.memory) new_num_words in
+  let gas := gas <| Gas.memory := memory_gas |> in
+  match cost with
+  | None =>
+    (false, (gas, memory))
+  | Some cost =>
+    match Impl_Gas.record_cost gas cost with
+    | None =>
+      (false, (gas, memory))
+    | Some gas =>
+      let '(_, memory) :=
+        IMemoryTrait.(MemoryTrait.resize) memory (new_num_words *i 32) in
+      (true, (gas, memory))
+    end
+  end.
+
+Definition resize_memory
+    {Memory Synthetic Synthetic1 : Set}
+    `{Link Memory} `{Link Synthetic} `{Link Synthetic1}
+    {IMemoryTrait : MemoryTrait.C Memory Synthetic Synthetic1}
+    (gas : Gas.t)
+    (memory : Memory)
+    (offset len : usize) :
+    bool * (Gas.t * Memory) :=
+  let new_num_words := num_words (Impl_usize.saturating_add offset len) in
+  if i[new_num_words] >? i[gas.(Gas.memory).(MemoryGas.words_num)] then
+    @resize_memory_cold
+      Memory Synthetic Synthetic1 H H0 H1 IMemoryTrait gas memory new_num_words
+  else
+    (true, (gas, memory)).
+
+Lemma resize_memory_eq
+    {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (InterpreterTypesEq :
+      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (offset len : usize)
+    (stack : Stack.t) :
+  let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+  let ref_gas : '&mut Gas.t := {| Ref.core :=
+    SubPointer.Runner.apply
+      ref_interpreter.(Ref.core)
+      Interpreter.SubPointer.get_gas
+  |} in
+  let ref_memory : '&mut WIRE_types.(InterpreterTypes.Types.Memory) := {| Ref.core :=
+    SubPointer.Runner.apply
+      ref_interpreter.(Ref.core)
+      Interpreter.SubPointer.get_memory
+  |} in
+  let result :=
+    @resize_memory
+      WIRE_types.(InterpreterTypes.Types.Memory)
+      WIRE_types.(InterpreterTypes.Types.Memory_Synthetic)
+      WIRE_types.(InterpreterTypes.Types.Memory_Synthetic1)
+      H0.(InterpreterTypes.Types.H_Memory)
+      H0.(InterpreterTypes.Types.H_Memory_Synthetic)
+      H0.(InterpreterTypes.Types.H_Memory_Synthetic1)
+      IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory)
+      interpreter.(Interpreter.gas)
+      interpreter.(Interpreter.memory)
+      offset
+      len in
+  {{
+    SimulateM.eval_f
+      (run_resize_memory
+        run_InterpreterTypes_for_WIRE.(InterpreterTypes.run_MemoryTrait_for_Memory)
+        ref_gas
+        ref_memory
+        offset
+        len)
+      (interpreter :: stack)%stack 🌲
+    (
+      Output.Success (fst result),
+      (
+        interpreter
+          <| Interpreter.gas := fst (snd result) |>
+          <| Interpreter.memory := snd (snd result) |>
+        :: stack
+      )%stack
+    )
+  }}.
+Admitted.

--- a/RocqOfRust/revm/revm_interpreter/interpreter/simulate/shared_memory.v
+++ b/RocqOfRust/revm/revm_interpreter/interpreter/simulate/shared_memory.v
@@ -90,9 +90,7 @@ Lemma resize_memory_cold_eq
       WIRE_types.(InterpreterTypes.Types.Memory)
       WIRE_types.(InterpreterTypes.Types.Memory_Synthetic)
       WIRE_types.(InterpreterTypes.Types.Memory_Synthetic1)
-      H0.(InterpreterTypes.Types.H_Memory)
-      H0.(InterpreterTypes.Types.H_Memory_Synthetic)
-      H0.(InterpreterTypes.Types.H_Memory_Synthetic1)
+      _ _ _
       IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory)
       interpreter.(Interpreter.gas)
       interpreter.(Interpreter.memory)
@@ -143,9 +141,7 @@ Lemma resize_memory_eq
       WIRE_types.(InterpreterTypes.Types.Memory)
       WIRE_types.(InterpreterTypes.Types.Memory_Synthetic)
       WIRE_types.(InterpreterTypes.Types.Memory_Synthetic1)
-      H0.(InterpreterTypes.Types.H_Memory)
-      H0.(InterpreterTypes.Types.H_Memory_Synthetic)
-      H0.(InterpreterTypes.Types.H_Memory_Synthetic1)
+      _ _ _
       IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory)
       interpreter.(Interpreter.gas)
       interpreter.(Interpreter.memory)

--- a/RocqOfRust/revm/revm_interpreter/interpreter/simulate/shared_memory.v
+++ b/RocqOfRust/revm/revm_interpreter/interpreter/simulate/shared_memory.v
@@ -25,13 +25,12 @@ Proof.
 Qed.
 
 Definition resize_memory_cold
-    {Memory Synthetic Synthetic1 : Set}
-    `{Link Memory} `{Link Synthetic} `{Link Synthetic1}
-    {IMemoryTrait : MemoryTrait.C Memory Synthetic Synthetic1}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    `{IInterpreterTypes : ! InterpreterTypes.C WIRE_types}
     (gas : Gas.t)
-    (memory : Memory)
+    (memory : WIRE_types.(InterpreterTypes.Types.Memory))
     (new_num_words : usize) :
-    bool * (Gas.t * Memory) :=
+    bool * (Gas.t * WIRE_types.(InterpreterTypes.Types.Memory)) :=
   let '(cost, memory_gas) :=
     Impl_MemoryGas.record_new_len gas.(Gas.memory) new_num_words in
   let gas := gas <| Gas.memory := memory_gas |> in
@@ -44,23 +43,25 @@ Definition resize_memory_cold
       (false, (gas, memory))
     | Some gas =>
       let '(_, memory) :=
-        IMemoryTrait.(MemoryTrait.resize) memory (new_num_words *i 32) in
+        IInterpreterTypes
+          .(InterpreterTypes.MemoryTrait_for_Memory)
+          .(MemoryTrait.resize)
+          memory
+          (new_num_words *i 32) in
       (true, (gas, memory))
     end
   end.
 
 Definition resize_memory
-    {Memory Synthetic Synthetic1 : Set}
-    `{Link Memory} `{Link Synthetic} `{Link Synthetic1}
-    {IMemoryTrait : MemoryTrait.C Memory Synthetic Synthetic1}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    `{IInterpreterTypes : ! InterpreterTypes.C WIRE_types}
     (gas : Gas.t)
-    (memory : Memory)
+    (memory : WIRE_types.(InterpreterTypes.Types.Memory))
     (offset len : usize) :
-    bool * (Gas.t * Memory) :=
+    bool * (Gas.t * WIRE_types.(InterpreterTypes.Types.Memory)) :=
   let new_num_words := num_words (Impl_usize.saturating_add offset len) in
   if i[new_num_words] >? i[gas.(Gas.memory).(MemoryGas.words_num)] then
-    @resize_memory_cold
-      Memory Synthetic Synthetic1 H H0 H1 IMemoryTrait gas memory new_num_words
+    resize_memory_cold gas memory new_num_words
   else
     (true, (gas, memory)).
 
@@ -86,12 +87,7 @@ Lemma resize_memory_cold_eq
       Interpreter.SubPointer.get_memory
   |} in
   let result :=
-    @resize_memory_cold
-      WIRE_types.(InterpreterTypes.Types.Memory)
-      WIRE_types.(InterpreterTypes.Types.Memory_Synthetic)
-      WIRE_types.(InterpreterTypes.Types.Memory_Synthetic1)
-      _ _ _
-      IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory)
+    resize_memory_cold
       interpreter.(Interpreter.gas)
       interpreter.(Interpreter.memory)
       new_num_words in
@@ -137,12 +133,7 @@ Lemma resize_memory_eq
       Interpreter.SubPointer.get_memory
   |} in
   let result :=
-    @resize_memory
-      WIRE_types.(InterpreterTypes.Types.Memory)
-      WIRE_types.(InterpreterTypes.Types.Memory_Synthetic)
-      WIRE_types.(InterpreterTypes.Types.Memory_Synthetic1)
-      _ _ _
-      IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory)
+    resize_memory
       interpreter.(Interpreter.gas)
       interpreter.(Interpreter.memory)
       offset

--- a/RocqOfRust/revm/revm_interpreter/interpreter/simulate/shared_memory.v
+++ b/RocqOfRust/revm/revm_interpreter/interpreter/simulate/shared_memory.v
@@ -64,11 +64,64 @@ Definition resize_memory
   else
     (true, (gas, memory)).
 
+Lemma resize_memory_cold_eq
+    {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+    `{IInterpreterTypes : ! InterpreterTypes.C WIRE_types}
+    (InterpreterTypesEq :
+      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (new_num_words : usize)
+    (stack : Stack.t) :
+  let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+  let ref_gas : '&mut Gas.t := {| Ref.core :=
+    SubPointer.Runner.apply
+      ref_interpreter.(Ref.core)
+      Interpreter.SubPointer.get_gas
+  |} in
+  let ref_memory : '&mut WIRE_types.(InterpreterTypes.Types.Memory) := {| Ref.core :=
+    SubPointer.Runner.apply
+      ref_interpreter.(Ref.core)
+      Interpreter.SubPointer.get_memory
+  |} in
+  let result :=
+    @resize_memory_cold
+      WIRE_types.(InterpreterTypes.Types.Memory)
+      WIRE_types.(InterpreterTypes.Types.Memory_Synthetic)
+      WIRE_types.(InterpreterTypes.Types.Memory_Synthetic1)
+      H0.(InterpreterTypes.Types.H_Memory)
+      H0.(InterpreterTypes.Types.H_Memory_Synthetic)
+      H0.(InterpreterTypes.Types.H_Memory_Synthetic1)
+      IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory)
+      interpreter.(Interpreter.gas)
+      interpreter.(Interpreter.memory)
+      new_num_words in
+  {{
+    SimulateM.eval_f
+      (run_resize_memory_cold
+        run_InterpreterTypes_for_WIRE.(InterpreterTypes.run_MemoryTrait_for_Memory)
+        ref_gas
+        ref_memory
+        new_num_words)
+      (interpreter :: stack)%stack 🌲
+    (
+      Output.Success (fst result),
+      (
+        interpreter
+          <| Interpreter.gas := fst (snd result) |>
+          <| Interpreter.memory := snd (snd result) |>
+        :: stack
+      )%stack
+    )
+  }}.
+Admitted.
+
 Lemma resize_memory_eq
     {WIRE : Set} `{Link WIRE}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    `{IInterpreterTypes : ! InterpreterTypes.C WIRE_types}
     (InterpreterTypesEq :
       InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
     (interpreter : Interpreter.t WIRE WIRE_types)

--- a/RocqOfRust/revm/revm_interpreter/links/interpreter.v
+++ b/RocqOfRust/revm/revm_interpreter/links/interpreter.v
@@ -67,6 +67,23 @@ Module Impl_Interpreter.
   Defined.
   Global Opaque run_halt.
 
+  (* pub fn halt_oog(&mut self) *)
+  Instance run_halt_oog
+      (IW : Set) `{Link IW}
+      {IW_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks IW_types}
+      {run_InterpreterTypes_for_IW : InterpreterTypes.Run IW IW_types}
+      (self : '&mut (Self IW run_InterpreterTypes_for_IW)) :
+    Run.Trait
+      (interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_oog (Φ IW))
+      [] [] [φ self]
+      unit.
+  Proof.
+    constructor.
+    run_symbolic.
+    eapply (@run_halt IW H IW_types H0 run_InterpreterTypes_for_IW).
+  Defined.
+  Global Opaque run_halt_oog.
+
   (* pub fn halt_underflow(&mut self) *)
   Instance run_halt_underflow
       (IW : Set) `{Link IW}

--- a/RocqOfRust/revm/revm_interpreter/simulate/gas.v
+++ b/RocqOfRust/revm/revm_interpreter/simulate/gas.v
@@ -145,6 +145,54 @@ Module Impl_Gas.
     }}.
   Admitted.
 
+  Lemma memory_interpreter_eq
+      {WIRE : Set} `{Link WIRE}
+      {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+      (interpreter : Interpreter.t WIRE WIRE_types)
+      (stack : Stack.t) :
+    let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+    let ref_self : '& _ := {| Ref.core :=
+        SubPointer.Runner.apply
+          ref_interpreter.(Ref.core)
+          Interpreter.SubPointer.get_gas
+    |} in
+    {{
+      SimulateM.eval_f (Impl_Gas.run_memory ref_self) (interpreter :: stack)%stack 🌲
+      (
+        Output.Success (RefStub.apply ref_self memory),
+        (interpreter :: stack)%stack
+      )
+    }}.
+  Proof.
+    apply Run.remove_extra_stack1.
+    with_strategy transparent [Impl_Gas.run_memory] cbn.
+    s.
+  Qed.
+
+  Lemma memory_mut_interpreter_eq
+      {WIRE : Set} `{Link WIRE}
+      {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+      (interpreter : Interpreter.t WIRE WIRE_types)
+      (stack : Stack.t) :
+    let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+    let ref_self : '&mut _ := {| Ref.core :=
+        SubPointer.Runner.apply
+          ref_interpreter.(Ref.core)
+          Interpreter.SubPointer.get_gas
+    |} in
+    {{
+      SimulateM.eval_f (Impl_Gas.run_memory_mut ref_self) (interpreter :: stack)%stack 🌲
+      (
+        Output.Success (RefStub.apply ref_self memory),
+        (interpreter :: stack)%stack
+      )
+    }}.
+  Proof.
+    apply Run.remove_extra_stack1.
+    with_strategy transparent [Impl_Gas.run_memory_mut] cbn.
+    s.
+  Qed.
+
   Definition refunded (self : Self) : i64 :=
     self.(Gas.refunded).
 
@@ -309,6 +357,33 @@ Module Impl_Gas.
           (interpreter <| Interpreter.control :=
             gas_stub.(RefStub.injection) interpreter.(Interpreter.control) result
           |>) :: stack
+        )%stack
+      )
+    }}.
+  Proof.
+    apply Run.remove_extra_stack1.
+    with_strategy transparent [Impl_Gas.run_spend_all] cbn.
+    s.
+  Qed.
+
+  Lemma spend_all_interpreter_eq
+      {WIRE : Set} `{Link WIRE}
+      {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+      (interpreter : Interpreter.t WIRE WIRE_types)
+      (stack : Stack.t) :
+    let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+    let ref_self : '&mut _ := {| Ref.core :=
+        SubPointer.Runner.apply
+          ref_interpreter.(Ref.core)
+          Interpreter.SubPointer.get_gas
+    |} in
+    let result := spend_all interpreter.(Interpreter.gas) in
+    {{
+      SimulateM.eval_f (Impl_Gas.run_spend_all ref_self) (interpreter :: stack)%stack 🌲
+      (
+        Output.Success tt,
+        (
+          (interpreter <| Interpreter.gas := result |>) :: stack
         )%stack
       )
     }}.
@@ -485,6 +560,50 @@ Module Impl_Gas.
     { destruct (Impl_u64.checked_sub
         (gas_stub.(RefStub.projection) interpreter.(Interpreter.control)).(Gas.remaining)
         cost); cbn.
+      { s. }
+      { repeat (lu || p). }
+    }
+  Qed.
+
+  Lemma record_cost_interpreter_eq
+      {WIRE : Set} `{Link WIRE}
+      {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+      (interpreter : Interpreter.t WIRE WIRE_types)
+      (cost : u64)
+      (stack : Stack.t) :
+    let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+    let ref_self : '&mut _ := {| Ref.core :=
+        SubPointer.Runner.apply
+          ref_interpreter.(Ref.core)
+          Interpreter.SubPointer.get_gas
+    |} in
+    let result := record_cost interpreter.(Interpreter.gas) cost in
+    {{
+      SimulateM.eval_f (Impl_Gas.run_record_cost ref_self cost) (interpreter :: stack)%stack 🌲
+      (
+        Output.Success (
+          match result with
+          | None => false
+          | Some _ => true
+          end
+        ),
+        (
+          match result with
+          | None => interpreter
+          | Some gas => interpreter <| Interpreter.gas := gas |>
+          end :: stack
+        )%stack
+      )
+    }}.
+  Proof.
+    apply Run.remove_extra_stack1.
+    with_strategy transparent [Impl_Gas.run_record_cost] (
+      unfold record_cost;
+      cbn
+    ).
+    s.
+    { apply Impl_u64.checked_sub_eq. }
+    { destruct (Impl_u64.checked_sub interpreter.(Interpreter.gas).(Gas.remaining) cost); cbn.
       { s. }
       { repeat (lu || p). }
     }

--- a/RocqOfRust/revm/revm_interpreter/simulate/interpreter.v
+++ b/RocqOfRust/revm/revm_interpreter/simulate/interpreter.v
@@ -1,0 +1,199 @@
+Require Import simulate.RocqOfRust.
+Require Import alloy_primitives.bytes.simulate.mod.
+Require Import revm.revm_interpreter.links.instruction_result.
+Require Import revm.revm_interpreter.links.interpreter.
+Require Import revm.revm_interpreter.links.interpreter_action.
+Require Import revm.revm_interpreter.links.interpreter_InterpreterResult.
+Require Import revm.revm_interpreter.links.interpreter_types.
+Require Import revm.revm_interpreter.simulate.gas.
+Require Import revm.revm_interpreter.simulate.interpreter_types.
+
+Definition halt {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (result : instruction_result.InstructionResult.t) :
+    Interpreter.t WIRE WIRE_types :=
+  let action :=
+    interpreter_action.InterpreterAction.Return {|
+      InterpreterResult.result := result;
+      InterpreterResult.output := Impl_Bytes.new;
+      InterpreterResult.gas := interpreter.(Interpreter.gas);
+    |} in
+  interpreter
+    <| Interpreter.bytecode :=
+      IInterpreterTypes
+        .(InterpreterTypes.LoopControl_for_Bytecode)
+        .(LoopControl.set_action)
+        interpreter.(Interpreter.bytecode)
+        action
+    |>.
+
+Definition halt_oog {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (interpreter : Interpreter.t WIRE WIRE_types) :
+    Interpreter.t WIRE WIRE_types :=
+  halt
+    (interpreter <| Interpreter.gas := Impl_Gas.spend_all interpreter.(Interpreter.gas) |>)
+    instruction_result.InstructionResult.OutOfGas.
+
+Definition halt_memory_oog {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (interpreter : Interpreter.t WIRE WIRE_types) :
+    Interpreter.t WIRE WIRE_types :=
+  halt interpreter instruction_result.InstructionResult.MemoryOOG.
+
+Lemma stack_dealloc_cons_alloc_unit
+    (A : Set)
+    (value : A)
+    (stack : Stack.t) :
+  Stack.dealloc (value :: Stack.alloc stack tt)%stack =
+  (value :: stack)%stack.
+Proof.
+  revert A value.
+  induction stack as [|B head stack IH]; intros A value; cbn.
+  { reflexivity. }
+  {
+    replace
+      (match Stack.alloc stack tt with
+       | []%stack => []%stack
+       | (_ :: _)%stack => (head :: Stack.dealloc (Stack.alloc stack tt))%stack
+       end)
+      with (head :: stack)%stack.
+    - specialize (IH B head).
+      cbn in IH.
+      rewrite IH.
+      reflexivity.
+    - specialize (IH B head).
+      cbn in IH.
+      symmetry.
+      exact IH.
+  }
+Qed.
+
+Lemma halt_eq {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (InterpreterTypesEq :
+      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (stack_rest : Stack.t)
+    (result : instruction_result.InstructionResult.t) :
+  let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+  let action :=
+    interpreter_action.InterpreterAction.Return {|
+      InterpreterResult.result := result;
+      InterpreterResult.output := Impl_Bytes.new;
+      InterpreterResult.gas := interpreter.(Interpreter.gas);
+    |} in
+  {{
+    SimulateM.eval_f
+      (Impl_Interpreter.run_halt WIRE ref_interpreter result)
+      (interpreter :: stack_rest)%stack 🌲
+    (
+      Output.Success tt,
+      (
+        interpreter
+          <| Interpreter.bytecode :=
+            IInterpreterTypes
+              .(InterpreterTypes.LoopControl_for_Bytecode)
+              .(LoopControl.set_action)
+              interpreter.(Interpreter.bytecode)
+              action
+          |>
+        :: stack_rest
+      )%stack
+    )
+  }}.
+Proof.
+  intros.
+  with_strategy transparent [
+    Impl_Interpreter.run_halt
+  ] unfold Impl_Interpreter.run_halt.
+  cbn.
+  repeat s.
+  - apply Impl_Bytes.new_eq.
+  - apply InterpreterTypesEq
+      .(InterpreterTypes.Eq.LoopControl_for_Bytecode)
+      .(LoopControl.BytecodeEq.set_action).
+  - repeat rewrite Stack.dealloc_alloc_eq;
+    repeat rewrite stack_dealloc_cons_alloc_unit;
+    reflexivity.
+Qed.
+
+Lemma halt_oog_eq {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (InterpreterTypesEq :
+      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (stack_rest : Stack.t) :
+  let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+  {{
+    SimulateM.eval_f
+      (Impl_Interpreter.run_halt_oog WIRE ref_interpreter)
+      (interpreter :: stack_rest)%stack 🌲
+    (
+      Output.Success tt,
+      (halt_oog interpreter :: stack_rest)%stack
+    )
+  }}.
+Proof.
+  intros.
+  unfold halt_oog, halt.
+  with_strategy transparent [
+    Impl_Interpreter.run_halt_oog
+    Impl_Interpreter.run_halt
+  ] unfold Impl_Interpreter.run_halt_oog, Impl_Interpreter.run_halt.
+  cbn.
+  s.
+  - apply Impl_Gas.spend_all_interpreter_eq.
+  - repeat s.
+    + apply Impl_Bytes.new_eq.
+    + apply InterpreterTypesEq
+        .(InterpreterTypes.Eq.LoopControl_for_Bytecode)
+        .(LoopControl.BytecodeEq.set_action).
+    + repeat rewrite Stack.dealloc_alloc_eq;
+      repeat rewrite stack_dealloc_cons_alloc_unit;
+      reflexivity.
+Qed.
+
+Lemma halt_memory_oog_eq {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (InterpreterTypesEq :
+      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (stack_rest : Stack.t) :
+  let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+  {{
+    SimulateM.eval_f
+      (Impl_Interpreter.run_halt_memory_oog WIRE ref_interpreter)
+      (interpreter :: stack_rest)%stack 🌲
+    (
+      Output.Success tt,
+      (halt_memory_oog interpreter :: stack_rest)%stack
+    )
+  }}.
+Proof.
+  intros.
+  unfold halt_memory_oog, halt.
+  with_strategy transparent [
+    Impl_Interpreter.run_halt_memory_oog
+    Impl_Interpreter.run_halt
+  ] unfold Impl_Interpreter.run_halt_memory_oog, Impl_Interpreter.run_halt.
+  cbn.
+  repeat s.
+  - apply Impl_Bytes.new_eq.
+  - apply InterpreterTypesEq
+      .(InterpreterTypes.Eq.LoopControl_for_Bytecode)
+      .(LoopControl.BytecodeEq.set_action).
+  - repeat rewrite Stack.dealloc_alloc_eq;
+    repeat rewrite stack_dealloc_cons_alloc_unit;
+    reflexivity.
+Qed.

--- a/RocqOfRust/revm/revm_interpreter/simulate/interpreter.v
+++ b/RocqOfRust/revm/revm_interpreter/simulate/interpreter.v
@@ -162,6 +162,57 @@ Proof.
       reflexivity.
 Qed.
 
+Lemma halt_underflow_eq {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (InterpreterTypesEq :
+      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (stack_rest : Stack.t) :
+  let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+  let action :=
+    interpreter_action.InterpreterAction.Return {|
+      InterpreterResult.result := instruction_result.InstructionResult.StackUnderflow;
+      InterpreterResult.output := Impl_Bytes.new;
+      InterpreterResult.gas := interpreter.(Interpreter.gas);
+    |} in
+  {{
+    SimulateM.eval_f
+      (Impl_Interpreter.run_halt_underflow WIRE ref_interpreter)
+      (interpreter :: stack_rest)%stack 🌲
+    (
+      Output.Success tt,
+      (
+        interpreter
+          <| Interpreter.bytecode :=
+            IInterpreterTypes
+              .(InterpreterTypes.LoopControl_for_Bytecode)
+              .(LoopControl.set_action)
+              interpreter.(Interpreter.bytecode)
+              action
+          |>
+        :: stack_rest
+      )%stack
+    )
+  }}.
+Proof.
+  intros.
+  with_strategy transparent [
+    Impl_Interpreter.run_halt_underflow
+    Impl_Interpreter.run_halt
+  ] unfold Impl_Interpreter.run_halt_underflow, Impl_Interpreter.run_halt.
+  cbn.
+  repeat s.
+  - apply Impl_Bytes.new_eq.
+  - apply InterpreterTypesEq
+      .(InterpreterTypes.Eq.LoopControl_for_Bytecode)
+      .(LoopControl.BytecodeEq.set_action).
+  - repeat rewrite Stack.dealloc_alloc_eq;
+    repeat rewrite stack_dealloc_cons_alloc_unit;
+    reflexivity.
+Qed.
+
 Lemma halt_memory_oog_eq {WIRE : Set} `{Link WIRE}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)


### PR DESCRIPTION
This PR continues the Revm v103 small compile-slice work after the memory expansion macro update.

It focuses on the memory resize helper path, adapting it to the current v103 structure where resizing goes through the shared-memory helper and the interpreter's direct gas field.

Local check:
- `make -k revm/revm_interpreter/instructions/simulate/system/memory_resize.vo`

The fake-body scan is clean. No local translated bodies or wrong-argument stubs were added.

There is one focused admitted `_eq` bridge for the shared-memory resize helper, kept at that helper boundary so this PR does not expand into the lower memory-gas proof work.