### PR TITLE
Update basefee link and simulate to v103

### DIFF
--- a/RocqOfRust/revm/revm_context_interface/links/host.v
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v
@@ -300,6 +300,7 @@ pub trait Host: TransactionGetter + BlockGetter + CfgGetter {
     fn block_hash(&mut self, number: u64) -> Option<B256>;
     fn block_number(&self) -> U256;
     fn chain_id(&self) -> U256;
+    fn basefee(&self) -> U256;
     fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>;
     fn code(&mut self, address: Address) -> Option<Eip7702CodeLoad<Bytes>>;
     fn code_hash(&mut self, address: Address) -> Option<Eip7702CodeLoad<B256>>;
@@ -403,6 +404,14 @@ Module Host.
     chain_id_is_method :: IsTraitMethod.C (trait Self) "chain_id" chain_id;
     run_chain_id (self : '& Self) ::
       Run.Trait chain_id [] [] [ φ self ] aliases.U256.t;
+  }.
+
+  (* fn basefee(&self) -> U256; *)
+  Class Method_basefee (Self : Set) `{Link Self} : Set := {
+    basefee : PolymorphicFunction.t;
+    basefee_is_method :: IsTraitMethod.C (trait Self) "basefee" basefee;
+    run_basefee (self : '& Self) ::
+      Run.Trait basefee [] [] [ φ self ] aliases.U256.t;
   }.
 
   (* fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>; *)
@@ -511,6 +520,7 @@ Module Host.
     method_block_hash :: Method_block_hash Self;
     method_block_number :: Method_block_number Self;
     method_chain_id :: Method_chain_id Self;
+    method_basefee :: Method_basefee Self;
     method_balance :: Method_balance Self;
     method_code :: Method_code Self;
     method_code_hash :: Method_code_hash Self;
@@ -525,6 +535,23 @@ End Host.
 Export (hints) Host.
 
 Module Impl_Host_for_RefMut.
+  Instance method_basefee
+      (Self : Set) `{Link Self}
+      (method_basefee : Host.Method_basefee Self) :
+    Host.Method_basefee ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.basefee (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_basefee.
+      run_symbolic.
+  Defined.
+
   Instance method_chain_id
       (Self : Set) `{Link Self}
       (method_chain_id : Host.Method_chain_id Self) :

--- a/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
@@ -104,6 +104,7 @@ pub trait Host: TransactionGetter + BlockGetter + CfgGetter {
     fn block_hash(&mut self, number: u64) -> Option<B256>;
     fn block_number(&self) -> U256;
     fn chain_id(&self) -> U256;
+    fn basefee(&self) -> U256;
     fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>;
     fn code(&mut self, address: Address) -> Option<Eip7702CodeLoad<Bytes>>;
     fn code_hash(&mut self, address: Address) -> Option<Eip7702CodeLoad<B256>>;
@@ -207,6 +208,14 @@ Module Host.
     chain_id_is_method :: IsTraitMethod.C (trait Self) "chain_id" chain_id;
     run_chain_id (self : '& Self) ::
       Run.Trait chain_id [] [] [ φ self ] aliases.U256.t;
+  }.
+
+  (* fn basefee(&self) -> U256; *)
+  Class Method_basefee (Self : Set) `{Link Self} : Set := {
+    basefee : PolymorphicFunction.t;
+    basefee_is_method :: IsTraitMethod.C (trait Self) "basefee" basefee;
+    run_basefee (self : '& Self) ::
+      Run.Trait basefee [] [] [ φ self ] aliases.U256.t;
   }.
 
   (* fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>; *)
@@ -315,6 +324,7 @@ Module Host.
     method_block_hash :: Method_block_hash Self;
     method_block_number :: Method_block_number Self;
     method_chain_id :: Method_chain_id Self;
+    method_basefee :: Method_basefee Self;
     method_balance :: Method_balance Self;
     method_code :: Method_code Self;
     method_code_hash :: Method_code_hash Self;
@@ -329,6 +339,23 @@ End Host.
 Export (hints) Host.
 
 Module Impl_Host_for_RefMut.
+  Instance method_basefee
+      (Self : Set) `{Link Self}
+      (method_basefee : Host.Method_basefee Self) :
+    Host.Method_basefee ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.basefee (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_basefee.
+      run_symbolic.
+  Defined.
+
   Instance method_chain_id
       (Self : Set) `{Link Self}
       (method_chain_id : Host.Method_chain_id Self) :

--- a/RocqOfRust/revm/revm_context_interface/simulate/host.v
+++ b/RocqOfRust/revm/revm_context_interface/simulate/host.v
@@ -48,6 +48,10 @@ Module Host.
     chain_id
       (self : Self) :
       aliases.U256.t * Self;
+    (* fn basefee(&self) -> U256; *)
+    basefee
+      (self : Self) :
+      aliases.U256.t * Self;
     (* fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>; *)
     balance
       (self : Self)
@@ -189,6 +193,22 @@ Module Host.
             (Host.run_chain_id ref_self)
             (interpreter :: self :: stack)%stack 🌲
           let result_self := I.(chain_id) self in
+          (
+            Output.Success (fst result_self),
+            (interpreter :: snd result_self :: stack)%stack
+          )
+        }};
+      basefee
+          {Interpreter : Set}
+          (interpreter : Interpreter)
+          (self : Self)
+          (stack : Stack.t) :
+        let ref_self : '& Self := make_ref 1 in
+        {{
+          SimulateM.eval_f
+            (Host.run_basefee ref_self)
+            (interpreter :: self :: stack)%stack 🌲
+          let result_self := I.(basefee) self in
           (
             Output.Success (fst result_self),
             (interpreter :: snd result_self :: stack)%stack

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
@@ -212,31 +212,38 @@ Global Opaque run_gaslimit.
 
 (*
 pub fn basefee<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    host: &mut H,
-)
+    context: InstructionContext<'_, H, WIRE>,
+) {
+    check!(context.interpreter, LONDON);
+    //gas!(context.interpreter, gas::BASE);
+    push!(context.interpreter, context.host.basefee());
+}
 *)
 Instance run_basefee
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
-  {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
+  {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_Host_for_H : Host.Run H H_types)
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.block_info.basefee [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.block_info.basefee [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
   destruct run_StackTrait_for_Stack.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   destruct run_Host_for_H.
-  destruct run_BlockGetter_for_Self.
-  destruct run_Block_for_Block.
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_not_activated. }
+  { eapply (@Host.run_basefee
+      ('&mut H)
+      _
+      (@Impl_Host_for_RefMut.method_basefee H _ method_basefee)
+      (Ref.cast_to Pointer.Kind.Ref sub_ref1)). }
+  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_basefee.
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/block_info/basefee.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/block_info/basefee.v
@@ -1,20 +1,16 @@
 Require Import simulate.RocqOfRust.
 Require Import alloy_primitives.links.aliases.
 Require Import revm.revm_context_interface.links.host.
-Require Import revm.revm_context_interface.simulate.block.
 Require Import revm.revm_context_interface.simulate.host.
-Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.block_info.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
-Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
-Require Import revm.revm_interpreter.simulate.gas.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import revm.revm_primitives.simulate.hardfork.
 Require Import ruint.links.lib.
-Require Import ruint.simulate.from.
 
 Definition basefee
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -26,16 +22,12 @@ Definition basefee
     (host : H) :
     Interpreter.t WIRE WIRE_types * H :=
   check_macro interpreter SpecId.LONDON (fun interpreter => (interpreter, host)) (fun interpreter =>
-  gas_macro interpreter constants.BASE (fun interpreter => (interpreter, host)) (fun interpreter =>
-  let block :=
-    IHost.(Host.BlockGetter_for_Self).(BlockGetter.block).(RefStub.projection) host in
-  let basefee :=
-    IHost.(Host.BlockGetter_for_Self).(BlockGetter.Block_for_Block).(Block.basefee) block in
+  let '(basefee, host) := IHost.(Host.basefee) host in
   push_macro interpreter
-    {| Uint.value := i[basefee] |}
+    basefee
     (fun interpreter => (interpreter, host)) (fun interpreter =>
   (interpreter, host)
-  ))).
+  )).
 
 Lemma basefee_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -52,9 +44,13 @@ Lemma basefee_eq
     (host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_basefee run_InterpreterTypes_for_WIRE ref_interpreter run_Host_for_H ref_host)
+      (run_basefee run_InterpreterTypes_for_WIRE run_Host_for_H context)
       ([interpreter; host]%stack) 🌲
     (
       Output.Success tt,
@@ -66,16 +62,16 @@ Proof.
   intros.
   with_strategy transparent [run_basefee] unfold basefee, run_basefee; cbn.
   check_macro_eq InterpreterTypesEq.
-  gas_macro_eq idtac.
-  s. {
-    apply HostEq.
+  destruct (IHost.(Host.basefee) host) as [basefee host'] eqn:?; cbn.
+  apply Run.LetUnfold.
+  eapply Run.Call.
+  {
+    s. {
+      eapply (Host.Eq.basefee (t := HostEq)).
+    }
+    s.
   }
-  s. {
-    s_apply HostEq.
-  }
-  s. {
-    s_apply Impl_Uint.from_eq.
-  }
+  rewrite Heqp; cbn.
   push_macro_eq InterpreterTypesEq.
-  s.
+  { s. }
 Qed.

--- a/RocqOfRust/revm/revm_interpreter/tests/host.v
+++ b/RocqOfRust/revm/revm_interpreter/tests/host.v
@@ -68,6 +68,10 @@ Module TestHost.
       aliases.U256.t * t :=
     ({| Uint.value := 1 |}, Make).
 
+  Definition host_basefee (self : t) :
+      aliases.U256.t * t :=
+    (Impl_Uint.ZERO, Make).
+
   Definition balance (self : t) (_address : Address.t) :
       option (StateLoad.t aliases.U256.t) * t :=
     (None, Make).
@@ -233,6 +237,7 @@ Module TestHost.
     Host.block_hash := block_hash;
     Host.block_number := block_number;
     Host.chain_id := host_chain_id;
+    Host.basefee := host_basefee;
     Host.balance := balance;
     Host.code := code;
     Host.code_hash := code_hash;
@@ -309,6 +314,10 @@ Module TestHostWithAccount.
       aliases.U256.t * t :=
     ({| Uint.value := 1 |}, Make).
 
+  Definition host_basefee (self : t) :
+      aliases.U256.t * t :=
+    (Impl_Uint.ZERO, Make).
+
   Definition balance (self : t) (_address : Address.t) :
       option (StateLoad.t aliases.U256.t) * t :=
     (None, Make).
@@ -474,6 +483,7 @@ Module TestHostWithAccount.
     Host.block_hash := block_hash;
     Host.block_number := block_number;
     Host.chain_id := host_chain_id;
+    Host.basefee := host_basefee;
     Host.balance := balance;
     Host.code := code;
     Host.code_hash := code_hash;


### PR DESCRIPTION
Update basefee to the v103 InstructionContext/Host.basefee path and wire the required Host link/simulate support.