### PR TITLE
Update timestamp link and simulate to v103

### DIFF
--- a/RocqOfRust/revm/revm_context_interface/links/host.v
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v
@@ -410,6 +410,14 @@ Module Host.
       Run.Trait block_number [] [] [ φ self ] aliases.U256.t;
   }.
 
+  (* fn timestamp(&self) -> U256; *)
+  Class Method_timestamp (Self : Set) `{Link Self} : Set := {
+    timestamp : PolymorphicFunction.t;
+    timestamp_is_method :: IsTraitMethod.C (trait Self) "timestamp" timestamp;
+    run_timestamp (self : '& Self) ::
+      Run.Trait timestamp [] [] [ φ self ] aliases.U256.t;
+  }.
+
   (* fn chain_id(&self) -> U256; *)
   Class Method_chain_id (Self : Set) `{Link Self} : Set := {
     chain_id : PolymorphicFunction.t;
@@ -556,6 +564,7 @@ Module Host.
     method_block_hash :: Method_block_hash Self;
     method_beneficiary :: Method_beneficiary Self;
     method_block_number :: Method_block_number Self;
+    method_timestamp :: Method_timestamp Self;
     method_chain_id :: Method_chain_id Self;
     method_basefee :: Method_basefee Self;
     method_blob_gasprice :: Method_blob_gasprice Self;
@@ -691,6 +700,23 @@ Module Impl_Host_for_RefMut.
     - intros self.
       constructor.
       destruct method_block_number.
+      run_symbolic.
+  Defined.
+
+  Instance method_timestamp
+      (Self : Set) `{Link Self}
+      (method_timestamp : Host.Method_timestamp Self) :
+    Host.Method_timestamp ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.timestamp (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_timestamp.
       run_symbolic.
   Defined.
 End Impl_Host_for_RefMut.

--- a/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
@@ -214,6 +214,14 @@ Module Host.
       Run.Trait block_number [] [] [ φ self ] aliases.U256.t;
   }.
 
+  (* fn timestamp(&self) -> U256; *)
+  Class Method_timestamp (Self : Set) `{Link Self} : Set := {
+    timestamp : PolymorphicFunction.t;
+    timestamp_is_method :: IsTraitMethod.C (trait Self) "timestamp" timestamp;
+    run_timestamp (self : '& Self) ::
+      Run.Trait timestamp [] [] [ φ self ] aliases.U256.t;
+  }.
+
   (* fn chain_id(&self) -> U256; *)
   Class Method_chain_id (Self : Set) `{Link Self} : Set := {
     chain_id : PolymorphicFunction.t;
@@ -360,6 +368,7 @@ Module Host.
     method_block_hash :: Method_block_hash Self;
     method_beneficiary :: Method_beneficiary Self;
     method_block_number :: Method_block_number Self;
+    method_timestamp :: Method_timestamp Self;
     method_chain_id :: Method_chain_id Self;
     method_basefee :: Method_basefee Self;
     method_blob_gasprice :: Method_blob_gasprice Self;
@@ -495,6 +504,23 @@ Module Impl_Host_for_RefMut.
     - intros self.
       constructor.
       destruct method_block_number.
+      run_symbolic.
+  Defined.
+
+  Instance method_timestamp
+      (Self : Set) `{Link Self}
+      (method_timestamp : Host.Method_timestamp Self) :
+    Host.Method_timestamp ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.timestamp (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_timestamp.
       run_symbolic.
   Defined.
 End Impl_Host_for_RefMut.

--- a/RocqOfRust/revm/revm_context_interface/simulate/host.v
+++ b/RocqOfRust/revm/revm_context_interface/simulate/host.v
@@ -50,6 +50,10 @@ Module Host.
     block_number
       (self : Self) :
       aliases.U256.t * Self;
+    (* fn timestamp(&self) -> U256; *)
+    timestamp
+      (self : Self) :
+      aliases.U256.t * Self;
     (* fn chain_id(&self) -> U256; *)
     chain_id
       (self : Self) :
@@ -211,6 +215,22 @@ Module Host.
             (Host.run_block_number ref_self)
             (interpreter :: self :: stack)%stack 🌲
           let result_self := I.(block_number) self in
+          (
+            Output.Success (fst result_self),
+            (interpreter :: snd result_self :: stack)%stack
+          )
+        }};
+      timestamp
+          {Interpreter : Set}
+          (interpreter : Interpreter)
+          (self : Self)
+          (stack : Stack.t) :
+        let ref_self : '& Self := make_ref 1 in
+        {{
+          SimulateM.eval_f
+            (Host.run_timestamp ref_self)
+            (interpreter :: self :: stack)%stack 🌲
+          let result_self := I.(timestamp) self in
           (
             Output.Success (fst result_self),
             (interpreter :: snd result_self :: stack)%stack

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
@@ -96,33 +96,35 @@ Global Opaque run_coinbase.
 
 (*
 pub fn timestamp<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    host: &mut H,
+    context: InstructionContext<'_, H, WIRE>,
 ) {
-    gas!(interpreter, gas::BASE);
-    push!(interpreter, U256::from(host.block().timestamp()));
+    //gas!(context.interpreter, gas::BASE);
+    push!(context.interpreter, context.host.timestamp());
 }
 *)
 Instance run_timestamp
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
-  {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+  {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_Host_for_H : Host.Run H H_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.block_info.timestamp [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.block_info.timestamp [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
   destruct run_StackTrait_for_Stack.
   destruct run_Host_for_H.
-  destruct run_BlockGetter_for_Self.
-  destruct run_Block_for_Block.
   run_symbolic.
+  { eapply (@Host.run_timestamp
+      ('&mut H)
+      _
+      (@Impl_Host_for_RefMut.method_timestamp H _ method_timestamp)
+      (Ref.cast_to Pointer.Kind.Ref sub_ref1)). }
+  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_timestamp.
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/block_info/timestamp.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/block_info/timestamp.v
@@ -1,18 +1,14 @@
 Require Import simulate.RocqOfRust.
 Require Import alloy_primitives.links.aliases.
 Require Import revm.revm_context_interface.links.host.
-Require Import revm.revm_context_interface.simulate.block.
 Require Import revm.revm_context_interface.simulate.host.
-Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.block_info.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
-Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
-Require Import revm.revm_interpreter.simulate.gas.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import ruint.links.lib.
-Require Import ruint.simulate.from.
 
 Definition timestamp
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -23,16 +19,12 @@ Definition timestamp
     (interpreter : Interpreter.t WIRE WIRE_types)
     (host : H) :
     Interpreter.t WIRE WIRE_types * H :=
-  gas_macro interpreter constants.BASE (fun interpreter => (interpreter, host)) (fun interpreter =>
-  let block :=
-    IHost.(Host.BlockGetter_for_Self).(BlockGetter.block).(RefStub.projection) host in
-  let timestamp :=
-    IHost.(Host.BlockGetter_for_Self).(BlockGetter.Block_for_Block).(Block.timestamp) block in
+  let '(timestamp, host) := IHost.(Host.timestamp) host in
   push_macro interpreter
-    {| Uint.value := i[timestamp] |}
+    timestamp
     (fun interpreter => (interpreter, host)) (fun interpreter =>
   (interpreter, host)
-  )).
+  ).
 
 Lemma timestamp_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -49,9 +41,13 @@ Lemma timestamp_eq
     (host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_timestamp run_InterpreterTypes_for_WIRE run_Host_for_H ref_interpreter ref_host)
+      (run_timestamp run_InterpreterTypes_for_WIRE run_Host_for_H context)
       ([interpreter; host]%stack) 🌲
     (
       Output.Success tt,
@@ -61,18 +57,17 @@ Lemma timestamp_eq
   }}.
 Proof.
   intros.
-  with_strategy transparent [run_timestamp]
-    unfold timestamp, run_timestamp; cbn.
-  gas_macro_eq idtac.
-  s. {
-    apply HostEq.
+  with_strategy transparent [run_timestamp] unfold timestamp, run_timestamp; cbn.
+  destruct (IHost.(Host.timestamp) host) as [timestamp host'] eqn:?; cbn.
+  apply Run.LetUnfold.
+  eapply Run.Call.
+  {
+    s. {
+      eapply (Host.Eq.timestamp (t := HostEq)).
+    }
+    s.
   }
-  s. {
-    apply HostEq; repeat unshelve econstructor.
-  }
-  s. {
-    apply Impl_Uint.from_eq; [typeclasses eauto | easy].
-  }
+  rewrite Heqp; cbn.
   push_macro_eq InterpreterTypesEq.
-  s.
+  { s. }
 Qed.

--- a/RocqOfRust/revm/revm_interpreter/tests/host.v
+++ b/RocqOfRust/revm/revm_interpreter/tests/host.v
@@ -68,6 +68,10 @@ Module TestHost.
       aliases.U256.t * t :=
     (Impl_Uint.ZERO, Make).
 
+  Definition host_timestamp (self : t) :
+      aliases.U256.t * t :=
+    (Impl_Uint.ZERO, Make).
+
   Definition host_chain_id (self : t) :
       aliases.U256.t * t :=
     ({| Uint.value := 1 |}, Make).
@@ -253,6 +257,7 @@ Module TestHost.
     Host.block_hash := block_hash;
     Host.beneficiary := host_beneficiary;
     Host.block_number := block_number;
+    Host.timestamp := host_timestamp;
     Host.chain_id := host_chain_id;
     Host.basefee := host_basefee;
     Host.blob_gasprice := host_blob_gasprice;
@@ -334,6 +339,10 @@ Module TestHostWithAccount.
       aliases.U256.t * t :=
     (Impl_Uint.ZERO, Make).
 
+  Definition host_timestamp (self : t) :
+      aliases.U256.t * t :=
+    (Impl_Uint.ZERO, Make).
+
   Definition host_chain_id (self : t) :
       aliases.U256.t * t :=
     ({| Uint.value := 1 |}, Make).
@@ -519,6 +528,7 @@ Module TestHostWithAccount.
     Host.block_hash := block_hash;
     Host.beneficiary := host_beneficiary;
     Host.block_number := block_number;
+    Host.timestamp := host_timestamp;
     Host.chain_id := host_chain_id;
     Host.basefee := host_basefee;
     Host.blob_gasprice := host_blob_gasprice;


### PR DESCRIPTION
Updates the timestamp block-info instruction to the v103 InstructionContext shape and adds the Host timestamp support needed by the simulate proof.