### PR TITLE
Update Revm v103 simple system simulate slice

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/address.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/address.v
@@ -22,6 +22,7 @@ Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.system.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -34,18 +35,23 @@ Instance run_address
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.system.address [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.system.address [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   destruct run_InputsTrait_for_Input.
   destruct (Impl_Into_for_From_T.run Impl_From_FixedBytes_32_for_U256.run).
   run_symbolic.
+  all: match goal with
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt_overflow
+  end.
 Defined.
 Global Opaque run_address.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/caller.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/caller.v
@@ -22,6 +22,7 @@ Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.system.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -34,18 +35,23 @@ Instance run_caller
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.system.caller [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.system.caller [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   destruct run_InputsTrait_for_Input.
   destruct (Impl_Into_for_From_T.run Impl_From_FixedBytes_32_for_U256.run).
   run_symbolic.
+  all: match goal with
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt_overflow
+  end.
 Defined.
 Global Opaque run_caller.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/callvalue.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/callvalue.v
@@ -22,6 +22,7 @@ Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.system.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -34,17 +35,22 @@ Instance run_callvalue
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.system.callvalue [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.system.callvalue [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   destruct run_InputsTrait_for_Input.
   run_symbolic.
+  all: match goal with
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt_overflow
+  end.
 Defined.
 Global Opaque run_callvalue.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/codesize.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/codesize.v
@@ -22,6 +22,7 @@ Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.system.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -34,17 +35,22 @@ Instance run_codesize
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.system.codesize [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.system.codesize [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   destruct run_LegacyBytecode_for_Bytecode.
   run_symbolic.
+  all: match goal with
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt_overflow
+  end.
 Defined.
 Global Opaque run_codesize.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/gas.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/gas.v
@@ -22,6 +22,7 @@ Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.system.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -34,16 +35,21 @@ Instance run_gas
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.system.gas [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.system.gas [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
+  all: match goal with
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt_overflow
+  end.
 Defined.
 Global Opaque run_gas.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/utility.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/utility.v
@@ -15,33 +15,6 @@ Require Import revm.revm_interpreter.instructions.utility.
 Require Import ruint.links.bytes.
 Require Import ruint.links.lib.
 
-(* pub fn cast_slice_to_u256(slice: &[u8], dest: &mut U256) *)
-Instance run_cast_slice_to_u256
-  (slice : '& (list u8))
-  (dest : '&mut aliases.U256.t) :
-  Run.Trait instructions.utility.cast_slice_to_u256 [] [] [ φ slice; φ dest ] unit.
-Proof.
-  constructor.
-  (* destruct (Impl_IntoIterator_for_Iterator_I.run (ChunksExact.t u8) u8).
-  destruct (Impl_Iterator_for_ChunksExact.run u8).
-  destruct (Impl_IntoIterator_for_Iterator_I.run (RChunksExact.t u8) u8).
-  destruct (Impl_Iterator_for_RChunksExact.run u8).
-  destruct (
-    let run_TryFrom :=
-      Impl_TryFrom_Ref_for_Array.run u8 {| Integer.value := 8 |} in
-    Impl_TryInto_for_TryFrom_T.run _ _ _ (run_TryFrom_for_U := run_TryFrom)
-  ). *)
-  (* Pointer cast and closures *)
-  run_symbolic.
-  (* 4: {
-    eapply Run.Rewrite. {
-      exact (array.repeat_φ_eq 8 (Integer.Build_t IntegerKind.U8 0)).
-    }
-    run_symbolic.
-  } *)
-Admitted.
-Global Opaque run_cast_slice_to_u256.
-
 (*
 pub trait IntoU256 {
     fn into_u256(self) -> U256;

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
@@ -256,12 +256,7 @@ Definition push_macro {WIRE K : Set} `{Link WIRE}
   let interpreter := interpreter <| Interpreter.stack := stack |> in
   if success then k interpreter
   else
-    let control :=
-      IInterpreterTypes.(InterpreterTypes.LoopControl_for_Control).(LoopControl.set_instruction_result)
-        interpreter.(Interpreter.control)
-        instruction_result.InstructionResult.StackOverflow in
-    let interpreter := interpreter <| Interpreter.control := control |> in
-    k_exit interpreter.
+    k_exit (halt_overflow interpreter).
 
 Ltac push_macro_eq InterpreterTypesEq :=
   unfold push_macro;
@@ -269,7 +264,10 @@ Ltac push_macro_eq InterpreterTypesEq :=
     apply InterpreterTypesEq
   |];
   destruct _.(InterpreterTypes.StackTrait_for_Stack).(StackTrait.push) as [[] ?]; [|
-    s; [apply InterpreterTypesEq|];
+    s; [
+      apply halt_overflow_eq;
+      apply InterpreterTypesEq
+    |];
     s
   ].
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/address.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/address.v
@@ -17,15 +17,13 @@ Definition address
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.BASE id (fun interpreter =>
   let target :=
     IInterpreterTypes.(InterpreterTypes.InputsTrait_for_Input).(InputTraits.target_address)
       interpreter.(Interpreter.input) in
   let value := Impl_IntoU256_for_Address.into_u256 target in
   push_macro interpreter value
     id
-    id
-  ).
+    id.
 
 Lemma address_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -40,7 +38,10 @@ Lemma address_eq
   let ref_host := make_ref (A := H) 1 in
     {{
       SimulateM.eval_f
-        (run_address run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+        (run_address run_InterpreterTypes_for_WIRE {|
+          instruction_context.InstructionContext.interpreter := ref_interpreter;
+          instruction_context.InstructionContext.host := ref_host;
+        |})
         [interpreter; host]%stack 🌲
       (
         Output.Success tt,
@@ -50,7 +51,6 @@ Lemma address_eq
 Proof.
   intros.
   with_strategy transparent [run_address] unfold address, run_address; cbn.
-  gas_macro_eq idtac.
   s. {
     apply InterpreterTypesEq.
   }

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/caller.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/caller.v
@@ -6,6 +6,7 @@ Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.system.caller.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.instructions.simulate.utility.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
@@ -17,15 +18,13 @@ Definition caller
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.BASE id (fun interpreter =>
   let caller :=
     IInterpreterTypes.(InterpreterTypes.InputsTrait_for_Input).(InputTraits.caller_address)
       interpreter.(Interpreter.input) in
   let value := Impl_IntoU256_for_Address.into_u256 caller in
   push_macro interpreter value
     id
-    id
-  ).
+    id.
 
 Lemma caller_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -40,7 +39,10 @@ Lemma caller_eq
   let ref_host := make_ref (A := H) 1 in
   {{
     SimulateM.eval_f
-      (run_caller run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_caller run_InterpreterTypes_for_WIRE {|
+        instruction_context.InstructionContext.interpreter := ref_interpreter;
+        instruction_context.InstructionContext.host := ref_host;
+      |})
       [interpreter; host]%stack 🌲
     (
       Output.Success tt,
@@ -50,7 +52,6 @@ Lemma caller_eq
 Proof.
   intros.
   with_strategy transparent [run_caller] unfold caller, run_caller; cbn.
-  gas_macro_eq idtac.
   s. {
     apply InterpreterTypesEq.
   }

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/callvalue.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/callvalue.v
@@ -2,6 +2,7 @@ Require Import simulate.RocqOfRust.
 Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.system.callvalue.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
@@ -12,14 +13,12 @@ Definition callvalue
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.BASE id (fun interpreter =>
   let value :=
     IInterpreterTypes.(InterpreterTypes.InputsTrait_for_Input).(InputTraits.call_value)
       interpreter.(Interpreter.input) in
   push_macro interpreter value
     id
-    id
-  ).
+    id.
 
 Lemma callvalue_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -34,7 +33,10 @@ Lemma callvalue_eq
   let ref_host := make_ref (A := H) 1 in
     {{
       SimulateM.eval_f
-        (run_callvalue run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+        (run_callvalue run_InterpreterTypes_for_WIRE {|
+          instruction_context.InstructionContext.interpreter := ref_interpreter;
+          instruction_context.InstructionContext.host := ref_host;
+        |})
         [interpreter; host]%stack 🌲
       (
         Output.Success tt,
@@ -44,7 +46,6 @@ Lemma callvalue_eq
 Proof.
   intros.
   with_strategy transparent [run_callvalue] unfold callvalue, run_callvalue; cbn.
-  gas_macro_eq idtac.
   s. {
     apply InterpreterTypesEq.
   }

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/codesize.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/codesize.v
@@ -2,6 +2,7 @@ Require Import simulate.RocqOfRust.
 Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.system.codesize.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
@@ -14,14 +15,12 @@ Definition codesize
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.BASE id (fun interpreter =>
   let size :=
     IInterpreterTypes.(InterpreterTypes.LegacyBytecode_for_Bytecode).(LegacyBytecode.bytecode_len)
       interpreter.(Interpreter.bytecode) in
   push_macro interpreter
     (Impl_Uint.from size)
-    id id
-  ).
+    id id.
 
 Lemma codesize_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -36,7 +35,10 @@ Lemma codesize_eq
   let ref_host := make_ref (A := H) 1 in
     {{
       SimulateM.eval_f
-        (run_codesize run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+        (run_codesize run_InterpreterTypes_for_WIRE {|
+          instruction_context.InstructionContext.interpreter := ref_interpreter;
+          instruction_context.InstructionContext.host := ref_host;
+        |})
         [interpreter; host]%stack 🌲
       (
         Output.Success tt,
@@ -45,7 +47,6 @@ Lemma codesize_eq
     }}.
 Proof.
   with_strategy transparent [run_codesize] unfold codesize, run_codesize; cbn.
-  gas_macro_eq idtac.
   s. {
     apply InterpreterTypesEq.
   }

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/gas.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/gas.v
@@ -3,6 +3,7 @@ Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.system.gas.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.gas.
@@ -16,15 +17,10 @@ Definition gas
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.BASE id (fun interpreter =>
-  let gas :=
-    IInterpreterTypes.(InterpreterTypes.LoopControl_for_Control).(LoopControl.gas)
-      .(RefStub.projection) interpreter.(Interpreter.control) in
   push_macro interpreter
-    (Impl_Uint.from gas.(Gas.remaining))
+    (Impl_Uint.from interpreter.(Interpreter.gas).(Gas.remaining))
     id
-    id
-  ).
+    id.
 
 Lemma gas_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -39,7 +35,10 @@ Lemma gas_eq
   let ref_host := make_ref (A := H) 1 in
   {{
     SimulateM.eval_f
-      (run_gas run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_gas run_InterpreterTypes_for_WIRE {|
+        instruction_context.InstructionContext.interpreter := ref_interpreter;
+        instruction_context.InstructionContext.host := ref_host;
+      |})
       ([interpreter; host]%stack) 🌲
     (
       Output.Success tt,
@@ -49,12 +48,8 @@ Lemma gas_eq
 Proof.
   intros.
   with_strategy transparent [run_gas] unfold gas, run_gas; cbn.
-  gas_macro_eq idtac.
   s. {
-    apply InterpreterTypesEq.
-  }
-  s. {
-    apply Impl_Gas.remaining_eq.
+    apply Impl_Gas.remaining_interpreter_eq.
   }
   s. {
     s_apply Impl_Uint.from_eq.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/utility.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/utility.v
@@ -12,28 +12,6 @@ Definition cast_slice_to_u256 (slice : list u8) : aliases.U256.t :=
     Uint.value := List.fold_left (fun acc byte => (acc * 256) + i[byte])%Z slice 0;
   |}.
 
-Lemma cast_slice_to_address_like
-    (stack : Stack.t)
-    (slice : '& (list u8))
-    (dest : '&mut aliases.U256.t) :
-  SimulateM.eval_f
-    (run_cast_slice_to_u256 slice dest)
-    stack =
-  let*s slice := SimulateM.read stack slice.(Ref.core) in
-  match slice with
-  | Output.Success slice =>
-    let*s stack' := SimulateM.write stack dest.(Ref.core) (cast_slice_to_u256 slice) in
-    match stack' with
-    | Output.Success stack' =>
-      SimulateM.Pure (Output.Success tt, stack')
-    | Output.Exception exception =>
-      SimulateM.Pure (Output.Exception exception, stack)
-    end
-  | Output.Exception exception =>
-    SimulateM.Pure (Output.Exception exception, stack)
-  end.
-Admitted.
-
 Module IntoU256.
   Class C (Self : Set) : Set := {
     into_u256 (self : Self) : aliases.U256.t;

--- a/RocqOfRust/revm/revm_interpreter/links/interpreter_types.v
+++ b/RocqOfRust/revm/revm_interpreter/links/interpreter_types.v
@@ -92,7 +92,7 @@ End Immediates.
 Export (hints) Immediates.
 
 (*
-pub trait InputsTrait {
+pub trait InputsTr {
     fn target_address(&self) -> Address;
     fn caller_address(&self) -> Address;
     fn input(&self) -> &[u8];
@@ -102,7 +102,7 @@ pub trait InputsTrait {
 Module InputsTrait.
   Definition trait (Self : Set) `{Link Self} : TraitHeader.t :=
     {|
-      TraitHeader.trait_name := "revm_interpreter::interpreter_types::InputsTrait";
+      TraitHeader.trait_name := "revm_interpreter::interpreter_types::InputsTr";
       TraitHeader.trait_consts := [];
       TraitHeader.trait_tys := [];
       TraitHeader.self_ty := Φ Self;

--- a/RocqOfRust/revm/revm_interpreter/simulate/gas.v
+++ b/RocqOfRust/revm/revm_interpreter/simulate/gas.v
@@ -271,6 +271,27 @@ Module Impl_Gas.
     p.
   Qed.
 
+  Lemma remaining_interpreter_eq
+      {WIRE : Set} `{Link WIRE}
+      {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+      (interpreter : Interpreter.t WIRE WIRE_types)
+      (stack : Stack.t) :
+    let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+    let ref_self : '& _ := {|
+      Ref.core :=
+        SubPointer.Runner.apply
+          ref_interpreter.(Ref.core)
+          Interpreter.SubPointer.get_gas
+    |} in
+    {{
+      SimulateM.eval_f (Impl_Gas.run_remaining ref_self) (interpreter :: stack)%stack 🌲
+      (Output.Success (remaining interpreter.(Interpreter.gas)), interpreter :: stack)%stack
+    }}.
+  Proof.
+    with_strategy transparent [Impl_Gas.run_remaining] cbn.
+    p.
+  Qed.
+
   Definition remaining_63_of_64_parts (self : Self) : u64 :=
     self.(Gas.remaining) -i self.(Gas.remaining) /i 64.
 

--- a/RocqOfRust/revm/revm_interpreter/simulate/interpreter.v
+++ b/RocqOfRust/revm/revm_interpreter/simulate/interpreter.v
@@ -45,6 +45,13 @@ Definition halt_memory_oog {WIRE : Set} `{Link WIRE}
     Interpreter.t WIRE WIRE_types :=
   halt interpreter instruction_result.InstructionResult.MemoryOOG.
 
+Definition halt_overflow {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (interpreter : Interpreter.t WIRE WIRE_types) :
+    Interpreter.t WIRE WIRE_types :=
+  halt interpreter instruction_result.InstructionResult.StackOverflow.
+
 Lemma stack_dealloc_cons_alloc_unit
     (A : Set)
     (value : A)
@@ -202,6 +209,57 @@ Proof.
     Impl_Interpreter.run_halt_underflow
     Impl_Interpreter.run_halt
   ] unfold Impl_Interpreter.run_halt_underflow, Impl_Interpreter.run_halt.
+  cbn.
+  repeat s.
+  - apply Impl_Bytes.new_eq.
+  - apply InterpreterTypesEq
+      .(InterpreterTypes.Eq.LoopControl_for_Bytecode)
+      .(LoopControl.BytecodeEq.set_action).
+  - repeat rewrite Stack.dealloc_alloc_eq;
+    repeat rewrite stack_dealloc_cons_alloc_unit;
+    reflexivity.
+Qed.
+
+Lemma halt_overflow_eq {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (InterpreterTypesEq :
+      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (stack_rest : Stack.t) :
+  let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+  let action :=
+    interpreter_action.InterpreterAction.Return {|
+      InterpreterResult.result := instruction_result.InstructionResult.StackOverflow;
+      InterpreterResult.output := Impl_Bytes.new;
+      InterpreterResult.gas := interpreter.(Interpreter.gas);
+    |} in
+  {{
+    SimulateM.eval_f
+      (Impl_Interpreter.run_halt_overflow WIRE ref_interpreter)
+      (interpreter :: stack_rest)%stack 🌲
+    (
+      Output.Success tt,
+      (
+        interpreter
+          <| Interpreter.bytecode :=
+            IInterpreterTypes
+              .(InterpreterTypes.LoopControl_for_Bytecode)
+              .(LoopControl.set_action)
+              interpreter.(Interpreter.bytecode)
+              action
+          |>
+        :: stack_rest
+      )%stack
+    )
+  }}.
+Proof.
+  intros.
+  with_strategy transparent [
+    Impl_Interpreter.run_halt_overflow
+    Impl_Interpreter.run_halt
+  ] unfold Impl_Interpreter.run_halt_overflow, Impl_Interpreter.run_halt.
   cbn.
   repeat s.
   - apply Impl_Bytes.new_eq.


### PR DESCRIPTION
This PR continues the Revm v103 compile-slice work for a small group of system instructions.

It updates address, caller, callvalue, codesize, and gas to the current v103 instruction shape using InstructionContext.

It also adds the shared overflow halt helper in the interpreter simulate file, updates the push macro overflow path, adds a direct helper for reading the interpreter gas field, and removes the stale utility bridge for cast_slice_to_u256 because that translated function no longer exists.