### PR TITLE
Clean up stop control link proof

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/stop.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/stop.v
@@ -41,6 +41,6 @@ Proof.
   destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  eapply Impl_Interpreter.run_halt.
+  { eapply Impl_Interpreter.run_halt. }
 Defined.
 Global Opaque run_stop.


### PR DESCRIPTION
Cleans up the stop control link proof by making the remaining halt obligation explicit; the matching stop link/simulate and interpreter dependency files compile locally.