### PR TITLE
Update Revm v103 arithmetic add simulate slice

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
@@ -1,10 +1,12 @@
 Require Import links.RocqOfRust.
 Require Import core.links.cmp.
+Require Import core.links.option.
 Require Import revm.revm_interpreter.instructions.arithmetic.
 Require Import revm.revm_context_interface.links.host.
 Require Import revm.revm_interpreter.gas.links.calc.
 Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -22,8 +24,7 @@ Require Import ruint.links.pow.
 
 (*
 pub fn add<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
+    context: InstructionContext<'_, H, WIRE>,
 )
 *)
 Instance run_add
@@ -31,14 +32,18 @@ Instance run_add
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.arithmetic.add [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.arithmetic.add [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_LoopControl_for_Control.
   run_symbolic.
+  all: try eapply Impl_Interpreter.run_halt_underflow.
+  all: try eapply Impl_Option.run_unwrap_unchecked.
 Defined.
 Global Opaque run_add.
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/add.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/add.v
@@ -1,14 +1,17 @@
 Require Import simulate.RocqOfRust.
 Require Import alloy_primitives.links.aliases.
 Require Import core.links.array.
+Require Import core.simulate.option.
 Require Import revm.revm_context_interface.links.host.
 Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.arithmetic.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.gas.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import ruint.links.lib.
 Require Import ruint.simulate.add.
@@ -19,7 +22,6 @@ Definition add
     `{!InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.VERYLOW id (fun interpreter =>
   popn_top_macro interpreter 1 id (fun arr top interpreter =>
   let '⟬ op1 ⟭ := arr.(array.value) in
   let op2 := top.(RefStub.projection) interpreter.(Interpreter.stack) in
@@ -28,7 +30,7 @@ Definition add
       interpreter.(Interpreter.stack) (Impl_Uint.wrapping_add op1 op2) in
   interpreter
     <| Interpreter.stack := stack |>
-  )).
+  ).
 
 Lemma add_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -42,9 +44,13 @@ Lemma add_eq
     (_host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_add run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_add run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -56,15 +62,64 @@ Lemma add_eq
   }}.
 Proof.
   intros.
-  unfold add.
-  gas_macro_eq idtac.
-  popn_top_macro_eq InterpreterTypesEq.
-  match goal with
-  | array : array.t aliases.U256.t _ |- _ =>
-    destruct array as [[op1 []]]
-  end.
-  s. {
-    apply Impl_Uint.wrapping_add_eq.
+  with_strategy transparent [run_add] unfold add, run_add; cbn.
+  unfold popn_top_macro.
+  s; [
+    apply InterpreterTypesEq
+      .(InterpreterTypes.Eq.StackTrait_for_Stack)
+      .(StackTrait.Eq.len)
+  |].
+  repeat s.
+  destruct (_ <? _) eqn:H_len; cbn.
+  { s; [
+      eapply halt_underflow_eq;
+      try exact InterpreterTypesEq
+    |].
+    repeat s.
   }
-  s.
+  eapply Run.Call; [
+    apply InterpreterTypesEq
+      .(InterpreterTypes.Eq.StackTrait_for_Stack)
+      .(StackTrait.Eq.popn_top)
+  |].
+  cbn.
+  destruct
+    (IInterpreterTypes
+      .(InterpreterTypes.StackTrait_for_Stack)
+      .(StackTrait.popn_top) {| Integer.value := 1 |} interpreter.(Interpreter.stack))
+    as [[[arr top] |] stack] eqn:H_popn_top;
+    cbn.
+  { eapply Run.Call; [
+      eapply Impl_Option.unwrap_unchecked_eq;
+      reflexivity
+    |].
+    cbn.
+    match goal with
+    | array : array.t aliases.U256.t _ |- _ =>
+      destruct array as [[op1 []]]
+    end.
+    s; [
+      apply Impl_Uint.wrapping_add_eq
+    |].
+    s.
+    change
+      (IInterpreterTypes
+        .(InterpreterTypes.StackTrait_for_Stack)
+        .(StackTrait.popn_top) 1 interpreter.(Interpreter.stack))
+      with
+      (IInterpreterTypes
+        .(InterpreterTypes.StackTrait_for_Stack)
+        .(StackTrait.popn_top) {| Integer.value := 1 |} interpreter.(Interpreter.stack)).
+    rewrite H_popn_top.
+    reflexivity.
+  }
+  pose proof (
+    StackTrait.popn_top_some_of_len
+      IInterpreterTypes.(InterpreterTypes.StackTrait_for_Stack)
+      interpreter.(Interpreter.stack)
+      {| Integer.value := 1 |}
+      H_len
+  ) as (? & ? & ? & H_some).
+  rewrite H_popn_top in H_some.
+  discriminate.
 Qed.

--- a/RocqOfRust/revm/revm_interpreter/simulate/interpreter_types.v
+++ b/RocqOfRust/revm/revm_interpreter/simulate/interpreter_types.v
@@ -589,6 +589,16 @@ Module StackTrait.
     dup (self : Self) (n : usize) : bool * Self;
   }.
 
+  Lemma popn_top_some_of_len
+      {Self : Set} `{Link Self}
+      (IStackTrait : C Self)
+      (stack : Self)
+      (N : usize) :
+    (i[IStackTrait.(len) stack] <? 1 + i[N]) = false ->
+    exists arr top stack',
+      IStackTrait.(popn_top) N stack = (Some (arr, top), stack').
+  Admitted.
+
   Module Eq.
     Class t
         (WIRE : Set) {WIRE_types : InterpreterTypes.Types.t}


### PR DESCRIPTION
This PR continues the Revm v103 instruction simulate work with a small arithmetic `add` slice.

It updates the `add` link and simulate files to use the current `InstructionContext` shape, removes the stale gas step from the pure simulate body, and restores `add_eq` as a `Qed` proof against the current generated v103 flow.

The local checks passed.

The fake-body scan is clean. No local translated Rust bodies, `PolymorphicFunction.t` stubs, `LowM.Pure (inl ...)`, or wrong-argument stubs were added.

One admitted dependency boundary remains in the stack trait simulate layer: `StackTrait.popn_top_some_of_len`. This captures the stack/reference fact needed after the length check before `unwrap_unchecked`, while keeping the `add` instruction body proof verified.