### PR TITLE
Update chainid link and simulate to v103

### DIFF
--- a/RocqOfRust/revm/revm_context_interface/links/host.v
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v
@@ -299,6 +299,7 @@ pub trait Host: TransactionGetter + BlockGetter + CfgGetter {
     fn load_account_delegated(&mut self, address: Address) -> Option<AccountLoad>;
     fn block_hash(&mut self, number: u64) -> Option<B256>;
     fn block_number(&self) -> U256;
+    fn chain_id(&self) -> U256;
     fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>;
     fn code(&mut self, address: Address) -> Option<Eip7702CodeLoad<Bytes>>;
     fn code_hash(&mut self, address: Address) -> Option<Eip7702CodeLoad<B256>>;
@@ -394,6 +395,14 @@ Module Host.
     block_number_is_method :: IsTraitMethod.C (trait Self) "block_number" block_number;
     run_block_number (self : '& Self) ::
       Run.Trait block_number [] [] [ φ self ] aliases.U256.t;
+  }.
+
+  (* fn chain_id(&self) -> U256; *)
+  Class Method_chain_id (Self : Set) `{Link Self} : Set := {
+    chain_id : PolymorphicFunction.t;
+    chain_id_is_method :: IsTraitMethod.C (trait Self) "chain_id" chain_id;
+    run_chain_id (self : '& Self) ::
+      Run.Trait chain_id [] [] [ φ self ] aliases.U256.t;
   }.
 
   (* fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>; *)
@@ -501,6 +510,7 @@ Module Host.
     method_load_account_delegated :: Method_load_account_delegated Self;
     method_block_hash :: Method_block_hash Self;
     method_block_number :: Method_block_number Self;
+    method_chain_id :: Method_chain_id Self;
     method_balance :: Method_balance Self;
     method_code :: Method_code Self;
     method_code_hash :: Method_code_hash Self;
@@ -515,6 +525,23 @@ End Host.
 Export (hints) Host.
 
 Module Impl_Host_for_RefMut.
+  Instance method_chain_id
+      (Self : Set) `{Link Self}
+      (method_chain_id : Host.Method_chain_id Self) :
+    Host.Method_chain_id ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.chain_id (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_chain_id.
+      run_symbolic.
+  Defined.
+
   Instance method_block_number
       (Self : Set) `{Link Self}
       (method_block_number : Host.Method_block_number Self) :

--- a/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
@@ -103,6 +103,7 @@ pub trait Host: TransactionGetter + BlockGetter + CfgGetter {
     fn load_account_delegated(&mut self, address: Address) -> Option<AccountLoad>;
     fn block_hash(&mut self, number: u64) -> Option<B256>;
     fn block_number(&self) -> U256;
+    fn chain_id(&self) -> U256;
     fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>;
     fn code(&mut self, address: Address) -> Option<Eip7702CodeLoad<Bytes>>;
     fn code_hash(&mut self, address: Address) -> Option<Eip7702CodeLoad<B256>>;
@@ -198,6 +199,14 @@ Module Host.
     block_number_is_method :: IsTraitMethod.C (trait Self) "block_number" block_number;
     run_block_number (self : '& Self) ::
       Run.Trait block_number [] [] [ φ self ] aliases.U256.t;
+  }.
+
+  (* fn chain_id(&self) -> U256; *)
+  Class Method_chain_id (Self : Set) `{Link Self} : Set := {
+    chain_id : PolymorphicFunction.t;
+    chain_id_is_method :: IsTraitMethod.C (trait Self) "chain_id" chain_id;
+    run_chain_id (self : '& Self) ::
+      Run.Trait chain_id [] [] [ φ self ] aliases.U256.t;
   }.
 
   (* fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>; *)
@@ -305,6 +314,7 @@ Module Host.
     method_load_account_delegated :: Method_load_account_delegated Self;
     method_block_hash :: Method_block_hash Self;
     method_block_number :: Method_block_number Self;
+    method_chain_id :: Method_chain_id Self;
     method_balance :: Method_balance Self;
     method_code :: Method_code Self;
     method_code_hash :: Method_code_hash Self;
@@ -319,6 +329,23 @@ End Host.
 Export (hints) Host.
 
 Module Impl_Host_for_RefMut.
+  Instance method_chain_id
+      (Self : Set) `{Link Self}
+      (method_chain_id : Host.Method_chain_id Self) :
+    Host.Method_chain_id ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.chain_id (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_chain_id.
+      run_symbolic.
+  Defined.
+
   Instance method_block_number
       (Self : Set) `{Link Self}
       (method_block_number : Host.Method_block_number Self) :

--- a/RocqOfRust/revm/revm_context_interface/simulate/host.v
+++ b/RocqOfRust/revm/revm_context_interface/simulate/host.v
@@ -44,6 +44,10 @@ Module Host.
     block_number
       (self : Self) :
       aliases.U256.t * Self;
+    (* fn chain_id(&self) -> U256; *)
+    chain_id
+      (self : Self) :
+      aliases.U256.t * Self;
     (* fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>; *)
     balance
       (self : Self)
@@ -169,6 +173,22 @@ Module Host.
             (Host.run_block_number ref_self)
             (interpreter :: self :: stack)%stack 🌲
           let result_self := I.(block_number) self in
+          (
+            Output.Success (fst result_self),
+            (interpreter :: snd result_self :: stack)%stack
+          )
+        }};
+      chain_id
+          {Interpreter : Set}
+          (interpreter : Interpreter)
+          (self : Self)
+          (stack : Stack.t) :
+        let ref_self : '& Self := make_ref 1 in
+        {{
+          SimulateM.eval_f
+            (Host.run_chain_id ref_self)
+            (interpreter :: self :: stack)%stack 🌲
+          let result_self := I.(chain_id) self in
           (
             Output.Success (fst result_self),
             (interpreter :: snd result_self :: stack)%stack

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
@@ -20,30 +20,38 @@ Require Import ruint.links.from.
 
 (*
 pub fn chainid<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    host: &mut H,
+    context: InstructionContext<'_, H, WIRE>,
 ) {
-    check!(interpreter, ISTANBUL);
-    gas!(interpreter, gas::BASE);
-    push!(interpreter, U256::from(host.cfg().chain_id()));
-  }
+    check!(context.interpreter, ISTANBUL);
+    //gas!(context.interpreter, gas::BASE);
+    push!(context.interpreter, context.host.chain_id());
+}
 *)
 Instance run_chainid
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
-  {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+  {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_Host_for_H : Host.Run H H_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.block_info.chainid [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.block_info.chainid [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_LoopControl_for_Control.
+  destruct run_StackTrait_for_Stack.
+  destruct run_RuntimeFlag_for_RuntimeFlag.
   destruct run_Host_for_H.
-  destruct run_CfgGetter_for_Self.
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_not_activated. }
+  { eapply (@Host.run_chain_id
+      ('&mut H)
+      _
+      (@Impl_Host_for_RefMut.method_chain_id H _ method_chain_id)
+      (Ref.cast_to Pointer.Kind.Ref sub_ref1)). }
+  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_chainid.
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/block_info/chainid.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/block_info/chainid.v
@@ -7,6 +7,7 @@ Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.block_info.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.gas.
@@ -14,7 +15,6 @@ Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import revm.revm_primitives.simulate.hardfork.
 Require Import ruint.links.lib.
-Require Import ruint.simulate.from.
 
 Definition chainid
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -26,14 +26,12 @@ Definition chainid
     (host : H) :
     Interpreter.t WIRE WIRE_types * H :=
   check_macro interpreter SpecId.ISTANBUL (fun interpreter => (interpreter, host)) (fun interpreter =>
-  gas_macro interpreter constants.BASE (fun interpreter => (interpreter, host)) (fun interpreter =>
-  let cfg := IHost.(Host.CfgGetter_for_Self).(CfgGetter.cfg).(RefStub.projection) host in
-  let chain_id := IHost.(Host.CfgGetter_for_Self).(CfgGetter.Cfg_for_Cfg).(Cfg.chain_id) cfg in
+  let '(chain_id, host) := IHost.(Host.chain_id) host in
   push_macro interpreter
-    {| Uint.value := i[chain_id] |}
+    chain_id
     (fun interpreter => (interpreter, host)) (fun interpreter =>
   (interpreter, host)
-  ))).
+  )).
 
 Lemma chainid_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -50,9 +48,13 @@ Lemma chainid_eq
     (host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_chainid run_InterpreterTypes_for_WIRE run_Host_for_H ref_interpreter ref_host)
+      (run_chainid run_InterpreterTypes_for_WIRE run_Host_for_H context)
       ([interpreter; host]%stack) 🌲
     (
       Output.Success tt,
@@ -64,16 +66,16 @@ Proof.
   intros.
   with_strategy transparent [run_chainid] unfold chainid, run_chainid; cbn.
   check_macro_eq InterpreterTypesEq.
-  gas_macro_eq idtac.
-  s. {
-    apply HostEq.
+  destruct (IHost.(Host.chain_id) host) as [chain_id host'] eqn:?; cbn.
+  apply Run.LetUnfold.
+  eapply Run.Call.
+  {
+    s. {
+      eapply (Host.Eq.chain_id (t := HostEq)).
+    }
+    s.
   }
-  s. {
-    s_apply HostEq.
-  }
-  s. {
-    s_apply Impl_Uint.from_eq.
-  }
+  rewrite Heqp; cbn.
   push_macro_eq InterpreterTypesEq.
-  s.
+  { s. }
 Qed.

--- a/RocqOfRust/revm/revm_interpreter/tests/host.v
+++ b/RocqOfRust/revm/revm_interpreter/tests/host.v
@@ -64,6 +64,10 @@ Module TestHost.
       aliases.U256.t * t :=
     (Impl_Uint.ZERO, Make).
 
+  Definition host_chain_id (self : t) :
+      aliases.U256.t * t :=
+    ({| Uint.value := 1 |}, Make).
+
   Definition balance (self : t) (_address : Address.t) :
       option (StateLoad.t aliases.U256.t) * t :=
     (None, Make).
@@ -228,6 +232,7 @@ Module TestHost.
     Host.load_account_delegated := load_account_delegated;
     Host.block_hash := block_hash;
     Host.block_number := block_number;
+    Host.chain_id := host_chain_id;
     Host.balance := balance;
     Host.code := code;
     Host.code_hash := code_hash;
@@ -300,6 +305,10 @@ Module TestHostWithAccount.
       aliases.U256.t * t :=
     (Impl_Uint.ZERO, Make).
 
+  Definition host_chain_id (self : t) :
+      aliases.U256.t * t :=
+    ({| Uint.value := 1 |}, Make).
+
   Definition balance (self : t) (_address : Address.t) :
       option (StateLoad.t aliases.U256.t) * t :=
     (None, Make).
@@ -464,6 +473,7 @@ Module TestHostWithAccount.
     Host.load_account_delegated := load_account_delegated;
     Host.block_hash := block_hash;
     Host.block_number := block_number;
+    Host.chain_id := host_chain_id;
     Host.balance := balance;
     Host.code := code;
     Host.code_hash := code_hash;


### PR DESCRIPTION
Updates CHAINID to the v103 InstructionContext and direct Host::chain_id shape.