### PR TITLE
Update Revm v103 control simulate slice

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/invalid.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/invalid.v
@@ -15,6 +15,7 @@ Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.control.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
@@ -25,24 +26,21 @@ Require Import ruint.links.from.
 Require Import ruint.links.lib.
 
 (*
-pub fn invalid<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
-)
+pub fn invalid<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>)
 *)
 Instance run_invalid
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.control.invalid [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.control.invalid [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
   run_symbolic.
+  eapply Impl_Interpreter.run_halt.
 Defined.
 Global Opaque run_invalid.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/jump.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/jump.v
@@ -16,6 +16,7 @@ Require Import revm.revm_interpreter.instructions.control.
 Require Import revm.revm_interpreter.instructions.links.control.jump_inner.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
@@ -26,25 +27,24 @@ Require Import ruint.links.from.
 Require Import ruint.links.lib.
 
 (*
-pub fn jump<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
-)
+pub fn jump<ITy: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, ITy>)
 *)
 Instance run_jump
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.control.jump [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.control.jump [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
   destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_StackTrait_for_Stack. 
   destruct run_LoopControl_for_Control.
+  destruct run_Jumps_for_Bytecode.
   run_symbolic.
+  all: try eapply run_jump_inner.
+  all: try eapply Impl_Interpreter.run_halt_underflow.
 Defined.
 Global Opaque run_jump.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/jump_inner.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/jump_inner.v
@@ -36,9 +36,10 @@ Instance run_jump_inner
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
   destruct run_Jumps_for_Bytecode.
   run_symbolic.
+  all: eapply (@Impl_Interpreter.run_halt WIRE H WIRE_types H0 run_InterpreterTypes_for_WIRE).
 Defined.
 Global Opaque run_jump_inner.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/jumpdest.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/jumpdest.v
@@ -15,6 +15,7 @@ Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.control.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
@@ -24,25 +25,16 @@ Require Import ruint.links.cmp.
 Require Import ruint.links.from.
 Require Import ruint.links.lib.
 
-(*
-pub fn jumpdest_or_nop<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
-)
-*)
-Instance run_jumpdest_or_nop
+Instance run_jumpdest
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.control.jumpdest_or_nop [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.control.jumpdest [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
-  destruct run_LoopControl_for_Control.
   run_symbolic.
 Defined.
-Global Opaque run_jumpdest_or_nop.
+Global Opaque run_jumpdest.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/jumpi.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/jumpi.v
@@ -16,6 +16,7 @@ Require Import revm.revm_interpreter.instructions.control.
 Require Import revm.revm_interpreter.instructions.links.control.jump_inner.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
@@ -26,25 +27,24 @@ Require Import ruint.links.from.
 Require Import ruint.links.lib.
 
 (*
-pub fn jumpi<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
-)
+pub fn jumpi<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>)
 *)
 Instance run_jumpi
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.control.jumpi [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.control.jumpi [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
   destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_StackTrait_for_Stack. 
   destruct run_LoopControl_for_Control.
+  destruct run_Jumps_for_Bytecode.
   run_symbolic.
+  all: try eapply run_jump_inner.
+  all: try eapply Impl_Interpreter.run_halt_underflow.
 Defined.
 Global Opaque run_jumpi.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/pc.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/pc.v
@@ -15,6 +15,7 @@ Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.control.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
@@ -25,26 +26,22 @@ Require Import ruint.links.from.
 Require Import ruint.links.lib.
 
 (*
-pub fn pc<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
-)
+pub fn pc<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>)
 *)
 Instance run_pc
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.control.pc [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.control.pc [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_StackTrait_for_Stack.
-  destruct run_LoopControl_for_Control.
   destruct run_Jumps_for_Bytecode.
   run_symbolic.
+  eapply Impl_Interpreter.run_halt_overflow.
 Defined.
 Global Opaque run_pc.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/ret.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/ret.v
@@ -16,6 +16,7 @@ Require Import revm.revm_interpreter.instructions.control.
 Require Import revm.revm_interpreter.instructions.links.control.return_inner.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
@@ -26,19 +27,15 @@ Require Import ruint.links.from.
 Require Import ruint.links.lib.
 
 (*
-pub fn ret<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
-)
+pub fn ret<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>)
 *)
 Instance run_ret
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.control.ret [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.control.ret [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/return_inner.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/return_inner.v
@@ -41,13 +41,40 @@ Instance run_return_inner
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
+  pose proof run_MemoryTrait_for_Memory as run_MemoryTrait_for_Memory_copy.
   destruct run_MemoryTrait_for_Memory.
   destruct run_Deref_for_Synthetic.
   destruct Impl_Default_for_Bytes.run.
   destruct (Impl_Into_for_From_T.run Impl_From_Vec_u8_for_Bytes.run).
   run_symbolic.
+  all: match goal with
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_underflow _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt_underflow
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt_overflow
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_memory_oog _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt_memory_oog
+  | |- Run.Trait
+      shared_memory.interpreter.shared_memory.resize_memory
+      _ _ _ _ =>
+      eapply (@shared_memory.run_resize_memory _ _ _ _ _ _ run_MemoryTrait_for_Memory_copy)
+  | |- Run.Trait
+      interpreter_action.interpreter_action.Impl_revm_interpreter_interpreter_action_InterpreterAction.new_return
+      _ _ _ _ =>
+      typeclasses eauto
+  end.
 Defined.
 Global Opaque run_return_inner.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/revert.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/revert.v
@@ -16,6 +16,7 @@ Require Import revm.revm_interpreter.instructions.control.
 Require Import revm.revm_interpreter.instructions.links.control.return_inner.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
@@ -26,19 +27,15 @@ Require Import ruint.links.from.
 Require Import ruint.links.lib.
 
 (*
-pub fn revert<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
-)
+pub fn revert<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>)
 *)
 Instance run_revert
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.control.revert [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.control.revert [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
@@ -46,5 +43,15 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   run_symbolic.
+  all: match goal with
+  | |- Run.Trait
+      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_not_activated _)
+      _ _ _ _ =>
+      eapply Impl_Interpreter.run_halt_not_activated
+  | |- Run.Trait
+      instructions.control.return_inner
+      _ _ _ _ =>
+      eapply run_return_inner
+  end.
 Defined.
 Global Opaque run_revert.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/stop.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/stop.v
@@ -15,6 +15,7 @@ Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.control.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
@@ -25,24 +26,21 @@ Require Import ruint.links.from.
 Require Import ruint.links.lib.
 
 (*
-pub fn stop<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
-)
+pub fn stop<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>)
 *)
 Instance run_stop
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.control.stop [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.control.stop [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
   run_symbolic.
+  eapply Impl_Interpreter.run_halt.
 Defined.
 Global Opaque run_stop.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/unknown.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/unknown.v
@@ -15,6 +15,7 @@ Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.control.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
@@ -25,29 +26,21 @@ Require Import ruint.links.from.
 Require Import ruint.links.lib.
 
 (*
-pub fn unknown<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
-)
+pub fn unknown<WIRE: InterpreterTypes, H: ?Sized>(context: InstructionContext<'_, H, WIRE>)
 *)
 Instance run_unknown
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.control.unknown [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.control.unknown [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  cbn.
-  eapply Run.Rewrite. {
-    erewrite IsTraitAssociatedType_eq by apply run_InterpreterTypes_for_WIRE.
-    reflexivity.
-  }
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
   run_symbolic.
+  eapply Impl_Interpreter.run_halt.
 Defined.
 Global Opaque run_unknown.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/README.md
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/README.md
@@ -77,7 +77,7 @@ Rust source: [`../control.rs`](../control.rs)
 | [invalid](control/invalid.v) | ✓ |
 | [jump](control/jump.v) | ✓ |
 | [jump_inner](control/jump_inner.v) | ✓ |
-| [jumpdest_or_nop](control/jumpdest_or_nop.v) | ✓ |
+| [jumpdest](control/jumpdest.v) | ✓ |
 | [jumpi](control/jumpi.v) | ✓ |
 | [pc](control/pc.v) | ✓ |
 | [ret](control/ret.v) | ✓ |

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/invalid.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/invalid.v
@@ -6,10 +6,12 @@ Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.control.invalid.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
 Require Import revm.revm_interpreter.links.interpreter_types.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import revm.revm_primitives.simulate.hardfork.
@@ -24,13 +26,7 @@ Definition invalid
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  let control :=
-    IInterpreterTypes
-      .(InterpreterTypes.LoopControl_for_Control)
-      .(LoopControl.set_instruction_result)
-      interpreter.(Interpreter.control)
-      instruction_result.InstructionResult.InvalidFEOpcode in
-  interpreter <| Interpreter.control := control |>.
+  halt interpreter instruction_result.InstructionResult.InvalidFEOpcode.
 
 Lemma invalid_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -43,9 +39,13 @@ Lemma invalid_eq
     (_host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_invalid run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_invalid run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -56,6 +56,7 @@ Proof.
   intros.
   with_strategy transparent [run_invalid] unfold invalid, run_invalid; cbn.
   s. {
+    apply halt_eq.
     apply InterpreterTypesEq.
   }
   s.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/jump.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/jump.v
@@ -25,11 +25,10 @@ Definition jump
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.MID id (fun interpreter =>
   popn_macro interpreter 1 id (fun arr interpreter =>
   let '⟬ target ⟭ := arr.(array.value) in
   jump_inner interpreter target
-  )).
+  ).
 
 Lemma jump_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -42,9 +41,13 @@ Lemma jump_eq
     (_host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_jump run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_jump run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -54,7 +57,6 @@ Lemma jump_eq
 Proof.
   intros.
   with_strategy transparent [run_jump] unfold jump, run_jump; cbn.
-  gas_macro_eq idtac.
   popn_macro_eq InterpreterTypesEq.
   match goal with
   | array : array.t aliases.U256.t _ |- _ =>

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/jump_inner.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/jump_inner.v
@@ -10,6 +10,7 @@ Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
 Require Import revm.revm_interpreter.links.interpreter_types.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import revm.revm_primitives.simulate.hardfork.
@@ -33,13 +34,7 @@ Definition jump_inner
       target in
   let interpreter := interpreter <| Interpreter.bytecode := bytecode |> in
   if negb is_valid then
-    let control :=
-      IInterpreterTypes
-        .(InterpreterTypes.LoopControl_for_Control)
-        .(LoopControl.set_instruction_result)
-        interpreter.(Interpreter.control)
-        instruction_result.InstructionResult.InvalidJump in
-    interpreter <| Interpreter.control := control |>
+    halt interpreter instruction_result.InstructionResult.InvalidJump
   else
     let bytecode :=
       IInterpreterTypes.(InterpreterTypes.Jumps_for_Bytecode).(Jumps.absolute_jump)
@@ -84,6 +79,7 @@ Proof.
     s.
   }
   { s. {
+      apply halt_eq.
       apply InterpreterTypesEq.
     }
     s.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/jumpdest.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/jumpdest.v
@@ -3,7 +3,7 @@ Require Import alloy_primitives.bytes.simulate.mod.
 Require Import alloy_primitives.links.aliases.
 Require Import core.links.array.
 Require Import revm.revm_interpreter.gas.simulate.constants.
-Require Import revm.revm_interpreter.instructions.links.control.jumpdest_or_nop.
+Require Import revm.revm_interpreter.instructions.links.control.jumpdest.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.links.gas.
 Require Import revm.revm_interpreter.links.instruction_result.
@@ -18,15 +18,15 @@ Require Import ruint.simulate.cmp.
 Require Import ruint.simulate.from.
 Require Import ruint.simulate.lib.
 
-Definition jumpdest_or_nop
+Definition jumpdest
     {WIRE : Set} `{Link WIRE}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.JUMPDEST id id.
+  interpreter.
 
-Lemma jumpdest_or_nop_eq
+Lemma jumpdest_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
@@ -37,18 +37,20 @@ Lemma jumpdest_or_nop_eq
     (_host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_jumpdest_or_nop run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_jumpdest run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
-      [jumpdest_or_nop interpreter; _host]%stack
+      [jumpdest interpreter; _host]%stack
     )
   }}.
 Proof.
-  intros.
-  with_strategy transparent [run_jumpdest_or_nop] unfold jumpdest_or_nop, run_jumpdest_or_nop; cbn.
-  gas_macro_eq idtac.
+  with_strategy transparent [run_jumpdest] unfold jumpdest, run_jumpdest; cbn.
   s.
 Qed.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/jumpi.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/jumpi.v
@@ -25,14 +25,13 @@ Definition jumpi
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.HIGH id (fun interpreter =>
   popn_macro interpreter 2 id (fun arr interpreter =>
   let '⟬ target; cond ⟭ := arr.(array.value) in
   if negb (Impl_Uint.is_zero cond) then
     jump_inner interpreter target
   else
     interpreter
-  )).
+  ).
 
 Lemma jumpi_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -45,9 +44,13 @@ Lemma jumpi_eq
     (_host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_jumpi run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_jumpi run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -57,7 +60,6 @@ Lemma jumpi_eq
 Proof.
   intros.
   with_strategy transparent [run_jumpi] unfold jumpi, run_jumpi; cbn.
-  gas_macro_eq idtac.
   popn_macro_eq InterpreterTypesEq.
   match goal with
   | array : array.t aliases.U256.t _ |- _ =>

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/pc.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/pc.v
@@ -6,6 +6,7 @@ Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.control.pc.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
@@ -24,13 +25,12 @@ Definition pc
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.BASE id (fun interpreter =>
   let pc :=
     IInterpreterTypes.(InterpreterTypes.Jumps_for_Bytecode).(Jumps.pc)
       interpreter.(Interpreter.bytecode) in
   let value : aliases.U256.t := {| Uint.value := i[pc -i 1] |} in
   push_macro interpreter value id id
-  ).
+  .
 
 Lemma pc_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -43,9 +43,13 @@ Lemma pc_eq
     (_host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_pc run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_pc run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -55,7 +59,6 @@ Lemma pc_eq
 Proof.
   intros.
   with_strategy transparent [run_pc] unfold pc, run_pc; cbn.
-  gas_macro_eq idtac.
   s. {
     apply InterpreterTypesEq.
   }

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/ret.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/ret.v
@@ -6,6 +6,7 @@ Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.control.ret.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
@@ -38,9 +39,13 @@ Lemma ret_eq
     (_host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    InstructionContext.interpreter := ref_interpreter;
+    InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_ret run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_ret run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/return_inner.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/return_inner.v
@@ -13,6 +13,7 @@ Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
 Require Import revm.revm_interpreter.links.interpreter_types.
+Require Import revm.revm_interpreter.simulate.interpreter_action.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import revm.revm_primitives.simulate.hardfork.
@@ -31,28 +32,20 @@ Definition return_inner
   popn_macro interpreter 2 id (fun _arr interpreter =>
   let '⟬ offset; len ⟭ := _arr.(array.value) in
   as_usize_or_fail_macro interpreter len None id (fun len interpreter =>
-  (* We factorize the end of the function in [next] *)
   let next output interpreter :=
-    let gas :=
-      IInterpreterTypes
-        .(InterpreterTypes.LoopControl_for_Control)
-        .(LoopControl.gas)
-        .(RefStub.projection)
-        interpreter.(Interpreter.control) in
     let action :=
       interpreter_action.InterpreterAction.Return {|
         InterpreterResult.result := instruction_result;
         InterpreterResult.output := output;
-        InterpreterResult.gas := gas;
+        InterpreterResult.gas := interpreter.(Interpreter.gas);
       |} in
-    let control :=
+    let bytecode :=
       IInterpreterTypes
-        .(InterpreterTypes.LoopControl_for_Control)
-        .(LoopControl.set_next_action)
-        interpreter.(Interpreter.control)
-        action
-        instruction_result in
-    interpreter <| Interpreter.control := control |> in
+        .(InterpreterTypes.LoopControl_for_Bytecode)
+        .(LoopControl.set_action)
+        interpreter.(Interpreter.bytecode)
+        action in
+    interpreter <| Interpreter.bytecode := bytecode |> in
   if negb (i[len] =? 0) then
     as_usize_or_fail_macro interpreter offset None id (fun offset interpreter =>
     resize_memory_macro interpreter offset len id (fun interpreter =>
@@ -111,30 +104,22 @@ Proof.
   s; destruct negb; cbn.
   { as_usize_or_fail_macro_eq InterpreterTypesEq.
     resize_memory_macro_eq InterpreterTypesEq.
-    s. {
-      apply InterpreterTypesEq.
-    }
-    s. {
-      apply InterpreterTypesEq.
-    }
-    s. {
+    - apply InterpreterTypesEq.
+    - apply InterpreterTypesEq.
+    - {
       set (ref_self := Ref.cast_to _ _).
       apply (Impl_Slice.to_vec_eq _ ref_self); repeat unshelve econstructor.
     }
-    s. {
-      apply Impl_Into_for_From_T.Eq.I.
+    - s. {
+      apply Impl_From_Vec_u8_for_Bytes.from_eq.
     }
-    s. {
-      apply InterpreterTypesEq.
-    }
-    s. {
-      apply InterpreterTypesEq.
-    }
-    s.
-    now destruct _.(MemoryTrait.resize).
+    - cbn.
+      constructor.
+      constructor.
+    - reflexivity.
   }
   { s. {
-      apply InterpreterTypesEq.
+      apply new_return_eq.
     }
     s. {
       apply InterpreterTypesEq.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/revert.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/revert.v
@@ -6,10 +6,12 @@ Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.control.revert.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
 Require Import revm.revm_interpreter.links.interpreter_types.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import revm.revm_primitives.simulate.hardfork.
@@ -39,9 +41,13 @@ Lemma revert_eq
     (_host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    InstructionContext.interpreter := ref_interpreter;
+    InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_revert run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_revert run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -51,13 +57,29 @@ Lemma revert_eq
 Proof.
   intros.
   with_strategy transparent [run_revert] unfold revert, run_revert; cbn.
-  check_macro_eq InterpreterTypesEq.
+  unfold check_macro; cbn.
   s. {
-    apply (return_inner_eq
-      run_InterpreterTypes_for_WIRE
-      IInterpreterTypes
-      InterpreterTypesEq
-    ).
+    apply InterpreterTypesEq
+      .(InterpreterTypes.Eq.RuntimeFlag_for_RuntimeFlag)
+      .(RuntimeFlag.Eq.spec_id).
   }
-  s.
+  s. {
+    apply Impl_SpecId.is_enabled_in_eq.
+  }
+  s; destruct Impl_SpecId.is_enabled_in; cbn.
+  { s. {
+      apply (return_inner_eq
+        run_InterpreterTypes_for_WIRE
+        IInterpreterTypes
+        InterpreterTypesEq
+      ).
+    }
+    s.
+  }
+  { s. {
+      apply halt_not_activated_eq.
+      apply InterpreterTypesEq.
+    }
+    s.
+  }
 Qed.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/stop.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/stop.v
@@ -6,10 +6,12 @@ Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.control.stop.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
 Require Import revm.revm_interpreter.links.interpreter_types.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import revm.revm_primitives.simulate.hardfork.
@@ -24,13 +26,7 @@ Definition stop
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  let control :=
-    IInterpreterTypes
-      .(InterpreterTypes.LoopControl_for_Control)
-      .(LoopControl.set_instruction_result)
-      interpreter.(Interpreter.control)
-      instruction_result.InstructionResult.Stop in
-  interpreter <| Interpreter.control := control |>.
+  halt interpreter instruction_result.InstructionResult.Stop.
 
 Lemma stop_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -43,9 +39,13 @@ Lemma stop_eq
     (_host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_stop run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_stop run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -56,6 +56,7 @@ Proof.
   intros.
   with_strategy transparent [run_stop] unfold stop, run_stop; cbn.
   s. {
+    apply halt_eq.
     apply InterpreterTypesEq.
   }
   s.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/unknown.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/control/unknown.v
@@ -6,10 +6,12 @@ Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.control.unknown.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
 Require Import revm.revm_interpreter.links.interpreter_types.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import revm.revm_primitives.simulate.hardfork.
@@ -24,13 +26,7 @@ Definition unknown
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  let control :=
-    IInterpreterTypes
-      .(InterpreterTypes.LoopControl_for_Control)
-      .(LoopControl.set_instruction_result)
-      interpreter.(Interpreter.control)
-      instruction_result.InstructionResult.OpcodeNotFound in
-  interpreter <| Interpreter.control := control |>.
+  halt interpreter instruction_result.InstructionResult.OpcodeNotFound.
 
 Lemma unknown_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -43,9 +39,13 @@ Lemma unknown_eq
     (_host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_unknown run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_unknown run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -56,6 +56,7 @@ Proof.
   intros.
   with_strategy transparent [run_unknown] unfold unknown, run_unknown; cbn.
   s. {
+    apply halt_eq.
     apply InterpreterTypesEq.
   }
   s.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
@@ -104,14 +104,7 @@ Definition popn_macro {WIRE K : Set} `{Link WIRE}
         <| Interpreter.stack := stack |> in
     match result with
     | Some arr => k arr interpreter
-    | None =>
-      let control :=
-        IInterpreterTypes.(InterpreterTypes.LoopControl_for_Control).(LoopControl.set_instruction_result)
-        interpreter.(Interpreter.control)
-        instruction_result.InstructionResult.StackUnderflow in
-      let interpreter := interpreter
-        <| Interpreter.control := control |> in
-      k_exit interpreter
+    | None => k_exit (halt_underflow interpreter)
     end.
 
 Ltac popn_macro_eq InterpreterTypesEq :=
@@ -121,7 +114,8 @@ Ltac popn_macro_eq InterpreterTypesEq :=
   |];
   destruct _.(InterpreterTypes.StackTrait_for_Stack).(StackTrait.popn) as [[|] ?]; [|
     s; [
-      apply InterpreterTypesEq
+      eapply halt_underflow_eq;
+      try exact InterpreterTypesEq
     |];
     s
   ].
@@ -290,16 +284,7 @@ Definition check_macro {WIRE K : Set} `{Link WIRE}
   then
     k interpreter
   else
-    let control :=
-      IInterpreterTypes
-          .(InterpreterTypes.LoopControl_for_Control)
-          .(LoopControl.set_instruction_result)
-        interpreter.(Interpreter.control)
-        instruction_result.InstructionResult.NotActivated in
-    let interpreter :=
-      interpreter
-        <| Interpreter.control := control |> in
-    k_exit interpreter.
+    k_exit (halt_not_activated interpreter).
 
 Ltac check_macro_eq InterpreterTypesEq :=
   unfold check_macro; cbn;
@@ -323,15 +308,8 @@ Ltac check_macro_eq InterpreterTypesEq :=
   |];
   cbn;
   destruct Impl_SpecId.is_enabled_in; cbn; [|
-    apply Run.LetUnfold;
-    cbn;
-    eapply Run.Call; [
-      apply InterpreterTypesEq
-        .(InterpreterTypes.Eq.LoopControl_for_Control)
-        .(LoopControl.Eq.set_instruction_result)
-    |];
-    cbn;
-    apply Run.Pure
+    apply halt_not_activated_eq;
+    apply InterpreterTypesEq
   ].
 
 Definition as_u64_saturated_macro (v : aliases.U256.t) : u64 :=

--- a/RocqOfRust/revm/revm_interpreter/links/interpreter.v
+++ b/RocqOfRust/revm/revm_interpreter/links/interpreter.v
@@ -136,6 +136,23 @@ Module Impl_Interpreter.
   Defined.
   Global Opaque run_halt_memory_oog.
 
+  (* pub fn halt_not_activated(&mut self) *)
+  Instance run_halt_not_activated
+      (IW : Set) `{Link IW}
+      {IW_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks IW_types}
+      {run_InterpreterTypes_for_IW : InterpreterTypes.Run IW IW_types}
+      (self : '&mut (Self IW run_InterpreterTypes_for_IW)) :
+    Run.Trait
+      (interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_not_activated (Φ IW))
+      [] [] [φ self]
+      unit.
+  Proof.
+    constructor.
+    run_symbolic.
+    eapply (@run_halt IW H IW_types H0 run_InterpreterTypes_for_IW).
+  Defined.
+  Global Opaque run_halt_not_activated.
+
   (* (*
   pub fn run<FN, H: Host>(
       &mut self,

--- a/RocqOfRust/revm/revm_interpreter/links/interpreter_action.v
+++ b/RocqOfRust/revm/revm_interpreter/links/interpreter_action.v
@@ -290,6 +290,21 @@ Module Impl_InterpreterAction.
     run_symbolic.
   Defined.   
 
+  (* pub fn new_return(result: InstructionResult, output: Bytes, gas: Gas) -> Self *)
+  Instance run_new_return
+      (result : InstructionResult.t)
+      (output : Bytes.t)
+      (gas : Gas.t) :
+    Run.Trait
+      interpreter_action.Impl_revm_interpreter_interpreter_action_InterpreterAction.new_return
+        [] [] [φ result; φ output; φ gas]
+      Self.
+  Proof.
+    constructor.
+    run_symbolic.
+  Defined.
+  Global Opaque run_new_return.
+
   (* pub fn is_call(&self) -> bool *)
   Instance run_is_call (self : '& Self) :
     Run.Trait

--- a/RocqOfRust/revm/revm_interpreter/links/interpreter_action.v.jinja2
+++ b/RocqOfRust/revm/revm_interpreter/links/interpreter_action.v.jinja2
@@ -58,6 +58,21 @@ Module Impl_InterpreterAction.
     run_symbolic.
   Defined.   
 
+  (* pub fn new_return(result: InstructionResult, output: Bytes, gas: Gas) -> Self *)
+  Instance run_new_return
+      (result : InstructionResult.t)
+      (output : Bytes.t)
+      (gas : Gas.t) :
+    Run.Trait
+      interpreter_action.Impl_revm_interpreter_interpreter_action_InterpreterAction.new_return
+        [] [] [φ result; φ output; φ gas]
+      Self.
+  Proof.
+    constructor.
+    run_symbolic.
+  Defined.
+  Global Opaque run_new_return.
+
   (* pub fn is_call(&self) -> bool *)
   Instance run_is_call (self : '& Self) :
     Run.Trait

--- a/RocqOfRust/revm/revm_interpreter/simulate/interpreter.v
+++ b/RocqOfRust/revm/revm_interpreter/simulate/interpreter.v
@@ -45,12 +45,26 @@ Definition halt_memory_oog {WIRE : Set} `{Link WIRE}
     Interpreter.t WIRE WIRE_types :=
   halt interpreter instruction_result.InstructionResult.MemoryOOG.
 
+Definition halt_underflow {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (interpreter : Interpreter.t WIRE WIRE_types) :
+    Interpreter.t WIRE WIRE_types :=
+  halt interpreter instruction_result.InstructionResult.StackUnderflow.
+
 Definition halt_overflow {WIRE : Set} `{Link WIRE}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
   halt interpreter instruction_result.InstructionResult.StackOverflow.
+
+Definition halt_not_activated {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (interpreter : Interpreter.t WIRE WIRE_types) :
+    Interpreter.t WIRE WIRE_types :=
+  halt interpreter instruction_result.InstructionResult.NotActivated.
 
 Lemma stack_dealloc_cons_alloc_unit
     (A : Set)
@@ -260,6 +274,57 @@ Proof.
     Impl_Interpreter.run_halt_overflow
     Impl_Interpreter.run_halt
   ] unfold Impl_Interpreter.run_halt_overflow, Impl_Interpreter.run_halt.
+  cbn.
+  repeat s.
+  - apply Impl_Bytes.new_eq.
+  - apply InterpreterTypesEq
+      .(InterpreterTypes.Eq.LoopControl_for_Bytecode)
+      .(LoopControl.BytecodeEq.set_action).
+  - repeat rewrite Stack.dealloc_alloc_eq;
+    repeat rewrite stack_dealloc_cons_alloc_unit;
+    reflexivity.
+Qed.
+
+Lemma halt_not_activated_eq {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (InterpreterTypesEq :
+      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (stack_rest : Stack.t) :
+  let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+  let action :=
+    interpreter_action.InterpreterAction.Return {|
+      InterpreterResult.result := instruction_result.InstructionResult.NotActivated;
+      InterpreterResult.output := Impl_Bytes.new;
+      InterpreterResult.gas := interpreter.(Interpreter.gas);
+    |} in
+  {{
+    SimulateM.eval_f
+      (Impl_Interpreter.run_halt_not_activated WIRE ref_interpreter)
+      (interpreter :: stack_rest)%stack 🌲
+    (
+      Output.Success tt,
+      (
+        interpreter
+          <| Interpreter.bytecode :=
+            IInterpreterTypes
+              .(InterpreterTypes.LoopControl_for_Bytecode)
+              .(LoopControl.set_action)
+              interpreter.(Interpreter.bytecode)
+              action
+          |>
+        :: stack_rest
+      )%stack
+    )
+  }}.
+Proof.
+  intros.
+  with_strategy transparent [
+    Impl_Interpreter.run_halt_not_activated
+    Impl_Interpreter.run_halt
+  ] unfold Impl_Interpreter.run_halt_not_activated, Impl_Interpreter.run_halt.
   cbn.
   repeat s.
   - apply Impl_Bytes.new_eq.

--- a/RocqOfRust/revm/revm_interpreter/simulate/interpreter_action.v
+++ b/RocqOfRust/revm/revm_interpreter/simulate/interpreter_action.v
@@ -1,0 +1,39 @@
+Require Import simulate.RocqOfRust.
+Require Import alloy_primitives.bytes.links.mod.
+Require Import alloy_primitives.bytes.simulate.mod.
+Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.interpreter_action.
+Require Import revm.revm_interpreter.links.interpreter_InterpreterResult.
+Require Import revm.revm_interpreter.links.instruction_result.
+
+Definition new_return
+    (result : InstructionResult.t)
+    (output : Bytes.t)
+    (gas : Gas.t) :
+    InterpreterAction.t :=
+  InterpreterAction.Return {|
+    InterpreterResult.result := result;
+    InterpreterResult.output := output;
+    InterpreterResult.gas := gas;
+  |}.
+
+Lemma new_return_eq
+    (result : InstructionResult.t)
+    (output : Bytes.t)
+    (gas : Gas.t)
+    (stack : Stack.t) :
+  {{
+    SimulateM.eval_f
+      (Impl_InterpreterAction.run_new_return result output gas)
+      stack 🌲
+    (
+      Output.Success (new_return result output gas),
+      stack
+    )
+  }}.
+Proof.
+  with_strategy transparent [Impl_InterpreterAction.run_new_return]
+    unfold new_return, Impl_InterpreterAction.run_new_return.
+  cbn.
+  s.
+Qed.


### PR DESCRIPTION
This PR continues the Revm v103 compile-slice work for the control instructions.

It updates the control instruction links and simulate files to use the current InstructionContext shape, and replaces the stale jumpdest_or_nop files with the current jumpdest path.

It also adds the missing interpreter-side helper for the not-activated halt path and the interpreter-action helper for constructing return actions, so revert and return_inner can follow the current translated v103 flow.

The fake-body scan and new-admit scan are clean. No local translated Rust bodies or wrong-argument stubs were added.