### PR TITLE
Update gaslimit link and simulate to v103

### DIFF
--- a/RocqOfRust/revm/revm_context_interface/links/host.v
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v
@@ -418,6 +418,14 @@ Module Host.
       Run.Trait timestamp [] [] [ φ self ] aliases.U256.t;
   }.
 
+  (* fn gas_limit(&self) -> U256; *)
+  Class Method_gas_limit (Self : Set) `{Link Self} : Set := {
+    gas_limit : PolymorphicFunction.t;
+    gas_limit_is_method :: IsTraitMethod.C (trait Self) "gas_limit" gas_limit;
+    run_gas_limit (self : '& Self) ::
+      Run.Trait gas_limit [] [] [ φ self ] aliases.U256.t;
+  }.
+
   (* fn chain_id(&self) -> U256; *)
   Class Method_chain_id (Self : Set) `{Link Self} : Set := {
     chain_id : PolymorphicFunction.t;
@@ -565,6 +573,7 @@ Module Host.
     method_beneficiary :: Method_beneficiary Self;
     method_block_number :: Method_block_number Self;
     method_timestamp :: Method_timestamp Self;
+    method_gas_limit :: Method_gas_limit Self;
     method_chain_id :: Method_chain_id Self;
     method_basefee :: Method_basefee Self;
     method_blob_gasprice :: Method_blob_gasprice Self;
@@ -717,6 +726,23 @@ Module Impl_Host_for_RefMut.
     - intros self.
       constructor.
       destruct method_timestamp.
+      run_symbolic.
+  Defined.
+
+  Instance method_gas_limit
+      (Self : Set) `{Link Self}
+      (method_gas_limit : Host.Method_gas_limit Self) :
+    Host.Method_gas_limit ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.gas_limit (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_gas_limit.
       run_symbolic.
   Defined.
 End Impl_Host_for_RefMut.

--- a/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
@@ -222,6 +222,14 @@ Module Host.
       Run.Trait timestamp [] [] [ φ self ] aliases.U256.t;
   }.
 
+  (* fn gas_limit(&self) -> U256; *)
+  Class Method_gas_limit (Self : Set) `{Link Self} : Set := {
+    gas_limit : PolymorphicFunction.t;
+    gas_limit_is_method :: IsTraitMethod.C (trait Self) "gas_limit" gas_limit;
+    run_gas_limit (self : '& Self) ::
+      Run.Trait gas_limit [] [] [ φ self ] aliases.U256.t;
+  }.
+
   (* fn chain_id(&self) -> U256; *)
   Class Method_chain_id (Self : Set) `{Link Self} : Set := {
     chain_id : PolymorphicFunction.t;
@@ -369,6 +377,7 @@ Module Host.
     method_beneficiary :: Method_beneficiary Self;
     method_block_number :: Method_block_number Self;
     method_timestamp :: Method_timestamp Self;
+    method_gas_limit :: Method_gas_limit Self;
     method_chain_id :: Method_chain_id Self;
     method_basefee :: Method_basefee Self;
     method_blob_gasprice :: Method_blob_gasprice Self;
@@ -521,6 +530,23 @@ Module Impl_Host_for_RefMut.
     - intros self.
       constructor.
       destruct method_timestamp.
+      run_symbolic.
+  Defined.
+
+  Instance method_gas_limit
+      (Self : Set) `{Link Self}
+      (method_gas_limit : Host.Method_gas_limit Self) :
+    Host.Method_gas_limit ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.gas_limit (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_gas_limit.
       run_symbolic.
   Defined.
 End Impl_Host_for_RefMut.

--- a/RocqOfRust/revm/revm_context_interface/simulate/host.v
+++ b/RocqOfRust/revm/revm_context_interface/simulate/host.v
@@ -54,6 +54,10 @@ Module Host.
     timestamp
       (self : Self) :
       aliases.U256.t * Self;
+    (* fn gas_limit(&self) -> U256; *)
+    gas_limit
+      (self : Self) :
+      aliases.U256.t * Self;
     (* fn chain_id(&self) -> U256; *)
     chain_id
       (self : Self) :
@@ -231,6 +235,22 @@ Module Host.
             (Host.run_timestamp ref_self)
             (interpreter :: self :: stack)%stack 🌲
           let result_self := I.(timestamp) self in
+          (
+            Output.Success (fst result_self),
+            (interpreter :: snd result_self :: stack)%stack
+          )
+        }};
+      gas_limit
+          {Interpreter : Set}
+          (interpreter : Interpreter)
+          (self : Self)
+          (stack : Stack.t) :
+        let ref_self : '& Self := make_ref 1 in
+        {{
+          SimulateM.eval_f
+            (Host.run_gas_limit ref_self)
+            (interpreter :: self :: stack)%stack 🌲
+          let result_self := I.(gas_limit) self in
           (
             Output.Success (fst result_self),
             (interpreter :: snd result_self :: stack)%stack

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
@@ -215,30 +215,35 @@ Global Opaque run_difficulty.
 
 (*
 pub fn gaslimit<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    host: &mut H,
-)
+    context: InstructionContext<'_, H, WIRE>,
+) {
+    //gas!(context.interpreter, gas::BASE);
+    push!(context.interpreter, context.host.gas_limit());
+}
 *)
 Instance run_gaslimit
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
-  {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+  {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_Host_for_H : Host.Run H H_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.block_info.gaslimit [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.block_info.gaslimit [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
   destruct run_StackTrait_for_Stack.
   destruct run_Host_for_H.
-  destruct run_BlockGetter_for_Self.
-  destruct run_Block_for_Block.
   run_symbolic.
+  { eapply (@Host.run_gas_limit
+      ('&mut H)
+      _
+      (@Impl_Host_for_RefMut.method_gas_limit H _ method_gas_limit)
+      (Ref.cast_to Pointer.Kind.Ref sub_ref1)). }
+  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_gaslimit.
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/block_info/gaslimit.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/block_info/gaslimit.v
@@ -1,18 +1,14 @@
 Require Import simulate.RocqOfRust.
 Require Import alloy_primitives.links.aliases.
 Require Import revm.revm_context_interface.links.host.
-Require Import revm.revm_context_interface.simulate.block.
 Require Import revm.revm_context_interface.simulate.host.
-Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.block_info.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
-Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
-Require Import revm.revm_interpreter.simulate.gas.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import ruint.links.lib.
-Require Import ruint.simulate.from.
 
 Definition gaslimit
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -23,16 +19,12 @@ Definition gaslimit
     (interpreter : Interpreter.t WIRE WIRE_types)
     (host : H) :
     Interpreter.t WIRE WIRE_types * H :=
-  gas_macro interpreter constants.BASE (fun interpreter => (interpreter, host)) (fun interpreter =>
-  let block :=
-    IHost.(Host.BlockGetter_for_Self).(BlockGetter.block).(RefStub.projection) host in
-  let gas_limit :=
-    IHost.(Host.BlockGetter_for_Self).(BlockGetter.Block_for_Block).(Block.gas_limit) block in
+  let '(gas_limit, host) := IHost.(Host.gas_limit) host in
   push_macro interpreter
-    {| Uint.value := i[gas_limit] |}
+    gas_limit
     (fun interpreter => (interpreter, host)) (fun interpreter =>
   (interpreter, host)
-  )).
+  ).
 
 Lemma gaslimit_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -49,9 +41,13 @@ Lemma gaslimit_eq
     (host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_gaslimit run_InterpreterTypes_for_WIRE run_Host_for_H ref_interpreter ref_host)
+      (run_gaslimit run_InterpreterTypes_for_WIRE run_Host_for_H context)
       ([interpreter; host]%stack) 🌲
     (
       Output.Success tt,
@@ -62,16 +58,16 @@ Lemma gaslimit_eq
 Proof.
   intros.
   with_strategy transparent [run_gaslimit] unfold gaslimit, run_gaslimit; cbn.
-  gas_macro_eq idtac.
-  s. {
-    apply HostEq.
+  destruct (IHost.(Host.gas_limit) host) as [gas_limit host'] eqn:?; cbn.
+  apply Run.LetUnfold.
+  eapply Run.Call.
+  {
+    s. {
+      eapply (Host.Eq.gas_limit (t := HostEq)).
+    }
+    s.
   }
-  s. {
-    s_apply HostEq.
-  }
-  s. {
-    s_apply Impl_Uint.from_eq.
-  }
+  rewrite Heqp; cbn.
   push_macro_eq InterpreterTypesEq.
-  s.
+  { s. }
 Qed.

--- a/RocqOfRust/revm/revm_interpreter/tests/host.v
+++ b/RocqOfRust/revm/revm_interpreter/tests/host.v
@@ -72,6 +72,10 @@ Module TestHost.
       aliases.U256.t * t :=
     (Impl_Uint.ZERO, Make).
 
+  Definition host_gas_limit (self : t) :
+      aliases.U256.t * t :=
+    (Impl_Uint.ZERO, Make).
+
   Definition host_chain_id (self : t) :
       aliases.U256.t * t :=
     ({| Uint.value := 1 |}, Make).
@@ -258,6 +262,7 @@ Module TestHost.
     Host.beneficiary := host_beneficiary;
     Host.block_number := block_number;
     Host.timestamp := host_timestamp;
+    Host.gas_limit := host_gas_limit;
     Host.chain_id := host_chain_id;
     Host.basefee := host_basefee;
     Host.blob_gasprice := host_blob_gasprice;
@@ -343,6 +348,10 @@ Module TestHostWithAccount.
       aliases.U256.t * t :=
     (Impl_Uint.ZERO, Make).
 
+  Definition host_gas_limit (self : t) :
+      aliases.U256.t * t :=
+    (Impl_Uint.ZERO, Make).
+
   Definition host_chain_id (self : t) :
       aliases.U256.t * t :=
     ({| Uint.value := 1 |}, Make).
@@ -529,6 +538,7 @@ Module TestHostWithAccount.
     Host.beneficiary := host_beneficiary;
     Host.block_number := block_number;
     Host.timestamp := host_timestamp;
+    Host.gas_limit := host_gas_limit;
     Host.chain_id := host_chain_id;
     Host.basefee := host_basefee;
     Host.blob_gasprice := host_blob_gasprice;


### PR DESCRIPTION
Updates the gaslimit block-info instruction to the v103 InstructionContext shape and adds the Host gas_limit support needed by the simulate proof.