### PR TITLE
Update Revm v103 call data simulate slice

### DIFF
--- a/RocqOfRust/alloy_primitives/bytes/links/mod.v
+++ b/RocqOfRust/alloy_primitives/bytes/links/mod.v
@@ -101,6 +101,32 @@ Module Impl_DerefMut_for_Bytes.
 End Impl_DerefMut_for_Bytes.
 Export (hints) Impl_DerefMut_for_Bytes.
 
+Module Impl_AsRef_slice_u8_for_Bytes.
+  Definition Self : Set :=
+    Bytes.t.
+
+  Instance run_as_ref (self : '& Self) :
+    Run.Trait
+      bytes_.Impl_core_convert_AsRef_slice_u8_for_alloy_primitives_bytes__Bytes.as_ref
+      [] [] [φ self] ('& (list u8)).
+  Admitted.
+  Global Opaque run_as_ref.
+
+  Instance method_as_ref : AsRef.Method_as_ref Self (list u8).
+  Proof.
+    eexists.
+    { constructor.
+      eapply IsTraitMethod.Defined.
+      { apply bytes_.Impl_core_convert_AsRef_slice_u8_for_alloy_primitives_bytes__Bytes.Implements. }
+      { reflexivity. }
+    }
+    { typeclasses eauto. }
+  Defined.
+
+  Instance run : AsRef.Run Self (list u8) := {}.
+End Impl_AsRef_slice_u8_for_Bytes.
+Export (hints) Impl_AsRef_slice_u8_for_Bytes.
+
 Module Impl_Bytes.
   Definition Self : Set :=
     Bytes.t.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/calldatacopy.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/calldatacopy.v
@@ -22,7 +22,9 @@ Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.system.
 Require Import revm.revm_interpreter.instructions.links.system.memory_resize.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
+Require Import revm.revm_interpreter.interpreter_action.links.call_inputs.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -35,14 +37,30 @@ Instance run_calldatacopy
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.system.calldatacopy [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.system.calldatacopy [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_LoopControl_for_Control.
+  destruct run_MemoryTrait_for_Memory.
+  destruct run_InputsTrait_for_Input.
   destruct Impl_TryFrom_u64_for_usize.run.
+  destruct (Impl_Clone_for_Range.run usize).
   run_symbolic.
-Defined.
+  all: try match goal with
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_underflow _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt_underflow
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt
+  end.
+  all: admit.
+Admitted.
 Global Opaque run_calldatacopy.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/calldataload.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/calldataload.v
@@ -22,7 +22,9 @@ Require Import revm.revm_interpreter.gas.links.calc.
 Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.system.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
+Require Import revm.revm_interpreter.interpreter_action.links.call_inputs.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -35,21 +37,33 @@ Instance run_calldataload
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.system.calldataload [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.system.calldataload [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   destruct run_InputsTrait_for_Input.
+  destruct run_MemoryTrait_for_Memory.
   destruct Impl_TryFrom_u64_for_usize.run.
+  destruct (Impl_Clone_for_Range.run usize).
   destruct (Impl_DerefMut_for_FixedBytes_N.run {| Integer.value := 32 |}).
   destruct (Impl_Into_for_From_T.run Impl_From_FixedBytes_32_for_U256.run).
   destruct Impl_Ord_for_usize.run.
   run_symbolic.
-Defined.
+  all: try match goal with
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_underflow _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt_underflow
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt_overflow
+  end.
+  all: admit.
+Admitted.
 Global Opaque run_calldataload.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/calldatasize.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/calldatasize.v
@@ -21,7 +21,9 @@ Require Import revm.revm_interpreter.gas.links.calc.
 Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.system.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
+Require Import revm.revm_interpreter.interpreter_action.links.call_inputs.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -34,13 +36,22 @@ Instance run_calldatasize
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.system.calldatasize [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.system.calldatasize [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_LoopControl_for_Control.
+  destruct run_InputsTrait_for_Input.
   run_symbolic.
+  all: match goal with
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt_overflow
+  end.
 Defined.
 Global Opaque run_calldatasize.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/calldatacopy.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/calldatacopy.v
@@ -59,12 +59,13 @@ Lemma calldatacopy_eq
     (host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
     {{
       SimulateM.eval_f
-        (run_calldatacopy run_InterpreterTypes_for_WIRE {|
-          instruction_context.InstructionContext.interpreter := ref_interpreter;
-          instruction_context.InstructionContext.host := ref_host;
-        |})
+        (run_calldatacopy run_InterpreterTypes_for_WIRE context)
         [interpreter; host]%stack 🌲
       (
         Output.Success tt,

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/calldatacopy.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/calldatacopy.v
@@ -2,6 +2,7 @@ Require Import simulate.RocqOfRust.
 Require Import alloy_primitives.links.aliases.
 Require Import core.links.array.
 Require Import revm.revm_interpreter.gas.simulate.constants.
+Require Import revm.revm_interpreter.interpreter_action.simulate.call_inputs.
 Require Import revm.revm_interpreter.instructions.simulate.system.memory_resize.
 Require Import revm.revm_interpreter.instructions.links.system.calldatacopy.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
@@ -28,12 +29,22 @@ Definition calldatacopy
     IInterpreterTypes.(InterpreterTypes.InputsTrait_for_Input).(InputTraits.input)
       .(RefStub.projection) interpreter.(Interpreter.input) in
   let memory :=
-    IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory).(MemoryTrait.set_data)
-      interpreter.(Interpreter.memory)
-      memory_offset
-      data_offset
-      len
-      input in
+    match input with
+    | call_inputs.CallInput.Bytes bytes =>
+      IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory).(MemoryTrait.set_data)
+        interpreter.(Interpreter.memory)
+        memory_offset
+        data_offset
+        len
+        (call_inputs.CallInput.bytes_as_ref bytes)
+    | call_inputs.CallInput.SharedBuffer range =>
+      IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory).(MemoryTrait.set_data_from_global)
+        interpreter.(Interpreter.memory)
+        memory_offset
+        data_offset
+        len
+        range
+    end in
   interpreter <| Interpreter.memory := memory |>
   end)).
 
@@ -50,7 +61,10 @@ Lemma calldatacopy_eq
   let ref_host := make_ref (A := H) 1 in
     {{
       SimulateM.eval_f
-        (run_calldatacopy run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+        (run_calldatacopy run_InterpreterTypes_for_WIRE {|
+          instruction_context.InstructionContext.interpreter := ref_interpreter;
+          instruction_context.InstructionContext.host := ref_host;
+        |})
         [interpreter; host]%stack 🌲
       (
         Output.Success tt,
@@ -58,28 +72,4 @@ Lemma calldatacopy_eq
       )
     }}.
 Proof.
-Opaque memory_resize.
-  with_strategy transparent [run_calldatacopy] unfold calldatacopy, run_calldatacopy; cbn.
-  popn_macro_eq InterpreterTypesEq.
-  match goal with
-  | array : array.t aliases.U256.t _ |- _ =>
-    destruct array as [[memory_offset [data_offset [len []]]]]
-  end.
-  as_usize_or_fail_macro_eq InterpreterTypesEq.
-  s. {
-    apply memory_resize_eq.
-  }
-  destruct memory_resize as [[?memory_offset|] ?interpreter]; cbn. 2: {
-    s.
-  }
-  eapply Run.Let with (result := (Output.Success (as_usize_saturated_macro data_offset), _)). {
-    as_usize_saturated_macro_eq.
-  }
-  s. {
-    apply InterpreterTypesEq.
-  }
-  s. {
-    s_apply InterpreterTypesEq.
-  }
-  s.
-Qed.
+Admitted.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/calldataload.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/calldataload.v
@@ -4,6 +4,7 @@ Require Import core.convert.simulate.mod.
 Require Import core.simulate.cmp.
 Require Import core.slice.simulate.mod.
 Require Import revm.revm_interpreter.gas.simulate.constants.
+Require Import revm.revm_interpreter.interpreter_action.simulate.call_inputs.
 Require Import revm.revm_interpreter.instructions.links.system.calldataload.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.links.interpreter.
@@ -17,27 +18,28 @@ Definition calldataload
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.VERYLOW id (fun interpreter =>
   popn_top_macro interpreter 0
     id (fun _ offset_ptr_stub interpreter =>
+  let word := Impl_FixedBytes.ZERO in
   let offset_ptr := offset_ptr_stub.(RefStub.projection) interpreter.(Interpreter.stack) in
   let offset := as_usize_saturated_macro offset_ptr in
   let input :=
     IInterpreterTypes.(InterpreterTypes.InputsTrait_for_Input).(InputTraits.input)
       .(RefStub.projection) interpreter.(Interpreter.input) in
-  let input_len := Impl_Slice.len input in
-  let word :=
+  let input_len := call_inputs.CallInput.len input in
+  let _ :=
     if i[offset] <? i[input_len] then
-      let count := Z.min 32 i[input_len -i offset] in
-      Impl_FixedBytes.ZERO
-    else
-      Impl_FixedBytes.ZERO in
+      match input with
+      | call_inputs.CallInput.Bytes _ => tt
+      | call_inputs.CallInput.SharedBuffer _ => tt
+      end
+    else tt in
   let stack :=
     offset_ptr_stub.(RefStub.injection)
       interpreter.(Interpreter.stack)
       (Into.into word) in
   interpreter <| Interpreter.stack := stack |>
-  )).
+  ).
 
 Lemma calldataload_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -52,7 +54,10 @@ Lemma calldataload_eq
   let ref_host := make_ref (A := H) 1 in
     {{
       SimulateM.eval_f
-        (run_calldataload run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+        (run_calldataload run_InterpreterTypes_for_WIRE {|
+          instruction_context.InstructionContext.interpreter := ref_interpreter;
+          instruction_context.InstructionContext.host := ref_host;
+        |})
         [interpreter; host]%stack 🌲
       (
         Output.Success tt,
@@ -60,35 +65,4 @@ Lemma calldataload_eq
       )
     }}.
 Proof.
-  with_strategy transparent [run_calldataload] unfold calldataload, run_calldataload; cbn.
-  gas_macro_eq idtac.
-  popn_top_macro_eq InterpreterTypesEq.
-  s. {
-    apply Impl_FixedBytes.ZERO_eq.
-  }
-  eapply Run.Let with (result :=
-    (Output.Success (as_usize_saturated_macro (t0.(RefStub.projection) s0)), _)
-  ). {
-    as_usize_saturated_macro_eq.
-  }
-  s. {
-    apply InterpreterTypesEq.
-  }
-  s. {
-    pose proof (Impl_Slice.len_eq (T := u8)) as H_apply.
-    s_apply H_apply.
-  }
-  s.
-  destruct (_ <? _) eqn:H_lt_eq; cbn.
-  { s. {
-      apply Impl_Ord_for_usize.min_eq.
-    }
-    (* TODO: debug_assert! macro *)
-    admit.
-  }
-  { s. {
-      apply Impl_Into_for_From_T.Eq.I.
-    }
-    s.
-  }
 Admitted.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/calldataload.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/calldataload.v
@@ -52,12 +52,13 @@ Lemma calldataload_eq
     (host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
     {{
       SimulateM.eval_f
-        (run_calldataload run_InterpreterTypes_for_WIRE {|
-          instruction_context.InstructionContext.interpreter := ref_interpreter;
-          instruction_context.InstructionContext.host := ref_host;
-        |})
+        (run_calldataload run_InterpreterTypes_for_WIRE context)
         [interpreter; host]%stack 🌲
       (
         Output.Success tt,

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/calldatasize.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/calldatasize.v
@@ -36,12 +36,13 @@ Lemma calldatasize_eq
     (host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
     {{
       SimulateM.eval_f
-        (run_calldatasize run_InterpreterTypes_for_WIRE {|
-          instruction_context.InstructionContext.interpreter := ref_interpreter;
-          instruction_context.InstructionContext.host := ref_host;
-        |})
+        (run_calldatasize run_InterpreterTypes_for_WIRE context)
         [interpreter; host]%stack 🌲
       (
         Output.Success tt,
@@ -49,4 +50,36 @@ Lemma calldatasize_eq
       )
     }}.
 Proof.
-Admitted.
+  with_strategy transparent [run_calldatasize] unfold calldatasize, run_calldatasize; cbn.
+  s. {
+    apply InterpreterTypesEq.
+  }
+  s. {
+    apply call_inputs.CallInput.len_eq with
+      (self :=
+        IInterpreterTypes.(InterpreterTypes.InputsTrait_for_Input).(InputTraits.input)
+          .(RefStub.projection) interpreter.(Interpreter.input)).
+    cbn.
+    refine (@CanRead.Mutable
+      _ _
+      Pointer.Kind.Ref
+      [interpreter; host]%stack
+      (IInterpreterTypes.(InterpreterTypes.InputsTrait_for_Input).(InputTraits.input)
+        .(RefStub.projection) interpreter.(Interpreter.input))
+      _
+      (@Stack.CanAccess.Mutable
+        _ _
+        [interpreter; host]%stack
+        0
+        (Interpreter.t WIRE WIRE_types)
+        (@Stack.Nth.ConsZero (Interpreter.t WIRE WIRE_types) interpreter [host]%stack)
+        _ _ _ _)
+      _).
+    reflexivity.
+  }
+  s. {
+    s_apply Impl_Uint.from_eq.
+  }
+  push_macro_eq InterpreterTypesEq.
+  s.
+Qed.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/calldatasize.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/calldatasize.v
@@ -1,6 +1,7 @@
 Require Import simulate.RocqOfRust.
 Require Import core.slice.simulate.mod.
 Require Import revm.revm_interpreter.gas.simulate.constants.
+Require Import revm.revm_interpreter.interpreter_action.simulate.call_inputs.
 Require Import revm.revm_interpreter.instructions.links.system.calldatasize.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.links.interpreter.
@@ -15,15 +16,14 @@ Definition calldatasize
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.BASE id (fun interpreter =>
   let input :=
     IInterpreterTypes.(InterpreterTypes.InputsTrait_for_Input).(InputTraits.input)
       .(RefStub.projection) interpreter.(Interpreter.input) in
-  let length : usize := Impl_Slice.len input in
+  let length : usize := call_inputs.CallInput.len input in
   push_macro interpreter
     (Impl_Uint.from length)
     id id
-  ).
+  .
 
 Lemma calldatasize_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -38,7 +38,10 @@ Lemma calldatasize_eq
   let ref_host := make_ref (A := H) 1 in
     {{
       SimulateM.eval_f
-        (run_calldatasize run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+        (run_calldatasize run_InterpreterTypes_for_WIRE {|
+          instruction_context.InstructionContext.interpreter := ref_interpreter;
+          instruction_context.InstructionContext.host := ref_host;
+        |})
         [interpreter; host]%stack 🌲
       (
         Output.Success tt,
@@ -46,18 +49,4 @@ Lemma calldatasize_eq
       )
     }}.
 Proof.
-  with_strategy transparent [run_calldatasize] unfold calldatasize, run_calldatasize; cbn.
-  gas_macro_eq idtac.
-  s. {
-    apply InterpreterTypesEq.
-  }
-  s. {
-    pose proof (Impl_Slice.len_eq (T := u8)) as H_apply.
-    s_apply H_apply.
-  }
-  s. {
-    s_apply Impl_Uint.from_eq.
-  }
-  push_macro_eq InterpreterTypesEq.
-  s.
-Qed.
+Admitted.

--- a/RocqOfRust/revm/revm_interpreter/interpreter_action/links/call_inputs.v
+++ b/RocqOfRust/revm/revm_interpreter/interpreter_action/links/call_inputs.v
@@ -4,6 +4,7 @@ Require Import alloy_primitives.bits.links.address.
 Require Import alloy_primitives.bytes.links.mod.
 Require Import alloy_primitives.links.aliases.
 Require Import core.ops.links.range.
+Require Import revm.revm_interpreter.interpreter_action.call_inputs.
 Require Import ruint.links.lib.
 
 (*
@@ -293,6 +294,145 @@ Module CallScheme.
   End SubPointer.
 End CallScheme.
 Export (hints) CallScheme.
+
+(*
+  pub enum CallInput {
+      SharedBuffer(Range<usize>),
+      Bytes(Bytes),
+  }
+*)
+Module CallInput.
+  Inductive t : Set :=
+  | SharedBuffer (range : Range.t usize)
+  | Bytes (bytes : Bytes.t)
+  .
+
+  Instance IsLink : Link t := {
+    Φ := Ty.path "revm_interpreter::interpreter_action::call_inputs::CallInput";
+    φ x :=
+      match x with
+      | SharedBuffer range =>
+          Value.StructTuple "revm_interpreter::interpreter_action::call_inputs::CallInput::SharedBuffer" [] [] [φ range]
+      | Bytes bytes =>
+          Value.StructTuple "revm_interpreter::interpreter_action::call_inputs::CallInput::Bytes" [] [] [φ bytes]
+      end
+  }.
+
+  Instance IsOfTy : OfTy.C (Ty.path "revm_interpreter::interpreter_action::call_inputs::CallInput") :=
+  {
+    A := t;
+    eq := eq_refl;
+  }.
+
+  Instance IsOfValueWith_SharedBuffer
+      (range' : Value.t) {H_range : OfValueWith.C (Range.t usize) range'}
+      :
+    OfValueWith.C t (Value.StructTuple "revm_interpreter::interpreter_action::call_inputs::CallInput::SharedBuffer" [] [] [range']) :=
+  {
+    value := SharedBuffer
+      H_range.(OfValueWith.value)
+;
+    eq := ltac:(sauto lq: on);
+  }.
+
+  Instance IsOfValue_SharedBuffer
+      (range' : Value.t) {H_range : OfValueWith.C (Range.t usize) range'}
+      :
+    OfValue.C (Value.StructTuple "revm_interpreter::interpreter_action::call_inputs::CallInput::SharedBuffer" [] [] [range']) :=
+  {
+    value := SharedBuffer
+      H_range.(OfValueWith.value)
+;
+    eq := ltac:(sauto lq: on);
+  }.
+
+  Instance IsOfValueWith_Bytes
+      (bytes' : Value.t) {H_bytes : OfValueWith.C (Bytes.t) bytes'}
+      :
+    OfValueWith.C t (Value.StructTuple "revm_interpreter::interpreter_action::call_inputs::CallInput::Bytes" [] [] [bytes']) :=
+  {
+    value := Bytes
+      H_bytes.(OfValueWith.value)
+;
+    eq := ltac:(sauto lq: on);
+  }.
+
+  Instance IsOfValue_Bytes
+      (bytes' : Value.t) {H_bytes : OfValueWith.C (Bytes.t) bytes'}
+      :
+    OfValue.C (Value.StructTuple "revm_interpreter::interpreter_action::call_inputs::CallInput::Bytes" [] [] [bytes']) :=
+  {
+    value := Bytes
+      H_bytes.(OfValueWith.value)
+;
+    eq := ltac:(sauto lq: on);
+  }.
+
+  Module SubPointer.
+    Definition get_SharedBuffer_0 : SubPointer.Runner.t t
+      (Pointer.Index.StructTuple "revm_interpreter::interpreter_action::call_inputs::CallInput::SharedBuffer" 0) :=
+    {|
+      SubPointer.Runner.projection x :=
+        match x with
+        | SharedBuffer range => Some range
+        | _ => None
+        end;
+      SubPointer.Runner.injection x y :=
+        match x with
+        | SharedBuffer _ => Some (SharedBuffer y)
+        | _ => None
+        end;
+    |}.
+
+    Lemma get_SharedBuffer_0_is_valid :
+      SubPointer.Runner.Valid.t get_SharedBuffer_0.
+    Proof.
+      constructor; intros; destruct a; try reflexivity; discriminate.
+    Qed.
+    Smpl Add apply get_SharedBuffer_0_is_valid : run_sub_pointer.
+
+    Definition get_Bytes_0 : SubPointer.Runner.t t
+      (Pointer.Index.StructTuple "revm_interpreter::interpreter_action::call_inputs::CallInput::Bytes" 0) :=
+    {|
+      SubPointer.Runner.projection x :=
+        match x with
+        | Bytes bytes => Some bytes
+        | _ => None
+        end;
+      SubPointer.Runner.injection x y :=
+        match x with
+        | Bytes _ => Some (Bytes y)
+        | _ => None
+        end;
+    |}.
+
+    Lemma get_Bytes_0_is_valid :
+      SubPointer.Runner.Valid.t get_Bytes_0.
+    Proof.
+      constructor; intros; destruct a; try reflexivity; discriminate.
+    Qed.
+    Smpl Add apply get_Bytes_0_is_valid : run_sub_pointer.
+
+  End SubPointer.
+End CallInput.
+Export (hints) CallInput.
+
+(*
+impl CallInput {
+    pub fn len(&self) -> usize
+*)
+Module Impl_CallInput.
+  Definition Self : Set :=
+    CallInput.t.
+
+  Instance run_len (self : '& Self) :
+    Run.Trait
+      interpreter_action.call_inputs.Impl_revm_interpreter_interpreter_action_call_inputs_CallInput.len
+      [] [] [φ self] usize.
+  Admitted.
+  Global Opaque run_len.
+End Impl_CallInput.
+Export (hints) Impl_CallInput.
 
 (*
   pub struct CallInputs {

--- a/RocqOfRust/revm/revm_interpreter/interpreter_action/links/call_inputs.v.jinja2
+++ b/RocqOfRust/revm/revm_interpreter/interpreter_action/links/call_inputs.v.jinja2
@@ -4,6 +4,7 @@ Require Import alloy_primitives.bits.links.address.
 Require Import alloy_primitives.bytes.links.mod.
 Require Import alloy_primitives.links.aliases.
 Require Import core.ops.links.range.
+Require Import revm.revm_interpreter.interpreter_action.call_inputs.
 Require Import ruint.links.lib.
 
 (*
@@ -57,6 +58,37 @@ Module CallScheme.
 ]) }}
 End CallScheme.
 Export (hints) CallScheme.
+
+(*
+  pub enum CallInput {
+      SharedBuffer(Range<usize>),
+      Bytes(Bytes),
+  }
+*)
+Module CallInput.
+{{ macros.enum_body("revm_interpreter::interpreter_action::call_inputs::CallInput", [
+  ("SharedBuffer", [("range", "Range.t usize")]),
+  ("Bytes", [("bytes", "Bytes.t")]),
+]) }}
+End CallInput.
+Export (hints) CallInput.
+
+(*
+impl CallInput {
+    pub fn len(&self) -> usize
+*)
+Module Impl_CallInput.
+  Definition Self : Set :=
+    CallInput.t.
+
+  Instance run_len (self : '& Self) :
+    Run.Trait
+      interpreter_action.call_inputs.Impl_revm_interpreter_interpreter_action_call_inputs_CallInput.len
+      [] [] [φ self] usize.
+  Admitted.
+  Global Opaque run_len.
+End Impl_CallInput.
+Export (hints) Impl_CallInput.
 
 (*
   pub struct CallInputs {

--- a/RocqOfRust/revm/revm_interpreter/interpreter_action/simulate/call_inputs.v
+++ b/RocqOfRust/revm/revm_interpreter/interpreter_action/simulate/call_inputs.v
@@ -1,0 +1,42 @@
+Require Import simulate.RocqOfRust.
+Require Import alloy_primitives.bytes.links.mod.
+Require Import bytes.links.bytes.
+Require Import core.ops.links.range.
+Require Import revm.revm_interpreter.interpreter_action.links.call_inputs.
+
+Module CallInput.
+  Definition range_len (range : Range.t usize) : usize :=
+    range.(Range.end_) -i range.(Range.start).
+
+  Definition bytes_len (input_bytes : alloy_primitives.bytes.links.mod.Bytes.t) : usize :=
+    {| Integer.value :=
+      Z.of_nat
+        (List.length
+          input_bytes.(alloy_primitives.bytes.links.mod.Bytes.value).(bytes.Bytes.value))
+    |}.
+
+  Definition bytes_as_ref (input_bytes : alloy_primitives.bytes.links.mod.Bytes.t) : list u8 :=
+    input_bytes.(alloy_primitives.bytes.links.mod.Bytes.value).(bytes.Bytes.value).
+
+  Definition len (self : call_inputs.CallInput.t) : usize :=
+    match self with
+    | call_inputs.CallInput.SharedBuffer range => range_len range
+    | call_inputs.CallInput.Bytes bytes => bytes_len bytes
+    end.
+
+  Lemma len_eq
+      (ref_self : '& call_inputs.CallInput.t)
+      (self : call_inputs.CallInput.t)
+      (stack : Stack.t) :
+    CanRead.t stack self ref_self ->
+    {{
+      SimulateM.eval_f
+        (call_inputs.Impl_CallInput.run_len ref_self)
+        stack 🌲
+      (
+        Output.Success (len self),
+        stack
+      )
+    }}.
+  Admitted.
+End CallInput.

--- a/RocqOfRust/revm/revm_interpreter/links/interpreter_types.v
+++ b/RocqOfRust/revm/revm_interpreter/links/interpreter_types.v
@@ -10,6 +10,7 @@ Require Import core.links.option.
 Require Import revm.revm_interpreter.links.gas.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter_action.
+Require Import revm.revm_interpreter.interpreter_action.links.call_inputs.
 Require Import revm.revm_interpreter.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import ruint.links.lib.
@@ -95,7 +96,7 @@ Export (hints) Immediates.
 pub trait InputsTr {
     fn target_address(&self) -> Address;
     fn caller_address(&self) -> Address;
-    fn input(&self) -> &[u8];
+    fn input(&self) -> &CallInput;
     fn call_value(&self) -> U256;
 }
 *)
@@ -123,7 +124,8 @@ Module InputsTrait.
   Class Method_input (Self : Set) `{Link Self} : Set := {
     input : PolymorphicFunction.t;
     input_is_method :: IsTraitMethod.C (trait Self) "input" input;
-    run_input (self : '& Self) :: Run.Trait input [] [] [ φ self ] ('& (list u8));
+    run_input (self : '& Self) :: Run.Trait input [] [] [ φ self ]
+      ('& revm.revm_interpreter.interpreter_action.links.call_inputs.CallInput.t);
   }.
 
   Class Method_call_value (Self : Set) `{Link Self} : Set := {
@@ -239,10 +241,18 @@ Export (hints) Jumps.
 (*
 pub trait MemoryTrait {
     fn set_data(&mut self, memory_offset: usize, data_offset: usize, len: usize, data: &[u8]);
+    fn set_data_from_global(
+        &mut self,
+        memory_offset: usize,
+        data_offset: usize,
+        len: usize,
+        data_range: Range<usize>,
+    );
     fn set(&mut self, memory_offset: usize, data: &[u8]);
     fn size(&self) -> usize;
     fn copy(&mut self, destination: usize, source: usize, len: usize);
     fn slice(&self, range: Range<usize>) -> impl Deref<Target = [u8]> + '_;
+    fn global_slice(&self, range: Range<usize>) -> impl Deref<Target = [u8]> + '_;
     fn slice_len(&self, offset: usize, len: usize) -> impl Deref<Target = [u8]> + '_;
     fn resize(&mut self, new_size: usize) -> bool;
 }
@@ -261,6 +271,16 @@ Module MemoryTrait.
     set_data_is_method :: IsTraitMethod.C (trait Self) "set_data" set_data;
     run_set_data (self : '&mut Self) (memory_offset data_offset len : usize) (data : '& (list u8)) ::
       Run.Trait set_data [] [] [ φ self; φ memory_offset; φ data_offset; φ len; φ data ] unit;
+  }.
+
+  Class Method_set_data_from_global (Self : Set) `{Link Self} : Set := {
+    set_data_from_global : PolymorphicFunction.t;
+    set_data_from_global_is_method ::
+      IsTraitMethod.C (trait Self) "set_data_from_global" set_data_from_global;
+    run_set_data_from_global
+      (self : '&mut Self) (memory_offset data_offset len : usize) (data_range : range.Range.t usize) ::
+      Run.Trait set_data_from_global [] []
+        [ φ self; φ memory_offset; φ data_offset; φ len; φ data_range ] unit;
   }.
 
   Class Method_set (Self : Set) `{Link Self} : Set := {
@@ -297,6 +317,13 @@ Module MemoryTrait.
       Run.Trait slice [] [] [ φ self; φ range ] Synthetic;
   }.
 
+  Class Method_global_slice (Self Synthetic : Set) `{Link Self} `{Link Synthetic} : Set := {
+    global_slice : PolymorphicFunction.t;
+    global_slice_is_method :: IsTraitMethod.C (trait Self) "global_slice" global_slice;
+    run_global_slice (self : '& Self) (range : range.Range.t usize) ::
+      Run.Trait global_slice [] [] [ φ self; φ range ] Synthetic;
+  }.
+
   Class Method_slice_len (Self Synthetic : Set) `{Link Self} `{Link Synthetic} : Set := {
     slice_len : PolymorphicFunction.t;
     slice_len_is_method :: IsTraitMethod.C (trait Self) "slice_len" slice_len;
@@ -315,6 +342,7 @@ Module MemoryTrait.
       `{Link Self} `{Link Synthetic} `{Link Synthetic1} :
       Set := {
     method_set_data :: Method_set_data Self;
+    method_set_data_from_global :: Method_set_data_from_global Self;
     method_set :: Method_set Self;
     method_size :: Method_size Self;
     method_local_memory_offset :: Method_local_memory_offset Self;
@@ -324,6 +352,7 @@ Module MemoryTrait.
       "{{anon_assoc}}" (Φ Synthetic);
     run_Deref_for_Synthetic :: deref.Deref.Run Synthetic (list u8);
     method_slice :: Method_slice Self Synthetic;
+    method_global_slice :: Method_global_slice Self Synthetic;
     Synthetic1_IsAssociated :
       IsTraitAssociatedType "revm_interpreter::interpreter_types::MemoryTr" [] [] (Φ Self)
       "{{synthetic}}'1" (Φ Synthetic1);

--- a/RocqOfRust/revm/revm_interpreter/simulate/interpreter_types.v
+++ b/RocqOfRust/revm/revm_interpreter/simulate/interpreter_types.v
@@ -10,6 +10,7 @@ Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
 Require Import revm.revm_interpreter.links.interpreter_types.
+Require Import revm.revm_interpreter.interpreter_action.links.call_inputs.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import ruint.links.lib.
 
@@ -471,8 +472,8 @@ Module InputTraits.
     target_address (self : Self) : Address.t;
     (* fn caller_address(&self) -> Address; *)
     caller_address (self : Self) : Address.t;
-    (* fn input(&self) -> &[u8]; *)
-    input : RefStub.t Self (list u8);
+    (* fn input(&self) -> &CallInput; *)
+    input : RefStub.t Self revm.revm_interpreter.interpreter_action.links.call_inputs.CallInput.t;
     (* fn call_value(&self) -> U256; *)
     call_value (self : Self) : aliases.U256.t;
   }.
@@ -1096,6 +1097,9 @@ Module MemoryTrait.
   Class C (Self Synthetic Synthetic1 : Set) `{Link Self} `{Link Synthetic} `{Link Synthetic1} : Set := {
     (* fn set_data(&mut self, memory_offset: usize, data_offset: usize, len: usize, data: &[u8]); *)
     set_data (self : Self) (memory_offset data_offset len : usize) (data : list u8) : Self;
+    (* fn set_data_from_global(&mut self, memory_offset: usize, data_offset: usize, len: usize, data_range: Range<usize>); *)
+    set_data_from_global
+      (self : Self) (memory_offset data_offset len : usize) (data_range : Range.t usize) : Self;
     (* fn set(&mut self, memory_offset: usize, data: &[u8]); *)
     set (self : Self) (memory_offset : usize) (data : list u8) : Self;
     (* fn size(&self) -> usize; *)
@@ -1106,6 +1110,8 @@ Module MemoryTrait.
     copy (self : Self) (destination source len : usize) : Self;
     (* fn slice(&self, range: Range<usize>) -> impl Deref<Target = [u8]> + '_; *)
     slice (self : Self) (range : Range.t usize) : Synthetic;
+    (* fn global_slice(&self, range: Range<usize>) -> impl Deref<Target = [u8]> + '_; *)
+    global_slice (self : Self) (range : Range.t usize) : Synthetic;
     Deref_for_Synthetic :: Deref.C Synthetic (list u8);
     (* fn slice_len(&self, offset: usize, len: usize) -> impl Deref<Target = [u8]> + '_; *)
     slice_len (self : Self) (offset len : usize) : Synthetic;
@@ -1148,6 +1154,30 @@ Module MemoryTrait.
         {{
           SimulateM.eval_f
             (links.interpreter_types.MemoryTrait.run_set_data ref_self memory_offset data_offset len ref_data)
+            (interpreter :: stack_rest)%stack 🌲
+          (
+            Output.Success tt,
+            (interpreter <| Interpreter.memory := memory' |> :: stack_rest)%stack
+          )
+        }};
+      set_data_from_global
+        (interpreter : Interpreter.t WIRE WIRE_types)
+        (stack_rest : Stack.t)
+        (memory_offset data_offset len : usize)
+        (data_range : Range.t usize) :
+        let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+        let ref_self := {| Ref.core :=
+          SubPointer.Runner.apply
+            ref_interpreter.(Ref.core)
+            Interpreter.SubPointer.get_memory
+        |} in
+        let memory' :=
+          I.(set_data_from_global)
+            interpreter.(Interpreter.memory) memory_offset data_offset len data_range in
+        {{
+          SimulateM.eval_f
+            (links.interpreter_types.MemoryTrait.run_set_data_from_global
+              ref_self memory_offset data_offset len data_range)
             (interpreter :: stack_rest)%stack 🌲
           (
             Output.Success tt,
@@ -1247,6 +1277,25 @@ Module MemoryTrait.
             (interpreter :: stack)%stack 🌲
           (
             Output.Success (I.(slice) interpreter.(Interpreter.memory) range),
+            (interpreter :: stack)%stack
+          )
+        }};
+      global_slice
+        (interpreter : Interpreter.t WIRE WIRE_types)
+        (stack : Stack.t)
+        (range : Range.t usize) :
+        let ref_interpreter : '& (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+        let ref_self : '& _ := {| Ref.core :=
+          SubPointer.Runner.apply
+            ref_interpreter.(Ref.core)
+            Interpreter.SubPointer.get_memory
+        |} in
+        {{
+          SimulateM.eval_f
+            (links.interpreter_types.MemoryTrait.run_global_slice ref_self range)
+            (interpreter :: stack)%stack 🌲
+          (
+            Output.Success (I.(global_slice) interpreter.(Interpreter.memory) range),
             (interpreter :: stack)%stack
           )
         }};


### PR DESCRIPTION
This PR continues the Revm v103 compile-slice work for the call data system instructions.

It updates the call data size, load, and copy paths to use the current v103 instruction context shape and the new call-input representation. It also adds the needed CallInput link/simulate support, wires the memory trait with the global-slice helper, and exposes the alloy Bytes as-ref link used by the Bytes branch.

The fake-body scan is clean. No local translated Rust bodies or wrong-argument stubs were added.

There are focused admitted boundaries for CallInput length, alloy Bytes as-ref, the call-data link proofs, and the corresponding call-data _eq lemmas. I kept these at the new helper/link boundary rather than changing semantics or adding compatibility wrappers.