### PR TITLE
Update Revm v103 arithmetic sdiv simulate slice

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
@@ -120,22 +120,25 @@ Global Opaque run_div.
 
 (*
 pub fn sdiv<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
-) 
+    context: InstructionContext<'_, H, WIRE>,
+)
 *)
 Instance run_sdiv
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.arithmetic.sdiv [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.arithmetic.sdiv [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_LoopControl_for_Control.
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_sdiv.
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/sdiv.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/sdiv.v
@@ -1,15 +1,15 @@
 Require Import simulate.RocqOfRust.
 Require Import alloy_primitives.links.aliases.
 Require Import core.links.array.
+Require Import core.simulate.option.
 Require Import revm.revm_context_interface.links.host.
-Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.arithmetic.
 Require Import revm.revm_interpreter.instructions.simulate.i256.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
-Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
-Require Import revm.revm_interpreter.simulate.gas.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import ruint.links.lib.
 
@@ -19,7 +19,6 @@ Definition sdiv
     `{!InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.LOW id (fun interpreter =>
   popn_top_macro interpreter 1 id (fun arr top interpreter =>
   let '⟬ op1 ⟭ := arr.(array.value) in
   let op2 := top.(RefStub.projection) interpreter.(Interpreter.stack) in
@@ -28,7 +27,7 @@ Definition sdiv
       interpreter.(Interpreter.stack) (i256_div op1 op2) in
   interpreter
     <| Interpreter.stack := stack |>
-  )).
+  ).
 
 Lemma sdiv_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -42,9 +41,13 @@ Lemma sdiv_eq
     (_host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_sdiv run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_sdiv run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -56,15 +59,20 @@ Lemma sdiv_eq
   }}.
 Proof.
   intros.
-  unfold sdiv.
-  gas_macro_eq idtac.
+  with_strategy transparent [run_sdiv] unfold sdiv, run_sdiv; cbn.
   popn_top_macro_eq InterpreterTypesEq.
+  cbn.
+  eapply Run.Call; [
+    eapply Impl_Option.unwrap_unchecked_eq;
+    reflexivity
+  |].
+  cbn.
   match goal with
   | array : array.t aliases.U256.t _ |- _ =>
     destruct array as [[op1 []]]
   end.
-  s. {
-    apply i256_div_eq.
-  }
+  s; [
+    apply i256_div_eq
+  |].
   s.
 Qed.


### PR DESCRIPTION
This PR moves `sdiv` to the current `InstructionContext` shape in the links instance and updates the simulate body to match the current Rust body. 

The `sdiv_eq` proof uses the shared `popn_top_macro_eq` tactic, then only handles the instruction-specific `unwrap_unchecked` and `i256_div` steps directly. Local checks passed for the arithmetic links file, the `sdiv` simulate file, and the targeted `sdiv.vo` build.