### PR TITLE
Clean up control link proof obligations

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/invalid.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/invalid.v
@@ -41,6 +41,6 @@ Proof.
   destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  eapply Impl_Interpreter.run_halt.
+  { eapply Impl_Interpreter.run_halt. }
 Defined.
 Global Opaque run_invalid.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/pc.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/pc.v
@@ -42,6 +42,6 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_Jumps_for_Bytecode.
   run_symbolic.
-  eapply Impl_Interpreter.run_halt_overflow.
+  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_pc.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/revert.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/revert.v
@@ -43,15 +43,6 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   run_symbolic.
-  all: match goal with
-  | |- Run.Trait
-      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_not_activated _)
-      _ _ _ _ =>
-      eapply Impl_Interpreter.run_halt_not_activated
-  | |- Run.Trait
-      instructions.control.return_inner
-      _ _ _ _ =>
-      eapply run_return_inner
-  end.
+  { eapply Impl_Interpreter.run_halt_not_activated. }
 Defined.
 Global Opaque run_revert.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/unknown.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/unknown.v
@@ -41,6 +41,6 @@ Proof.
   destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  eapply Impl_Interpreter.run_halt.
+  { eapply Impl_Interpreter.run_halt. }
 Defined.
 Global Opaque run_unknown.


### PR DESCRIPTION
Cleans up invalid, unknown, pc, and revert control link proofs by replacing stale or broad cleanup with explicit halt obligations; matching simulate files compile unchanged.