### PR TITLE
Update bitand link and simulate to v103

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/bitand.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/bitand.v
@@ -1,8 +1,10 @@
 Require Import RocqOfRust.RocqOfRust.
 Require Import links.RocqOfRust.
 Require Import core.links.cmp.
+Require Import core.links.option.
 Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -16,14 +18,17 @@ Instance run_bitwise_bitand
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.bitwise.bitand [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.bitwise.bitand [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_LoopControl_for_Control.
   destruct (Impl_BitAnd_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_bitwise_bitand.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/bitwise/bitand.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/bitwise/bitand.v
@@ -4,10 +4,11 @@ Require Import core.links.array.
 Require Import core.links.cmp.
 Require Import core.ops.simulate.bit.
 Require Import core.simulate.cmp.
-Require Import revm.revm_context_interface.links.host.
+Require Import core.simulate.option.
 Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.bitwise.bitand.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
@@ -22,7 +23,6 @@ Definition op_bitand
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.VERYLOW id (fun interpreter =>
   popn_top_macro interpreter {| Integer.value := 1 |} id (fun arr top interpreter =>
     let '⟬ op1 ⟭ := arr.(array.value) in
     let op2 := top.(RefStub.projection) interpreter.(Interpreter.stack) in
@@ -32,12 +32,11 @@ Definition op_bitand
         interpreter.(Interpreter.stack) result in
     interpreter
       <| Interpreter.stack := stack |>
-  )).
+  ).
 
 Lemma op_bitand_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
-    {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
     (IInterpreterTypes : InterpreterTypes.C WIRE_types)
     (InterpreterTypesEq :
@@ -46,9 +45,13 @@ Lemma op_bitand_eq
     (_host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_bitwise_bitand run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_bitwise_bitand run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -60,9 +63,13 @@ Lemma op_bitand_eq
   }}.
 Proof.
   intros.
-  unfold op_bitand.
-  gas_macro_eq idtac.
+  with_strategy transparent [run_bitwise_bitand] unfold op_bitand, run_bitwise_bitand; cbn.
   popn_top_macro_eq InterpreterTypesEq.
+  eapply Run.Call; [
+    eapply Impl_Option.unwrap_unchecked_eq;
+    reflexivity
+  |].
+  cbn.
   match goal with
   | array : array.t aliases.U256.t _ |- _ =>
     destruct array as [[op1 []]]


### PR DESCRIPTION
Updates the bitand link and simulate files to the v103 InstructionContext shape and removes stale static gas handling from the simulate body.