### PR TITLE
Update Revm v103 arithmetic rem simulate slice

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
@@ -144,22 +144,25 @@ Global Opaque run_sdiv.
 
 (*
 pub fn rem<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
-) 
+    context: InstructionContext<'_, H, WIRE>,
+)
 *)
 Instance run_rem
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.arithmetic.rem [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.arithmetic.rem [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_LoopControl_for_Control.
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_rem.
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/rem.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/rem.v
@@ -1,14 +1,14 @@
 Require Import simulate.RocqOfRust.
 Require Import alloy_primitives.links.aliases.
 Require Import core.links.array.
+Require Import core.simulate.option.
 Require Import revm.revm_context_interface.links.host.
-Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.arithmetic.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
-Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
-Require Import revm.revm_interpreter.simulate.gas.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import ruint.links.lib.
 Require Import ruint.simulate.cmp.
@@ -20,7 +20,6 @@ Definition rem
     `{!InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.LOW id (fun interpreter =>
   popn_top_macro interpreter 1 id (fun arr top interpreter =>
   let '⟬ op1 ⟭ := arr.(array.value) in
   let op2 := top.(RefStub.projection) interpreter.(Interpreter.stack) in
@@ -33,7 +32,7 @@ Definition rem
         (Impl_Uint.wrapping_rem op1 op2) in
     interpreter
       <| Interpreter.stack := stack |>
-  )).
+  ).
 
 Lemma rem_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -47,9 +46,13 @@ Lemma rem_eq
     (_host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_rem run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_rem run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -61,19 +64,24 @@ Lemma rem_eq
   }}.
 Proof.
   intros.
-  unfold rem.
-  gas_macro_eq idtac.
+  with_strategy transparent [run_rem] unfold rem, run_rem; cbn.
   popn_top_macro_eq InterpreterTypesEq.
+  cbn.
+  eapply Run.Call; [
+    eapply Impl_Option.unwrap_unchecked_eq;
+    reflexivity
+  |].
+  cbn.
   match goal with
   | array : array.t aliases.U256.t _ |- _ =>
     destruct array as [[op1 []]]
   end.
-  s. {
-    s_apply @Impl_Uint.is_zero_eq.
-  }
+  s; [
+    s_apply @Impl_Uint.is_zero_eq
+  |].
   destruct Impl_Uint.is_zero; [s|].
-  s. {
-    apply Impl_Uint.wrapping_rem_eq.
-  }
+  s; [
+    apply Impl_Uint.wrapping_rem_eq
+  |].
   s.
 Qed.


### PR DESCRIPTION
The links instance now uses `InstructionContext`, and the simulate definition follows the current Rust body: `popn_top`, zero check, then `wrapping_rem`. 

The proof uses `popn_top_macro_eq` for the stack macro part, with the remaining `is_zero` and `wrapping_rem` steps handled directly.

Checked locally with the arithmetic links file, `rem.v`, and the targeted `rem.vo` build.