### PR TITLE
Update coinbase link and simulate to v103

### DIFF
--- a/RocqOfRust/revm/revm_context_interface/links/host.v
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v
@@ -298,6 +298,7 @@ Export (hints) SelfDestructResult.
 pub trait Host: TransactionGetter + BlockGetter + CfgGetter {
     fn load_account_delegated(&mut self, address: Address) -> Option<AccountLoad>;
     fn block_hash(&mut self, number: u64) -> Option<B256>;
+    fn beneficiary(&self) -> Address;
     fn block_number(&self) -> U256;
     fn chain_id(&self) -> U256;
     fn basefee(&self) -> U256;
@@ -391,6 +392,14 @@ Module Host.
     block_hash_is_method :: IsTraitMethod.C (trait Self) "block_hash" block_hash;
     run_block_hash (self : '&mut Self) (number : u64) ::
       Run.Trait block_hash [] [] [ φ self; φ number ] (option aliases.B256.t);
+  }.
+
+  (* fn beneficiary(&self) -> Address; *)
+  Class Method_beneficiary (Self : Set) `{Link Self} : Set := {
+    beneficiary : PolymorphicFunction.t;
+    beneficiary_is_method :: IsTraitMethod.C (trait Self) "beneficiary" beneficiary;
+    run_beneficiary (self : '& Self) ::
+      Run.Trait beneficiary [] [] [ φ self ] Address.t;
   }.
 
   (* fn block_number(&self) -> U256; *)
@@ -545,6 +554,7 @@ Module Host.
     run_CfgGetter_for_Self :: CfgGetter.Run Self (Types.to_CfgGetter_types types);
     method_load_account_delegated :: Method_load_account_delegated Self;
     method_block_hash :: Method_block_hash Self;
+    method_beneficiary :: Method_beneficiary Self;
     method_block_number :: Method_block_number Self;
     method_chain_id :: Method_chain_id Self;
     method_basefee :: Method_basefee Self;
@@ -565,6 +575,23 @@ End Host.
 Export (hints) Host.
 
 Module Impl_Host_for_RefMut.
+  Instance method_beneficiary
+      (Self : Set) `{Link Self}
+      (method_beneficiary : Host.Method_beneficiary Self) :
+    Host.Method_beneficiary ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.beneficiary (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_beneficiary.
+      run_symbolic.
+  Defined.
+
   Instance method_prevrandao
       (Self : Set) `{Link Self}
       (method_prevrandao : Host.Method_prevrandao Self) :

--- a/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
@@ -102,6 +102,7 @@ Export (hints) SelfDestructResult.
 pub trait Host: TransactionGetter + BlockGetter + CfgGetter {
     fn load_account_delegated(&mut self, address: Address) -> Option<AccountLoad>;
     fn block_hash(&mut self, number: u64) -> Option<B256>;
+    fn beneficiary(&self) -> Address;
     fn block_number(&self) -> U256;
     fn chain_id(&self) -> U256;
     fn basefee(&self) -> U256;
@@ -195,6 +196,14 @@ Module Host.
     block_hash_is_method :: IsTraitMethod.C (trait Self) "block_hash" block_hash;
     run_block_hash (self : '&mut Self) (number : u64) ::
       Run.Trait block_hash [] [] [ φ self; φ number ] (option aliases.B256.t);
+  }.
+
+  (* fn beneficiary(&self) -> Address; *)
+  Class Method_beneficiary (Self : Set) `{Link Self} : Set := {
+    beneficiary : PolymorphicFunction.t;
+    beneficiary_is_method :: IsTraitMethod.C (trait Self) "beneficiary" beneficiary;
+    run_beneficiary (self : '& Self) ::
+      Run.Trait beneficiary [] [] [ φ self ] Address.t;
   }.
 
   (* fn block_number(&self) -> U256; *)
@@ -349,6 +358,7 @@ Module Host.
     run_CfgGetter_for_Self :: CfgGetter.Run Self (Types.to_CfgGetter_types types);
     method_load_account_delegated :: Method_load_account_delegated Self;
     method_block_hash :: Method_block_hash Self;
+    method_beneficiary :: Method_beneficiary Self;
     method_block_number :: Method_block_number Self;
     method_chain_id :: Method_chain_id Self;
     method_basefee :: Method_basefee Self;
@@ -369,6 +379,23 @@ End Host.
 Export (hints) Host.
 
 Module Impl_Host_for_RefMut.
+  Instance method_beneficiary
+      (Self : Set) `{Link Self}
+      (method_beneficiary : Host.Method_beneficiary Self) :
+    Host.Method_beneficiary ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.beneficiary (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_beneficiary.
+      run_symbolic.
+  Defined.
+
   Instance method_prevrandao
       (Self : Set) `{Link Self}
       (method_prevrandao : Host.Method_prevrandao Self) :

--- a/RocqOfRust/revm/revm_context_interface/simulate/host.v
+++ b/RocqOfRust/revm/revm_context_interface/simulate/host.v
@@ -42,6 +42,10 @@ Module Host.
       (self : Self)
       (number : u64) :
       option aliases.B256.t * Self;
+    (* fn beneficiary(&self) -> Address; *)
+    beneficiary
+      (self : Self) :
+      Address.t * Self;
     (* fn block_number(&self) -> U256; *)
     block_number
       (self : Self) :
@@ -175,6 +179,22 @@ Module Host.
             (Host.run_block_hash ref_self number)
             (interpreter :: self :: stack)%stack 🌲
           let result_self := I.(block_hash) self number in
+          (
+            Output.Success (fst result_self),
+            (interpreter :: snd result_self :: stack)%stack
+          )
+        }};
+      beneficiary
+          {Interpreter : Set}
+          (interpreter : Interpreter)
+          (self : Self)
+          (stack : Stack.t) :
+        let ref_self : '& Self := make_ref 1 in
+        {{
+          SimulateM.eval_f
+            (Host.run_beneficiary ref_self)
+            (interpreter :: self :: stack)%stack 🌲
+          let result_self := I.(beneficiary) self in
           (
             Output.Success (fst result_self),
             (interpreter :: snd result_self :: stack)%stack

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
@@ -57,29 +57,40 @@ Global Opaque run_chainid.
 
 (*
 pub fn coinbase<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    host: &mut H,
-)
+    context: InstructionContext<'_, H, WIRE>,
+) {
+    //gas!(context.interpreter, gas::BASE);
+    push!(
+        context.interpreter,
+        context.host.beneficiary().into_word().into()
+    );
+}
 *)
 Instance run_coinbase
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
-  {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+  {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_Host_for_H : Host.Run H H_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.block_info.coinbase [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.block_info.coinbase [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_LoopControl_for_Control.
+  destruct run_StackTrait_for_Stack.
   destruct run_Host_for_H.
-  destruct run_BlockGetter_for_Self.
-  destruct run_Block_for_Block.
   (* NOTE: used for resolving dependency issue for `core::convert::Into::into` *)
   destruct (Impl_Into_for_From_T.run Impl_From_FixedBytes_32_for_U256.run).
   run_symbolic.
+  { eapply (@Host.run_beneficiary
+      ('&mut H)
+      _
+      (@Impl_Host_for_RefMut.method_beneficiary H _ method_beneficiary)
+      (Ref.cast_to Pointer.Kind.Ref sub_ref1)). }
+  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_coinbase.
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/block_info/coinbase.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/block_info/coinbase.v
@@ -5,15 +5,12 @@ Require Import alloy_primitives.bits.simulate.address.
 Require Import alloy_primitives.bits.simulate.fixed.
 Require Import core.convert.simulate.mod.
 Require Import revm.revm_context_interface.links.host.
-Require Import revm.revm_context_interface.simulate.block.
 Require Import revm.revm_context_interface.simulate.host.
-Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.block_info.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
-Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
-Require Import revm.revm_interpreter.simulate.gas.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import ruint.links.lib.
 
@@ -26,17 +23,13 @@ Definition coinbase
     (interpreter : Interpreter.t WIRE WIRE_types)
     (host : H) :
     Interpreter.t WIRE WIRE_types * H :=
-  gas_macro interpreter constants.BASE (fun interpreter => (interpreter, host)) (fun interpreter =>
-  let block :=
-    IHost.(Host.BlockGetter_for_Self).(BlockGetter.block).(RefStub.projection) host in
-  let beneficiary :=
-    IHost.(Host.BlockGetter_for_Self).(BlockGetter.Block_for_Block).(Block.beneficiary) block in
+  let '(beneficiary, host) := IHost.(Host.beneficiary) host in
   let beneficiary := Impl_From_FixedBytes_32_for_U256.from (Impl_Address.into_word beneficiary) in
   push_macro interpreter
     beneficiary
     (fun interpreter => (interpreter, host)) (fun interpreter =>
   (interpreter, host)
-  )).
+  ).
 
 Lemma coinbase_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -53,9 +46,13 @@ Lemma coinbase_eq
     (host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_coinbase run_InterpreterTypes_for_WIRE run_Host_for_H ref_interpreter ref_host)
+      (run_coinbase run_InterpreterTypes_for_WIRE run_Host_for_H context)
       ([interpreter; host]%stack) 🌲
     (
       Output.Success tt,
@@ -66,13 +63,16 @@ Lemma coinbase_eq
 Proof.
   intros.
   with_strategy transparent [run_coinbase] unfold coinbase, run_coinbase; cbn.
-  gas_macro_eq idtac.
-  s. {
-    apply HostEq.
+  destruct (IHost.(Host.beneficiary) host) as [beneficiary host'] eqn:?; cbn.
+  apply Run.LetUnfold.
+  eapply Run.Call.
+  {
+    s. {
+      eapply (Host.Eq.beneficiary (t := HostEq)).
+    }
+    s.
   }
-  s. {
-    apply HostEq; repeat unshelve econstructor.
-  }
+  rewrite Heqp; cbn.
   s. {
     apply Impl_Address.into_word_eq; repeat unshelve econstructor.
   }
@@ -80,5 +80,5 @@ Proof.
     apply Impl_Into_for_From_T.Eq.I.
   }
   push_macro_eq InterpreterTypesEq.
-  s.
+  { s. }
 Qed.

--- a/RocqOfRust/revm/revm_interpreter/tests/host.v
+++ b/RocqOfRust/revm/revm_interpreter/tests/host.v
@@ -60,6 +60,10 @@ Module TestHost.
       option aliases.B256.t * t :=
     (None, Make).
 
+  Definition host_beneficiary (self : t) :
+      Address.t * t :=
+    ({| Address.value := 0 |}, Make).
+
   Definition block_number (self : t) :
       aliases.U256.t * t :=
     (Impl_Uint.ZERO, Make).
@@ -247,6 +251,7 @@ Module TestHost.
     Host.CfgGetter_for_Self := CfgGetter_for_t;
     Host.load_account_delegated := load_account_delegated;
     Host.block_hash := block_hash;
+    Host.beneficiary := host_beneficiary;
     Host.block_number := block_number;
     Host.chain_id := host_chain_id;
     Host.basefee := host_basefee;
@@ -321,6 +326,10 @@ Module TestHostWithAccount.
       option aliases.B256.t * t :=
     (None, Make).
 
+  Definition host_beneficiary (self : t) :
+      Address.t * t :=
+    ({| Address.value := 0 |}, Make).
+
   Definition block_number (self : t) :
       aliases.U256.t * t :=
     (Impl_Uint.ZERO, Make).
@@ -508,6 +517,7 @@ Module TestHostWithAccount.
     Host.CfgGetter_for_Self := CfgGetter_for_t;
     Host.load_account_delegated := load_account_delegated;
     Host.block_hash := block_hash;
+    Host.beneficiary := host_beneficiary;
     Host.block_number := block_number;
     Host.chain_id := host_chain_id;
     Host.basefee := host_basefee;


### PR DESCRIPTION
Updates coinbase to the v103 InstructionContext/Host flow and adds Host beneficiary support needed by the instruction simulation.