### PR TITLE
Clean up jump control link proofs

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/jump.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/jump.v
@@ -44,7 +44,6 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct run_Jumps_for_Bytecode.
   run_symbolic.
-  all: try eapply run_jump_inner.
-  all: try eapply Impl_Interpreter.run_halt_underflow.
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_jump.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/jump_inner.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/jump_inner.v
@@ -40,6 +40,7 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct run_Jumps_for_Bytecode.
   run_symbolic.
-  all: eapply (@Impl_Interpreter.run_halt WIRE H WIRE_types H0 run_InterpreterTypes_for_WIRE).
+  { eapply Impl_Interpreter.run_halt. }
+  { eapply Impl_Interpreter.run_halt. }
 Defined.
 Global Opaque run_jump_inner.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/jumpi.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/jumpi.v
@@ -44,7 +44,6 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct run_Jumps_for_Bytecode.
   run_symbolic.
-  all: try eapply run_jump_inner.
-  all: try eapply Impl_Interpreter.run_halt_underflow.
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_jumpi.


### PR DESCRIPTION
The public control links and simulate files already use the v103 InstructionContext shape and compile as-is. This PR only removes stale broad cleanup from jump, jumpi, and jump_inner.