### PR TITLE
Update Revm v103 arithmetic addmod simulate slice

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
@@ -183,22 +183,25 @@ Global Opaque run_smod.
 
 (*
 pub fn addmod<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
-) 
+    context: InstructionContext<'_, H, WIRE>,
+)
 *)
 Instance run_addmod
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.arithmetic.addmod [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.arithmetic.addmod [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_LoopControl_for_Control.
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_addmod.
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/addmod.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/addmod.v
@@ -1,14 +1,14 @@
 Require Import simulate.RocqOfRust.
 Require Import alloy_primitives.links.aliases.
 Require Import core.links.array.
+Require Import core.simulate.option.
 Require Import revm.revm_context_interface.links.host.
-Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.arithmetic.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
-Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
-Require Import revm.revm_interpreter.simulate.gas.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import ruint.links.lib.
 Require Import ruint.simulate.modular.
@@ -19,7 +19,6 @@ Definition addmod
     `{!InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.MID id (fun interpreter =>
   popn_top_macro interpreter 2 id (fun arr top interpreter =>
   let '⟬ op1; op2 ⟭ := arr.(array.value) in
   let op3 := top.(RefStub.projection) interpreter.(Interpreter.stack) in
@@ -28,7 +27,7 @@ Definition addmod
       interpreter.(Interpreter.stack) (Impl_Uint.add_mod op1 op2 op3) in
   interpreter
     <| Interpreter.stack := stack |>
-  )).
+  ).
 
 Lemma addmod_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -42,9 +41,13 @@ Lemma addmod_eq
     (_host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_addmod run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_addmod run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -56,15 +59,20 @@ Lemma addmod_eq
   }}.
 Proof.
   intros.
-  unfold addmod.
-  gas_macro_eq idtac.
+  with_strategy transparent [run_addmod] unfold addmod, run_addmod; cbn.
   popn_top_macro_eq InterpreterTypesEq.
+  cbn.
+  eapply Run.Call; [
+    eapply Impl_Option.unwrap_unchecked_eq;
+    reflexivity
+  |].
+  cbn.
   match goal with
   | array : array.t aliases.U256.t _ |- _ =>
     destruct array as [[op1 [op2 []]]]
   end.
-  s. {
-    apply Impl_Uint.add_mod_eq.
-  }
+  s; [
+    apply Impl_Uint.add_mod_eq
+  |].
   s.
 Qed.


### PR DESCRIPTION
This PR updates the Revm v103 `addmod` arithmetic slice.

It changes `addmod` to use the current `InstructionContext` shape, removes the old static gas step from the simulate body to match the Rust body, and keeps the instruction proof closed with `Qed`.

Local checks passed for the arithmetic links file, the direct `addmod` simulate file, and the targeted `addmod.vo` check. The fake-body scan is clean, and no new admitted boundaries were added. The proof follows the nearby arithmetic slices by using `popn_top_macro_eq` and closing the remaining `unwrap_unchecked` call explicitly.