### PR TITLE
Update Revm v103 arithmetic mul simulate slice

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
@@ -49,26 +49,26 @@ Global Opaque run_add.
 
 (*
 pub fn mul<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
-) {
-    gas!(interpreter, gas::LOW);
-    popn_top!([op1], op2, interpreter);
-    *op2 = op1.wrapping_mul( *op2);
-}
+    context: InstructionContext<'_, H, WIRE>,
+)
 *)
 Instance run_mul
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.arithmetic.mul [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.arithmetic.mul [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_LoopControl_for_Control.
   run_symbolic.
+  all: try eapply Impl_Interpreter.run_halt_underflow.
+  all: try eapply Impl_Option.run_unwrap_unchecked.
 Defined.
 Global Opaque run_mul.
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/mul.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/mul.v
@@ -60,63 +60,19 @@ Lemma mul_eq
 Proof.
   intros.
   with_strategy transparent [run_mul] unfold mul, run_mul; cbn.
-  unfold popn_top_macro.
-  s; [
-    apply InterpreterTypesEq
-      .(InterpreterTypes.Eq.StackTrait_for_Stack)
-      .(StackTrait.Eq.len)
-  |].
-  repeat s.
-  destruct (_ <? _) eqn:H_len; cbn.
-  { s; [
-      eapply halt_underflow_eq;
-      try exact InterpreterTypesEq
-    |].
-    repeat s.
-  }
+  popn_top_macro_eq InterpreterTypesEq.
+  cbn.
   eapply Run.Call; [
-    apply InterpreterTypesEq
-      .(InterpreterTypes.Eq.StackTrait_for_Stack)
-      .(StackTrait.Eq.popn_top)
+    eapply Impl_Option.unwrap_unchecked_eq;
+    reflexivity
   |].
   cbn.
-  destruct
-    (IInterpreterTypes
-      .(InterpreterTypes.StackTrait_for_Stack)
-      .(StackTrait.popn_top) {| Integer.value := 1 |} interpreter.(Interpreter.stack))
-    as [[[arr top] |] stack] eqn:H_popn_top;
-    cbn.
-  { eapply Run.Call; [
-      eapply Impl_Option.unwrap_unchecked_eq;
-      reflexivity
-    |].
-    cbn.
-    match goal with
-    | array : array.t aliases.U256.t _ |- _ =>
-      destruct array as [[op1 []]]
-    end.
-    s; [
-      apply Impl_Uint.wrapping_mul_eq
-    |].
-    s.
-    change
-      (IInterpreterTypes
-        .(InterpreterTypes.StackTrait_for_Stack)
-        .(StackTrait.popn_top) 1 interpreter.(Interpreter.stack))
-      with
-      (IInterpreterTypes
-        .(InterpreterTypes.StackTrait_for_Stack)
-        .(StackTrait.popn_top) {| Integer.value := 1 |} interpreter.(Interpreter.stack)).
-    rewrite H_popn_top.
-    reflexivity.
-  }
-  pose proof (
-    StackTrait.popn_top_some_of_len
-      IInterpreterTypes.(InterpreterTypes.StackTrait_for_Stack)
-      interpreter.(Interpreter.stack)
-      {| Integer.value := 1 |}
-      H_len
-  ) as (? & ? & ? & H_some).
-  rewrite H_popn_top in H_some.
-  discriminate.
+  match goal with
+  | array : array.t aliases.U256.t _ |- _ =>
+    destruct array as [[op1 []]]
+  end.
+  s; [
+    apply Impl_Uint.wrapping_mul_eq
+  |].
+  s.
 Qed.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/mul.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/mul.v
@@ -1,14 +1,14 @@
 Require Import simulate.RocqOfRust.
 Require Import alloy_primitives.links.aliases.
 Require Import core.links.array.
+Require Import core.simulate.option.
 Require Import revm.revm_context_interface.links.host.
-Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.arithmetic.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
-Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
-Require Import revm.revm_interpreter.simulate.gas.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import ruint.links.lib.
 Require Import ruint.simulate.mul.
@@ -19,7 +19,6 @@ Definition mul
     `{!InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.LOW id (fun interpreter =>
   popn_top_macro interpreter 1 id (fun arr top interpreter =>
   let '⟬ op1 ⟭ := arr.(array.value) in
   let op2 := top.(RefStub.projection) interpreter.(Interpreter.stack) in
@@ -28,7 +27,7 @@ Definition mul
       interpreter.(Interpreter.stack) (Impl_Uint.wrapping_mul op1 op2) in
   interpreter
     <| Interpreter.stack := stack |>
-  )).
+  ).
 
 Lemma mul_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -42,9 +41,13 @@ Lemma mul_eq
     (_host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_mul run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_mul run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -56,15 +59,64 @@ Lemma mul_eq
   }}.
 Proof.
   intros.
-  unfold mul.
-  gas_macro_eq idtac.
-  popn_top_macro_eq InterpreterTypesEq.
-  match goal with
-  | array : array.t aliases.U256.t _ |- _ =>
-    destruct array as [[op1 []]]
-  end.
-  s. {
-    apply Impl_Uint.wrapping_mul_eq.
+  with_strategy transparent [run_mul] unfold mul, run_mul; cbn.
+  unfold popn_top_macro.
+  s; [
+    apply InterpreterTypesEq
+      .(InterpreterTypes.Eq.StackTrait_for_Stack)
+      .(StackTrait.Eq.len)
+  |].
+  repeat s.
+  destruct (_ <? _) eqn:H_len; cbn.
+  { s; [
+      eapply halt_underflow_eq;
+      try exact InterpreterTypesEq
+    |].
+    repeat s.
   }
-  s.
+  eapply Run.Call; [
+    apply InterpreterTypesEq
+      .(InterpreterTypes.Eq.StackTrait_for_Stack)
+      .(StackTrait.Eq.popn_top)
+  |].
+  cbn.
+  destruct
+    (IInterpreterTypes
+      .(InterpreterTypes.StackTrait_for_Stack)
+      .(StackTrait.popn_top) {| Integer.value := 1 |} interpreter.(Interpreter.stack))
+    as [[[arr top] |] stack] eqn:H_popn_top;
+    cbn.
+  { eapply Run.Call; [
+      eapply Impl_Option.unwrap_unchecked_eq;
+      reflexivity
+    |].
+    cbn.
+    match goal with
+    | array : array.t aliases.U256.t _ |- _ =>
+      destruct array as [[op1 []]]
+    end.
+    s; [
+      apply Impl_Uint.wrapping_mul_eq
+    |].
+    s.
+    change
+      (IInterpreterTypes
+        .(InterpreterTypes.StackTrait_for_Stack)
+        .(StackTrait.popn_top) 1 interpreter.(Interpreter.stack))
+      with
+      (IInterpreterTypes
+        .(InterpreterTypes.StackTrait_for_Stack)
+        .(StackTrait.popn_top) {| Integer.value := 1 |} interpreter.(Interpreter.stack)).
+    rewrite H_popn_top.
+    reflexivity.
+  }
+  pose proof (
+    StackTrait.popn_top_some_of_len
+      IInterpreterTypes.(InterpreterTypes.StackTrait_for_Stack)
+      interpreter.(Interpreter.stack)
+      {| Integer.value := 1 |}
+      H_len
+  ) as (? & ? & ? & H_some).
+  rewrite H_popn_top in H_some.
+  discriminate.
 Qed.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/macros.v
@@ -215,7 +215,8 @@ Ltac popn_top_macro_eq InterpreterTypesEq :=
       .(StackTrait.Eq.len)
   |];
   repeat s;
-  destruct (_ <? _) eqn:?; cbn;
+  let H_len := fresh "H_len" in
+  destruct (_ <? _) eqn:H_len; cbn;
   [
     s; [
       eapply halt_underflow_eq;
@@ -229,11 +230,21 @@ Ltac popn_top_macro_eq InterpreterTypesEq :=
       .(StackTrait.Eq.popn_top)
   |];
   cbn;
-  destruct _.(InterpreterTypes.StackTrait_for_Stack).(StackTrait.popn_top) as [[[? ?]|] ?];
+  let H_popn_top := fresh "H_popn_top" in
+  destruct _.(InterpreterTypes.StackTrait_for_Stack).(StackTrait.popn_top)
+    as [[[? ?] |] ?] eqn:H_popn_top;
   [
     idtac
   |
-    s
+    match type of H_popn_top with
+    | ?IStackTrait.(StackTrait.popn_top) ?N ?stack = (None, ?stack') =>
+      let H_some := fresh "H_some" in
+      pose proof (
+        StackTrait.popn_top_some_of_len IStackTrait stack N H_len
+      ) as (? & ? & ? & H_some);
+      rewrite H_popn_top in H_some;
+      discriminate
+    end
   ].
 
 Definition push_macro {WIRE K : Set} `{Link WIRE}


### PR DESCRIPTION
This PR continues the Revm v103 arithmetic work with the `mul` simulate slice.

It updates `mul` to use the current `InstructionContext` shape and adjusts the simulate body to match the current Rust body. The old fixed gas step is not modeled in the body because Rust now charges that static gas before the instruction function runs.

The local arithmetic links check, direct `mul` simulate check, and targeted `mul.vo` make check passed.

The fake-body scan is clean. No new admitted boundaries remain; `mul_eq` is closed with `Qed`.