### PR TITLE
Update blob basefee link and simulate to v103

### DIFF
--- a/RocqOfRust/revm/revm_context_interface/links/host.v
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v
@@ -301,6 +301,7 @@ pub trait Host: TransactionGetter + BlockGetter + CfgGetter {
     fn block_number(&self) -> U256;
     fn chain_id(&self) -> U256;
     fn basefee(&self) -> U256;
+    fn blob_gasprice(&self) -> U256;
     fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>;
     fn code(&mut self, address: Address) -> Option<Eip7702CodeLoad<Bytes>>;
     fn code_hash(&mut self, address: Address) -> Option<Eip7702CodeLoad<B256>>;
@@ -414,6 +415,14 @@ Module Host.
       Run.Trait basefee [] [] [ φ self ] aliases.U256.t;
   }.
 
+  (* fn blob_gasprice(&self) -> U256; *)
+  Class Method_blob_gasprice (Self : Set) `{Link Self} : Set := {
+    blob_gasprice : PolymorphicFunction.t;
+    blob_gasprice_is_method :: IsTraitMethod.C (trait Self) "blob_gasprice" blob_gasprice;
+    run_blob_gasprice (self : '& Self) ::
+      Run.Trait blob_gasprice [] [] [ φ self ] aliases.U256.t;
+  }.
+
   (* fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>; *)
   Class Method_balance (Self : Set) `{Link Self} : Set := {
     balance : PolymorphicFunction.t;
@@ -521,6 +530,7 @@ Module Host.
     method_block_number :: Method_block_number Self;
     method_chain_id :: Method_chain_id Self;
     method_basefee :: Method_basefee Self;
+    method_blob_gasprice :: Method_blob_gasprice Self;
     method_balance :: Method_balance Self;
     method_code :: Method_code Self;
     method_code_hash :: Method_code_hash Self;
@@ -535,6 +545,23 @@ End Host.
 Export (hints) Host.
 
 Module Impl_Host_for_RefMut.
+  Instance method_blob_gasprice
+      (Self : Set) `{Link Self}
+      (method_blob_gasprice : Host.Method_blob_gasprice Self) :
+    Host.Method_blob_gasprice ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.blob_gasprice (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_blob_gasprice.
+      run_symbolic.
+  Defined.
+
   Instance method_basefee
       (Self : Set) `{Link Self}
       (method_basefee : Host.Method_basefee Self) :

--- a/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
@@ -105,6 +105,7 @@ pub trait Host: TransactionGetter + BlockGetter + CfgGetter {
     fn block_number(&self) -> U256;
     fn chain_id(&self) -> U256;
     fn basefee(&self) -> U256;
+    fn blob_gasprice(&self) -> U256;
     fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>;
     fn code(&mut self, address: Address) -> Option<Eip7702CodeLoad<Bytes>>;
     fn code_hash(&mut self, address: Address) -> Option<Eip7702CodeLoad<B256>>;
@@ -218,6 +219,14 @@ Module Host.
       Run.Trait basefee [] [] [ φ self ] aliases.U256.t;
   }.
 
+  (* fn blob_gasprice(&self) -> U256; *)
+  Class Method_blob_gasprice (Self : Set) `{Link Self} : Set := {
+    blob_gasprice : PolymorphicFunction.t;
+    blob_gasprice_is_method :: IsTraitMethod.C (trait Self) "blob_gasprice" blob_gasprice;
+    run_blob_gasprice (self : '& Self) ::
+      Run.Trait blob_gasprice [] [] [ φ self ] aliases.U256.t;
+  }.
+
   (* fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>; *)
   Class Method_balance (Self : Set) `{Link Self} : Set := {
     balance : PolymorphicFunction.t;
@@ -325,6 +334,7 @@ Module Host.
     method_block_number :: Method_block_number Self;
     method_chain_id :: Method_chain_id Self;
     method_basefee :: Method_basefee Self;
+    method_blob_gasprice :: Method_blob_gasprice Self;
     method_balance :: Method_balance Self;
     method_code :: Method_code Self;
     method_code_hash :: Method_code_hash Self;
@@ -339,6 +349,23 @@ End Host.
 Export (hints) Host.
 
 Module Impl_Host_for_RefMut.
+  Instance method_blob_gasprice
+      (Self : Set) `{Link Self}
+      (method_blob_gasprice : Host.Method_blob_gasprice Self) :
+    Host.Method_blob_gasprice ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.blob_gasprice (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_blob_gasprice.
+      run_symbolic.
+  Defined.
+
   Instance method_basefee
       (Self : Set) `{Link Self}
       (method_basefee : Host.Method_basefee Self) :

--- a/RocqOfRust/revm/revm_context_interface/simulate/host.v
+++ b/RocqOfRust/revm/revm_context_interface/simulate/host.v
@@ -52,6 +52,10 @@ Module Host.
     basefee
       (self : Self) :
       aliases.U256.t * Self;
+    (* fn blob_gasprice(&self) -> U256; *)
+    blob_gasprice
+      (self : Self) :
+      aliases.U256.t * Self;
     (* fn balance(&mut self, address: Address) -> Option<StateLoad<U256>>; *)
     balance
       (self : Self)
@@ -209,6 +213,22 @@ Module Host.
             (Host.run_basefee ref_self)
             (interpreter :: self :: stack)%stack 🌲
           let result_self := I.(basefee) self in
+          (
+            Output.Success (fst result_self),
+            (interpreter :: snd result_self :: stack)%stack
+          )
+        }};
+      blob_gasprice
+          {Interpreter : Set}
+          (interpreter : Interpreter)
+          (self : Self)
+          (stack : Stack.t) :
+        let ref_self : '& Self := make_ref 1 in
+        {{
+          SimulateM.eval_f
+            (Host.run_blob_gasprice ref_self)
+            (interpreter :: self :: stack)%stack 🌲
+          let result_self := I.(blob_gasprice) self in
           (
             Output.Success (fst result_self),
             (interpreter :: snd result_self :: stack)%stack

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
@@ -249,30 +249,37 @@ Global Opaque run_basefee.
 
 (*
 pub fn blob_basefee<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    host: &mut H,
-)
+    context: InstructionContext<'_, H, WIRE>,
+) {
+    check!(context.interpreter, CANCUN);
+    //gas!(context.interpreter, gas::BASE);
+    push!(context.interpreter, context.host.blob_gasprice());
+}
 *)
 Instance run_blob_basefee
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
-  {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+  {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_Host_for_H : Host.Run H H_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.block_info.blob_basefee [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.block_info.blob_basefee [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
   destruct run_StackTrait_for_Stack.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   destruct run_Host_for_H.
-  destruct run_BlockGetter_for_Self.
-  destruct run_Block_for_Block.
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_not_activated. }
+  { eapply (@Host.run_blob_gasprice
+      ('&mut H)
+      _
+      (@Impl_Host_for_RefMut.method_blob_gasprice H _ method_blob_gasprice)
+      (Ref.cast_to Pointer.Kind.Ref sub_ref1)). }
+  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_blob_basefee.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/block_info/blob_basefee.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/block_info/blob_basefee.v
@@ -1,22 +1,16 @@
 Require Import simulate.RocqOfRust.
 Require Import alloy_primitives.links.aliases.
-Require Import core.simulate.default.
-Require Import core.simulate.option.
 Require Import revm.revm_context_interface.links.host.
-Require Import revm.revm_context_interface.simulate.block.
 Require Import revm.revm_context_interface.simulate.host.
-Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.block_info.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
-Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
-Require Import revm.revm_interpreter.simulate.gas.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import revm.revm_primitives.simulate.hardfork.
 Require Import ruint.links.lib.
-Require Import ruint.simulate.from.
 
 Definition blob_basefee
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -28,16 +22,11 @@ Definition blob_basefee
     (host : H) :
     Interpreter.t WIRE WIRE_types * H :=
   check_macro interpreter SpecId.CANCUN (fun interpreter => (interpreter, host)) (fun interpreter =>
-  gas_macro interpreter constants.BASE (fun interpreter => (interpreter, host)) (fun interpreter =>
-  let block :=
-    IHost.(Host.BlockGetter_for_Self).(BlockGetter.block).(RefStub.projection) host in
-  let price :=
-    Impl_Option.unwrap_or_default
-      (IHost.(Host.BlockGetter_for_Self).(BlockGetter.Block_for_Block).(Block.blob_gasprice) block) in
-  push_macro interpreter {| Uint.value := i[price] |}
+  let '(price, host) := IHost.(Host.blob_gasprice) host in
+  push_macro interpreter price
     (fun interpreter => (interpreter, host)) (fun interpreter =>
   (interpreter, host)
-  ))).
+  )).
 
 Lemma blob_basefee_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -54,9 +43,13 @@ Lemma blob_basefee_eq
     (host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_blob_basefee run_InterpreterTypes_for_WIRE run_Host_for_H ref_interpreter ref_host)
+      (run_blob_basefee run_InterpreterTypes_for_WIRE run_Host_for_H context)
       ([interpreter; host]%stack) 🌲
     (
       Output.Success tt,
@@ -68,19 +61,16 @@ Proof.
   intros.
   with_strategy transparent [run_blob_basefee] unfold blob_basefee, run_blob_basefee; cbn.
   check_macro_eq InterpreterTypesEq.
-  gas_macro_eq idtac.
-  s. {
-    apply HostEq.
+  destruct (IHost.(Host.blob_gasprice) host) as [price host'] eqn:?; cbn.
+  apply Run.LetUnfold.
+  eapply Run.Call.
+  {
+    s. {
+      eapply (Host.Eq.blob_gasprice (t := HostEq)).
+    }
+    s.
   }
-  s. {
-    s_apply HostEq.
-  }
-  s. {
-    apply Impl_Option.unwrap_or_default_eq.
-  }
-  s. {
-    s_apply Impl_Uint.from_eq.
-  }
+  rewrite Heqp; cbn.
   push_macro_eq InterpreterTypesEq.
-  s.
+  { s. }
 Qed.

--- a/RocqOfRust/revm/revm_interpreter/tests/host.v
+++ b/RocqOfRust/revm/revm_interpreter/tests/host.v
@@ -72,6 +72,10 @@ Module TestHost.
       aliases.U256.t * t :=
     (Impl_Uint.ZERO, Make).
 
+  Definition host_blob_gasprice (self : t) :
+      aliases.U256.t * t :=
+    (Impl_Uint.ZERO, Make).
+
   Definition balance (self : t) (_address : Address.t) :
       option (StateLoad.t aliases.U256.t) * t :=
     (None, Make).
@@ -238,6 +242,7 @@ Module TestHost.
     Host.block_number := block_number;
     Host.chain_id := host_chain_id;
     Host.basefee := host_basefee;
+    Host.blob_gasprice := host_blob_gasprice;
     Host.balance := balance;
     Host.code := code;
     Host.code_hash := code_hash;
@@ -318,6 +323,10 @@ Module TestHostWithAccount.
       aliases.U256.t * t :=
     (Impl_Uint.ZERO, Make).
 
+  Definition host_blob_gasprice (self : t) :
+      aliases.U256.t * t :=
+    (Impl_Uint.ZERO, Make).
+
   Definition balance (self : t) (_address : Address.t) :
       option (StateLoad.t aliases.U256.t) * t :=
     (None, Make).
@@ -484,6 +493,7 @@ Module TestHostWithAccount.
     Host.block_number := block_number;
     Host.chain_id := host_chain_id;
     Host.basefee := host_basefee;
+    Host.blob_gasprice := host_blob_gasprice;
     Host.balance := balance;
     Host.code := code;
     Host.code_hash := code_hash;


### PR DESCRIPTION
Update blob_basefee to the v103 InstructionContext/Host.blob_gasprice path and wire the required Host link/simulate support.