### PR TITLE
Update block_number link and simulate to v103

### DIFF
--- a/RocqOfRust/revm/revm_context_interface/links/host.v
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v
@@ -9,6 +9,7 @@ Require Import core.links.option.
 Require Import core.links.result.
 Require Import revm.revm_context_interface.links.cfg.
 Require Import revm.revm_context_interface.links.block.
+Require Import revm.revm_context_interface.host.
 Require Import revm.revm_context_interface.links.journaled_state.
 Require Import revm.revm_context_interface.links.transaction.
 Require Import ruint.links.lib.
@@ -297,6 +298,7 @@ Export (hints) SelfDestructResult.
 pub trait Host: TransactionGetter + BlockGetter + CfgGetter {
     fn load_account_delegated(&mut self, address: Address) -> Option<AccountLoad>;
     fn block_hash(&mut self, number: u64) -> Option<B256>;
+    fn block_number(&self) -> U256;
     fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>;
     fn code(&mut self, address: Address) -> Option<Eip7702CodeLoad<Bytes>>;
     fn code_hash(&mut self, address: Address) -> Option<Eip7702CodeLoad<B256>>;
@@ -384,6 +386,14 @@ Module Host.
     block_hash_is_method :: IsTraitMethod.C (trait Self) "block_hash" block_hash;
     run_block_hash (self : '&mut Self) (number : u64) ::
       Run.Trait block_hash [] [] [ φ self; φ number ] (option aliases.B256.t);
+  }.
+
+  (* fn block_number(&self) -> U256; *)
+  Class Method_block_number (Self : Set) `{Link Self} : Set := {
+    block_number : PolymorphicFunction.t;
+    block_number_is_method :: IsTraitMethod.C (trait Self) "block_number" block_number;
+    run_block_number (self : '& Self) ::
+      Run.Trait block_number [] [] [ φ self ] aliases.U256.t;
   }.
 
   (* fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>; *)
@@ -490,6 +500,7 @@ Module Host.
     run_CfgGetter_for_Self :: CfgGetter.Run Self (Types.to_CfgGetter_types types);
     method_load_account_delegated :: Method_load_account_delegated Self;
     method_block_hash :: Method_block_hash Self;
+    method_block_number :: Method_block_number Self;
     method_balance :: Method_balance Self;
     method_code :: Method_code Self;
     method_code_hash :: Method_code_hash Self;
@@ -502,3 +513,23 @@ Module Host.
   }.
 End Host.
 Export (hints) Host.
+
+Module Impl_Host_for_RefMut.
+  Instance method_block_number
+      (Self : Set) `{Link Self}
+      (method_block_number : Host.Method_block_number Self) :
+    Host.Method_block_number ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.block_number (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_block_number.
+      run_symbolic.
+  Defined.
+End Impl_Host_for_RefMut.
+Export (hints) Impl_Host_for_RefMut.

--- a/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
@@ -9,6 +9,7 @@ Require Import core.links.option.
 Require Import core.links.result.
 Require Import revm.revm_context_interface.links.cfg.
 Require Import revm.revm_context_interface.links.block.
+Require Import revm.revm_context_interface.host.
 Require Import revm.revm_context_interface.links.journaled_state.
 Require Import revm.revm_context_interface.links.transaction.
 Require Import ruint.links.lib.
@@ -101,6 +102,7 @@ Export (hints) SelfDestructResult.
 pub trait Host: TransactionGetter + BlockGetter + CfgGetter {
     fn load_account_delegated(&mut self, address: Address) -> Option<AccountLoad>;
     fn block_hash(&mut self, number: u64) -> Option<B256>;
+    fn block_number(&self) -> U256;
     fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>;
     fn code(&mut self, address: Address) -> Option<Eip7702CodeLoad<Bytes>>;
     fn code_hash(&mut self, address: Address) -> Option<Eip7702CodeLoad<B256>>;
@@ -188,6 +190,14 @@ Module Host.
     block_hash_is_method :: IsTraitMethod.C (trait Self) "block_hash" block_hash;
     run_block_hash (self : '&mut Self) (number : u64) ::
       Run.Trait block_hash [] [] [ φ self; φ number ] (option aliases.B256.t);
+  }.
+
+  (* fn block_number(&self) -> U256; *)
+  Class Method_block_number (Self : Set) `{Link Self} : Set := {
+    block_number : PolymorphicFunction.t;
+    block_number_is_method :: IsTraitMethod.C (trait Self) "block_number" block_number;
+    run_block_number (self : '& Self) ::
+      Run.Trait block_number [] [] [ φ self ] aliases.U256.t;
   }.
 
   (* fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>; *)
@@ -294,6 +304,7 @@ Module Host.
     run_CfgGetter_for_Self :: CfgGetter.Run Self (Types.to_CfgGetter_types types);
     method_load_account_delegated :: Method_load_account_delegated Self;
     method_block_hash :: Method_block_hash Self;
+    method_block_number :: Method_block_number Self;
     method_balance :: Method_balance Self;
     method_code :: Method_code Self;
     method_code_hash :: Method_code_hash Self;
@@ -306,3 +317,23 @@ Module Host.
   }.
 End Host.
 Export (hints) Host.
+
+Module Impl_Host_for_RefMut.
+  Instance method_block_number
+      (Self : Set) `{Link Self}
+      (method_block_number : Host.Method_block_number Self) :
+    Host.Method_block_number ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.block_number (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_block_number.
+      run_symbolic.
+  Defined.
+End Impl_Host_for_RefMut.
+Export (hints) Impl_Host_for_RefMut.

--- a/RocqOfRust/revm/revm_context_interface/simulate/host.v
+++ b/RocqOfRust/revm/revm_context_interface/simulate/host.v
@@ -40,6 +40,10 @@ Module Host.
       (self : Self)
       (number : u64) :
       option aliases.B256.t * Self;
+    (* fn block_number(&self) -> U256; *)
+    block_number
+      (self : Self) :
+      aliases.U256.t * Self;
     (* fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>; *)
     balance
       (self : Self)
@@ -149,6 +153,22 @@ Module Host.
             (Host.run_block_hash ref_self number)
             (interpreter :: self :: stack)%stack 🌲
           let result_self := I.(block_hash) self number in
+          (
+            Output.Success (fst result_self),
+            (interpreter :: snd result_self :: stack)%stack
+          )
+        }};
+      block_number
+          {Interpreter : Set}
+          (interpreter : Interpreter)
+          (self : Self)
+          (stack : Stack.t) :
+        let ref_self : '& Self := make_ref 1 in
+        {{
+          SimulateM.eval_f
+            (Host.run_block_number ref_self)
+            (interpreter :: self :: stack)%stack 🌲
+          let result_self := I.(block_number) self in
           (
             Output.Success (fst result_self),
             (interpreter :: snd result_self :: stack)%stack

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
@@ -8,6 +8,7 @@ Require Import revm.revm_context_interface.links.host.
 Require Import revm.revm_context_interface.links.block.
 Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -108,11 +109,10 @@ Global Opaque run_timestamp.
 
 (*
 pub fn block_number<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    host: &mut H,
+    context: InstructionContext<'_, H, WIRE>,
 ) {
-    gas!(interpreter, gas::BASE);
-    push!(interpreter, U256::from(host.block().number()));
+    //gas!(context.interpreter, gas::BASE);
+    push!(context.interpreter, context.host.block_number());
 }
 *)
 Instance run_block_number
@@ -121,20 +121,23 @@ Instance run_block_number
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
   {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_Host_for_H : Host.Run H H_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.block_info.block_number [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.block_info.block_number [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
   destruct run_StackTrait_for_Stack.
   destruct run_Host_for_H.
-  destruct run_BlockGetter_for_Self.
-  destruct run_Block_for_Block.
   run_symbolic.
+  { eapply (@Host.run_block_number
+      ('&mut H)
+      _
+      (@Impl_Host_for_RefMut.method_block_number H _ method_block_number)
+      (Ref.cast_to Pointer.Kind.Ref sub_ref1)). }
+  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_block_number.
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/block_info/block_number.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/block_info/block_number.v
@@ -7,12 +7,12 @@ Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.block_info.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.gas.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import ruint.links.lib.
-Require Import ruint.simulate.from.
 
 Definition block_number
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -23,16 +23,12 @@ Definition block_number
     (interpreter : Interpreter.t WIRE WIRE_types)
     (host : H) :
     Interpreter.t WIRE WIRE_types * H :=
-  gas_macro interpreter constants.BASE (fun interpreter => (interpreter, host)) (fun interpreter =>
-  let block :=
-    IHost.(Host.BlockGetter_for_Self).(BlockGetter.block).(RefStub.projection) host in
-  let number :=
-    IHost.(Host.BlockGetter_for_Self).(BlockGetter.Block_for_Block).(Block.number) block in
+  let '(number, host) := IHost.(Host.block_number) host in
   push_macro interpreter
-    {| Uint.value := i[number] |}
+    number
     (fun interpreter => (interpreter, host)) (fun interpreter =>
   (interpreter, host)
-  )).
+  ).
 
 Lemma block_number_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -49,9 +45,13 @@ Lemma block_number_eq
     (host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_block_number run_InterpreterTypes_for_WIRE run_Host_for_H ref_interpreter ref_host)
+      (run_block_number run_InterpreterTypes_for_WIRE run_Host_for_H context)
       ([interpreter; host]%stack) 🌲
     (
       Output.Success tt,
@@ -62,16 +62,16 @@ Lemma block_number_eq
 Proof.
   intros.
   with_strategy transparent [run_block_number] unfold block_number, run_block_number; cbn.
-  gas_macro_eq idtac.
-  s. {
-    apply HostEq.
+  destruct (IHost.(Host.block_number) host) as [number host'] eqn:?; cbn.
+  apply Run.LetUnfold.
+  eapply Run.Call.
+  {
+    s. {
+      eapply (Host.Eq.block_number (t := HostEq)).
+    }
+    s.
   }
-  s. {
-    s_apply HostEq.
-  }
-  s. {
-    s_apply Impl_Uint.from_eq.
-  }
+  rewrite Heqp; cbn.
   push_macro_eq InterpreterTypesEq.
-  s.
+  { s. }
 Qed.

--- a/RocqOfRust/revm/revm_interpreter/tests/host.v
+++ b/RocqOfRust/revm/revm_interpreter/tests/host.v
@@ -60,6 +60,10 @@ Module TestHost.
       option aliases.B256.t * t :=
     (None, Make).
 
+  Definition block_number (self : t) :
+      aliases.U256.t * t :=
+    (Impl_Uint.ZERO, Make).
+
   Definition balance (self : t) (_address : Address.t) :
       option (StateLoad.t aliases.U256.t) * t :=
     (None, Make).
@@ -223,6 +227,7 @@ Module TestHost.
     Host.CfgGetter_for_Self := CfgGetter_for_t;
     Host.load_account_delegated := load_account_delegated;
     Host.block_hash := block_hash;
+    Host.block_number := block_number;
     Host.balance := balance;
     Host.code := code;
     Host.code_hash := code_hash;
@@ -291,6 +296,10 @@ Module TestHostWithAccount.
       option aliases.B256.t * t :=
     (None, Make).
 
+  Definition block_number (self : t) :
+      aliases.U256.t * t :=
+    (Impl_Uint.ZERO, Make).
+
   Definition balance (self : t) (_address : Address.t) :
       option (StateLoad.t aliases.U256.t) * t :=
     (None, Make).
@@ -454,6 +463,7 @@ Module TestHostWithAccount.
     Host.CfgGetter_for_Self := CfgGetter_for_t;
     Host.load_account_delegated := load_account_delegated;
     Host.block_hash := block_hash;
+    Host.block_number := block_number;
     Host.balance := balance;
     Host.code := code;
     Host.code_hash := code_hash;


### PR DESCRIPTION
This touches 6 files because BLOCK_NUMBER no longer reads host.block().number(); the translated v103 body calls context.host.block_number() directly. That required adding the missing Host link/simulate method, regenerating the Jinja-backed host links file, updating the instruction link/simulate files, and adding the method to the test host records.