### PR TITLE
Update Revm v103 static_call contract slice

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/static_call.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/static_call.v
@@ -25,6 +25,7 @@ Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.interpreter_action.links.call_inputs.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
@@ -40,8 +41,7 @@ Require Import ruint.links.lib.
 
 (*
 pub fn static_call<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    host: &mut H,
+    mut context: InstructionContext<'_, H, WIRE>,
 )
 *)
 Instance run_static_call
@@ -50,14 +50,29 @@ Instance run_static_call
   {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
   (run_Host_for_H : Host.Run H H_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.contract.static_call [] [ Φ WIRE; Φ H ] [ φ interpreter; φ host ]
+    instructions.contract.static_call [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
   destruct (TryFrom_Uint_for_u64.method_try_from (BITS := {| Integer.value := 256 |}) (LIMBS := {| Integer.value := 4 |})).
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_not_activated. }
+  {
+    eapply (@Impl_Box.run_new CallInputs.t CallInputs.IsLink {|
+      CallInputs.bytecode_address := value15;
+      CallInputs.caller := value_inter2;
+      CallInputs.gas_limit := value12;
+      CallInputs.input := CallInput.SharedBuffer value11;
+      CallInputs.is_static := true;
+      CallInputs.known_bytecode := Some (value16, value17);
+      CallInputs.return_memory_offset := value19;
+      CallInputs.scheme := CallScheme.StaticCall;
+      CallInputs.target_address := value13;
+      CallInputs.value := CallValue.Transfer value18;
+    |}).
+  }
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_static_call.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/contract/static_call.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/contract/static_call.v
@@ -12,6 +12,7 @@ Require Import revm.revm_context_interface.simulate.host.
 Require Import revm.revm_interpreter.instructions.contract.simulate.call_helpers.
 Require Import revm.revm_interpreter.instructions.links.contract.static_call.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
@@ -97,10 +98,14 @@ Lemma static_call_eq
     (host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f (
       run_static_call
-        run_InterpreterTypes_for_WIRE run_Host_for_H ref_interpreter ref_host
+        run_InterpreterTypes_for_WIRE run_Host_for_H context
       )
       [interpreter; host]%stack 🌲
     (

--- a/RocqOfRust/revm/revm_interpreter/instructions/tests/contract.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/tests/contract.v
@@ -12,12 +12,35 @@ Require Import revm.revm_interpreter.instructions.simulate.contract.delegate_cal
 Require Import revm.revm_interpreter.instructions.simulate.contract.static_call.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.instruction_result.
+Require Import revm.revm_interpreter.links.interpreter_action.
+Require Import revm.revm_interpreter.links.interpreter_InterpreterResult.
 Require Import revm.revm_interpreter.tests.host.
 Require Import revm.revm_interpreter.tests.interpreter.
 Require Import revm.revm_interpreter.tests.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import ruint.links.lib.
 Require Import ruint.simulate.lib.
+
+Definition bytecode_action
+    (interpreter : Interpreter.t WIRE WIRE_types) :
+    option InterpreterAction.t :=
+  interpreter.(Interpreter.bytecode).(Bytecode.action).
+
+Definition bytecode_result
+    (interpreter : Interpreter.t WIRE WIRE_types) :
+    option InstructionResult.t :=
+  match bytecode_action interpreter with
+  | Some (InterpreterAction.Return result) =>
+    Some result.(InterpreterResult.result)
+  | _ => None
+  end.
+
+Definition is_call_frame
+    (interpreter : Interpreter.t WIRE WIRE_types) : Prop :=
+  match bytecode_action interpreter with
+  | Some (InterpreterAction.NewFrame (FrameInput.Call _)) => True
+  | _ => False
+  end.
 
 (** ** StackUnderflow Tests *)
 
@@ -27,8 +50,7 @@ Goal
   let interpreter := make_interpreter stack in
   let host : TestHost.t := TestHost.Make in
   let '(result_interpreter, _) := static_call interpreter host in
-  result_interpreter.(Interpreter.control).(Control.instruction_result) =
-    Some InstructionResult.StackUnderflow.
+  bytecode_result result_interpreter = Some InstructionResult.StackUnderflow.
 Proof.
   timeout 1 vm_compute.
   reflexivity.
@@ -42,8 +64,7 @@ Goal
   let interpreter := make_interpreter stack in
   let host : TestHost.t := TestHost.Make in
   let '(result_interpreter, _) := call interpreter host in
-  result_interpreter.(Interpreter.control).(Control.instruction_result) =
-    Some InstructionResult.StackUnderflow.
+  bytecode_result result_interpreter = Some InstructionResult.StackUnderflow.
 Proof.
   timeout 1 vm_compute.
   reflexivity.
@@ -58,8 +79,7 @@ Goal
   let interpreter := make_interpreter stack in
   let host : TestHost.t := TestHost.Make in
   let '(result_interpreter, _) := call interpreter host in
-  result_interpreter.(Interpreter.control).(Control.instruction_result) =
-    Some InstructionResult.StackUnderflow.
+  bytecode_result result_interpreter = Some InstructionResult.StackUnderflow.
 Proof.
   timeout 1 vm_compute.
   reflexivity.
@@ -85,7 +105,7 @@ Goal
     Some InstructionResult.FatalExternalError.
 Proof.
   timeout 1 vm_compute.
-  destruct (RuntimeFlag.is_static SpecId.LATEST); auto.
+  destruct (RuntimeFlag.is_static SpecId.PRAGUE); auto.
 Qed.
 
 Goal
@@ -103,11 +123,10 @@ Goal
   let '(result_interpreter, _) := call interpreter host in
   result_interpreter.(Interpreter.control).(Control.instruction_result) =
     Some InstructionResult.CallNotAllowedInsideStatic \/
-  result_interpreter.(Interpreter.control).(Control.instruction_result) =
-    Some InstructionResult.CallOrCreate.
+  is_call_frame result_interpreter.
 Proof.
   timeout 1 vm_compute.
-  destruct (RuntimeFlag.is_static SpecId.LATEST); auto.
+  destruct (RuntimeFlag.is_static SpecId.PRAGUE); auto.
 Qed.
 
 (** ** CALLCODE tests *)
@@ -117,8 +136,7 @@ Goal
   let interpreter := make_interpreter stack in
   let host : TestHost.t := TestHost.Make in
   let '(result_interpreter, _) := call_code interpreter host in
-  result_interpreter.(Interpreter.control).(Control.instruction_result) =
-    Some InstructionResult.StackUnderflow.
+  bytecode_result result_interpreter = Some InstructionResult.StackUnderflow.
 Proof.
   timeout 1 vm_compute.
   reflexivity.
@@ -157,8 +175,7 @@ Goal
   let interpreter := make_interpreter stack in
   let host : TestHostWithAccount.t := TestHostWithAccount.Make in
   let '(result_interpreter, _) := call_code interpreter host in
-  result_interpreter.(Interpreter.control).(Control.instruction_result) =
-    Some InstructionResult.CallOrCreate.
+  is_call_frame result_interpreter.
 Proof.
   timeout 1 vm_compute.
   reflexivity.
@@ -173,8 +190,7 @@ Goal
   let interpreter := make_interpreter stack in
   let host : TestHost.t := TestHost.Make in
   let '(result_interpreter, _) := delegate_call interpreter host in
-  result_interpreter.(Interpreter.control).(Control.instruction_result) =
-    Some InstructionResult.StackUnderflow.
+  bytecode_result result_interpreter = Some InstructionResult.StackUnderflow.
 Proof.
   timeout 1 vm_compute.
   reflexivity.
@@ -211,8 +227,7 @@ Goal
   let interpreter := make_interpreter stack in
   let host : TestHostWithAccount.t := TestHostWithAccount.Make in
   let '(result_interpreter, _) := delegate_call interpreter host in
-  result_interpreter.(Interpreter.control).(Control.instruction_result) =
-    Some InstructionResult.CallOrCreate.
+  is_call_frame result_interpreter.
 Proof.
   timeout 1 vm_compute.
   reflexivity.
@@ -227,8 +242,7 @@ Goal
   let interpreter := make_interpreter stack in
   let host : TestHost.t := TestHost.Make in
   let '(result_interpreter, _) := static_call interpreter host in
-  result_interpreter.(Interpreter.control).(Control.instruction_result) =
-    Some InstructionResult.StackUnderflow.
+  bytecode_result result_interpreter = Some InstructionResult.StackUnderflow.
 Proof.
   timeout 1 vm_compute.
   reflexivity.
@@ -247,14 +261,13 @@ Goal
   let interpreter := make_interpreter stack in
   let host : TestHost.t := TestHost.Make in
   let '(result_interpreter, _) := static_call interpreter host in
-  result_interpreter.(Interpreter.control).(Control.instruction_result) =
-    Some InstructionResult.StackUnderflow.
+  bytecode_result result_interpreter = Some InstructionResult.StackUnderflow.
 Proof.
   timeout 1 vm_compute.
   reflexivity.
 Qed.
 
-(** ** Tests requiring full path (FatalExternalError, CallOrCreate)
+(** ** Tests requiring full path (FatalExternalError, call frame)
     These tests go through get_memory_input_and_out_ranges which involves
     complex computation. *)
 
@@ -278,7 +291,7 @@ Proof.
   reflexivity.
 Qed.
 
-(** Test that static_call with valid account returns CallOrCreate *)
+(** Test that static_call with valid account creates a call frame *)
 Goal
   let stack := {| Stack.value := [
     {| Uint.value := 0 |};     (* out_len *)
@@ -291,8 +304,7 @@ Goal
   let interpreter := make_interpreter stack in
   let host : TestHostWithAccount.t := TestHostWithAccount.Make in
   let '(result_interpreter, _) := static_call interpreter host in
-  result_interpreter.(Interpreter.control).(Control.instruction_result) =
-    Some InstructionResult.CallOrCreate.
+  is_call_frame result_interpreter.
 Proof.
   timeout 1 vm_compute.
   reflexivity.


### PR DESCRIPTION
Updates static_call to the v103 InstructionContext link/simulate shape and adjusts the contract tests for the bytecode action behavior. The remaining simulate proof is still at the existing admitted helper boundary for load_acc_and_calc_gas.