### PR TITLE
Update Revm v103 arithmetic exp simulate slice

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
@@ -240,22 +240,28 @@ Global Opaque run_mulmod.
 
 (*
 pub fn exp<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    _host: &mut H,
-) 
+    context: InstructionContext<'_, H, WIRE>,
+)
 *)
 Instance run_exp
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.arithmetic.exp [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.arithmetic.exp [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_RuntimeFlag_for_RuntimeFlag.
+  destruct run_StackTrait_for_Stack.
+  destruct run_LoopControl_for_Control.
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_underflow. }
+  { eapply Impl_Interpreter.run_halt_oog. }
+  { eapply Impl_Interpreter.run_halt_oog. }
 Defined.
 Global Opaque run_exp.
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/exp.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/arithmetic/exp.v
@@ -6,6 +6,7 @@ Require Import revm.revm_interpreter.gas.simulate.calc.
 Require Import revm.revm_interpreter.instructions.links.arithmetic.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.gas.
@@ -49,9 +50,13 @@ Lemma exp_eq
     (_host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_exp run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_exp run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -63,7 +68,7 @@ Lemma exp_eq
   }}.
 Proof.
   intros.
-  unfold exp.
+  with_strategy transparent [run_exp] unfold exp, run_exp; cbn.
   s. {
     apply InterpreterTypesEq.
   }
@@ -75,21 +80,9 @@ Proof.
   s. {
     apply exp_cost_eq.
   }
-  unfold gas_macro.
-  s. {
-    apply InterpreterTypesEq.
-  }
-  s. {
-    apply Impl_Gas.record_cost_eq.
-  }
-  destruct Impl_Gas.record_cost.
+  gas_macro_eq idtac.
   { s. {
       apply Impl_Uint.pow_eq.
-    }
-    s.
-  }
-  { s. {
-      apply InterpreterTypesEq.
     }
     s.
   }


### PR DESCRIPTION
`run_exp` now uses `InstructionContext`, and the simulate proof passes the same context shape. The dynamic `gas_or_fail` path stays in the simulate body since `exp` still charges gas inside the instruction.

Checked locally with the arithmetic links file, `exp.v`, and the targeted `exp.vo` build.