### PR TITLE
Update byte link and simulate to v103

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/byte.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/byte.v
@@ -2,11 +2,13 @@ Require Import RocqOfRust.RocqOfRust.
 Require Import links.RocqOfRust.
 Require Import core.convert.links.num.
 Require Import core.links.cmp.
+Require Import core.links.option.
 Require Import core.links.result.
 Require Import core.num.links.error.
 Require Import core.num.links.mod.
 Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -20,14 +22,17 @@ Instance run_byte
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.bitwise.byte [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.bitwise.byte [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_LoopControl_for_Control.
   destruct Impl_TryFrom_u64_for_usize.run.
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_byte.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/bitwise/byte.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/bitwise/byte.v
@@ -4,11 +4,12 @@ Require Import core.links.array.
 Require Import core.links.cmp.
 Require Import core.num.simulate.mod.
 Require Import core.simulate.cmp.
+Require Import core.simulate.option.
 Require Import core.simulate.result.
-Require Import revm.revm_context_interface.links.host.
 Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.bitwise.byte.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
@@ -24,7 +25,6 @@ Definition op_byte
     {IInterpreterTypes : InterpreterTypes.C WIRE_types}
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
-  gas_macro interpreter constants.VERYLOW id (fun interpreter =>
   popn_top_macro interpreter 1 id (fun arr top interpreter =>
   let '⟬ op1 ⟭ := arr.(array.value) in
   let op2 := top.(RefStub.projection) interpreter.(Interpreter.stack) in
@@ -41,12 +41,11 @@ Definition op_byte
       interpreter.(Interpreter.stack) result in
   interpreter
     <| Interpreter.stack := stack |>
-  )).
+  ).
 
 Lemma op_byte_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
-    {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
     (IInterpreterTypes : InterpreterTypes.C WIRE_types)
     (InterpreterTypesEq :
@@ -55,9 +54,13 @@ Lemma op_byte_eq
     (_host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_byte run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_byte run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -69,9 +72,13 @@ Lemma op_byte_eq
   }}.
 Proof.
   intros.
-  unfold op_byte.
-  gas_macro_eq idtac.
+  with_strategy transparent [run_byte] unfold op_byte, run_byte; cbn.
   popn_top_macro_eq InterpreterTypesEq.
+  eapply Run.Call; [
+    eapply Impl_Option.unwrap_unchecked_eq;
+    reflexivity
+  |].
+  cbn.
   match goal with
   | array : array.t aliases.U256.t _ |- _ => destruct array as [[op1 []]]; cbn
   end.


### PR DESCRIPTION
Updates the byte link and simulate files to the v103 InstructionContext shape and removes stale static gas handling from the simulate body.