### PR TITLE
Update Revm v103 arithmetic div simulate slice

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
@@ -99,22 +99,26 @@ Global Opaque run_sub.
 
 (*
 pub fn div<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
-) 
+    context: InstructionContext<'_, H, WIRE>,
+)
 *)
 Instance run_div
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.arithmetic.div [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.arithmetic.div [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_LoopControl_for_Control.
   run_symbolic.
+  all: try eapply Impl_Interpreter.run_halt_underflow.
+  all: try eapply Impl_Option.run_unwrap_unchecked.
 Defined.
 Global Opaque run_div.
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
@@ -42,8 +42,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  all: try eapply Impl_Interpreter.run_halt_underflow.
-  all: try eapply Impl_Option.run_unwrap_unchecked.
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_add.
 
@@ -67,8 +66,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  all: try eapply Impl_Interpreter.run_halt_underflow.
-  all: try eapply Impl_Option.run_unwrap_unchecked.
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_mul.
 
@@ -92,8 +90,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  all: try eapply Impl_Interpreter.run_halt_underflow.
-  all: try eapply Impl_Option.run_unwrap_unchecked.
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_sub.
 
@@ -117,8 +114,7 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  all: try eapply Impl_Interpreter.run_halt_underflow.
-  all: try eapply Impl_Option.run_unwrap_unchecked.
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_div.
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/div.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/div.v
@@ -1,14 +1,14 @@
 Require Import simulate.RocqOfRust.
 Require Import alloy_primitives.links.aliases.
 Require Import core.links.array.
+Require Import core.simulate.option.
 Require Import revm.revm_context_interface.links.host.
-Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.arithmetic.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
-Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
-Require Import revm.revm_interpreter.simulate.gas.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import ruint.links.lib.
 Require Import ruint.simulate.cmp.
@@ -20,7 +20,6 @@ Definition div
     `{!InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.LOW id (fun interpreter =>
   popn_top_macro interpreter 1 id (fun arr top interpreter =>
   let '⟬ op1 ⟭ := arr.(array.value) in
   let op2 := top.(RefStub.projection) interpreter.(Interpreter.stack) in
@@ -33,7 +32,7 @@ Definition div
         (Impl_Uint.wrapping_div op1 op2) in
     interpreter
       <| Interpreter.stack := stack |>
-  )).
+  ).
 
 Lemma div_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -47,9 +46,13 @@ Lemma div_eq
     (_host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_div run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_div run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -61,19 +64,24 @@ Lemma div_eq
   }}.
 Proof.
   intros.
-  unfold div.
-  gas_macro_eq idtac.
+  with_strategy transparent [run_div] unfold div, run_div; cbn.
   popn_top_macro_eq InterpreterTypesEq.
+  cbn.
+  eapply Run.Call; [
+    eapply Impl_Option.unwrap_unchecked_eq;
+    reflexivity
+  |].
+  cbn.
   match goal with
   | array : array.t aliases.U256.t _ |- _ =>
     destruct array as [[op1 []]]
   end.
-  s. {
-    s_apply @Impl_Uint.is_zero_eq.
-  }
+  s; [
+    s_apply @Impl_Uint.is_zero_eq
+  |].
   destruct Impl_Uint.is_zero; [s|].
-  s. {
-    apply Impl_Uint.wrapping_div_eq.
-  }
+  s; [
+    apply Impl_Uint.wrapping_div_eq
+  |].
   s.
 Qed.


### PR DESCRIPTION
This PR continues the Revm v103 arithmetic work with the `div` simulate slice.

It updates `div` to use the current `InstructionContext` shape and adjusts the simulate body to match the current Rust body. The old fixed gas step is not modeled in the body because Rust now charges that static gas before the instruction function runs.

The local arithmetic links check, direct `div` simulate check, and targeted `div.vo` make check passed.

The fake-body scan is clean. No new admitted boundaries remain; `div_eq` is closed with `Qed`.