### PR TITLE
Update Revm v103 create contract link slice

### DIFF
--- a/RocqOfRust/revm/revm_context_interface/links/host.v
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v
@@ -394,6 +394,14 @@ Module Host.
       Run.Trait block_hash [] [] [ φ self; φ number ] (option aliases.B256.t);
   }.
 
+  (* fn max_initcode_size(&self) -> usize; *)
+  Class Method_max_initcode_size (Self : Set) `{Link Self} : Set := {
+    max_initcode_size : PolymorphicFunction.t;
+    max_initcode_size_is_method :: IsTraitMethod.C (trait Self) "max_initcode_size" max_initcode_size;
+    run_max_initcode_size (self : '& Self) ::
+      Run.Trait max_initcode_size [] [] [ φ self ] usize;
+  }.
+
   (* fn beneficiary(&self) -> Address; *)
   Class Method_beneficiary (Self : Set) `{Link Self} : Set := {
     beneficiary : PolymorphicFunction.t;
@@ -570,6 +578,7 @@ Module Host.
     run_CfgGetter_for_Self :: CfgGetter.Run Self (Types.to_CfgGetter_types types);
     method_load_account_delegated :: Method_load_account_delegated Self;
     method_block_hash :: Method_block_hash Self;
+    method_max_initcode_size :: Method_max_initcode_size Self;
     method_beneficiary :: Method_beneficiary Self;
     method_block_number :: Method_block_number Self;
     method_timestamp :: Method_timestamp Self;
@@ -593,6 +602,23 @@ End Host.
 Export (hints) Host.
 
 Module Impl_Host_for_RefMut.
+  Instance method_max_initcode_size
+      (Self : Set) `{Link Self}
+      (method_max_initcode_size : Host.Method_max_initcode_size Self) :
+    Host.Method_max_initcode_size ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.max_initcode_size (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_max_initcode_size.
+      run_symbolic.
+  Defined.
+
   Instance method_beneficiary
       (Self : Set) `{Link Self}
       (method_beneficiary : Host.Method_beneficiary Self) :

--- a/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v.jinja2
@@ -102,6 +102,7 @@ Export (hints) SelfDestructResult.
 pub trait Host: TransactionGetter + BlockGetter + CfgGetter {
     fn load_account_delegated(&mut self, address: Address) -> Option<AccountLoad>;
     fn block_hash(&mut self, number: u64) -> Option<B256>;
+    fn max_initcode_size(&self) -> usize;
     fn beneficiary(&self) -> Address;
     fn block_number(&self) -> U256;
     fn chain_id(&self) -> U256;
@@ -196,6 +197,14 @@ Module Host.
     block_hash_is_method :: IsTraitMethod.C (trait Self) "block_hash" block_hash;
     run_block_hash (self : '&mut Self) (number : u64) ::
       Run.Trait block_hash [] [] [ φ self; φ number ] (option aliases.B256.t);
+  }.
+
+  (* fn max_initcode_size(&self) -> usize; *)
+  Class Method_max_initcode_size (Self : Set) `{Link Self} : Set := {
+    max_initcode_size : PolymorphicFunction.t;
+    max_initcode_size_is_method :: IsTraitMethod.C (trait Self) "max_initcode_size" max_initcode_size;
+    run_max_initcode_size (self : '& Self) ::
+      Run.Trait max_initcode_size [] [] [ φ self ] usize;
   }.
 
   (* fn beneficiary(&self) -> Address; *)
@@ -374,6 +383,7 @@ Module Host.
     run_CfgGetter_for_Self :: CfgGetter.Run Self (Types.to_CfgGetter_types types);
     method_load_account_delegated :: Method_load_account_delegated Self;
     method_block_hash :: Method_block_hash Self;
+    method_max_initcode_size :: Method_max_initcode_size Self;
     method_beneficiary :: Method_beneficiary Self;
     method_block_number :: Method_block_number Self;
     method_timestamp :: Method_timestamp Self;
@@ -397,6 +407,23 @@ End Host.
 Export (hints) Host.
 
 Module Impl_Host_for_RefMut.
+  Instance method_max_initcode_size
+      (Self : Set) `{Link Self}
+      (method_max_initcode_size : Host.Method_max_initcode_size Self) :
+    Host.Method_max_initcode_size ('&mut Self).
+  Proof.
+    unshelve econstructor.
+    - exact (host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.max_initcode_size (Φ Self)).
+    - constructor.
+      econstructor.
+      + apply host.underscore.Impl_revm_context_interface_host_Host_where_revm_context_interface_host_Host_T_where_core_marker_Sized_T_for_ref_mut_T.Implements.
+      + reflexivity.
+    - intros self.
+      constructor.
+      destruct method_max_initcode_size.
+      run_symbolic.
+  Defined.
+
   Instance method_beneficiary
       (Self : Set) `{Link Self}
       (method_beneficiary : Host.Method_beneficiary Self) :

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/create.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/create.v
@@ -26,6 +26,7 @@ Require Import revm.revm_interpreter.interpreter_action.links.call_inputs.
 Require Import revm.revm_interpreter.interpreter_action.links.create_inputs.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_action.
@@ -41,8 +42,7 @@ Require Import ruint.links.lib.
 
 (*
 pub fn create<WIRE: InterpreterTypes, const IS_CREATE2: bool, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    host: &mut H,
+    context: InstructionContext<'_, H, WIRE>,
 )
 *)
 Instance run_create
@@ -52,15 +52,16 @@ Instance run_create
   {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
   (run_Host_for_H : Host.Run H H_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.contract.create [ φ IS_CREATE2 ] [ Φ WIRE; Φ H ] [ φ interpreter; φ host ]
+    instructions.contract.create [ φ IS_CREATE2 ] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  pose proof run_InterpreterTypes_for_WIRE as run_InterpreterTypes_for_WIRE_copy.
   destruct run_InterpreterTypes_for_WIRE.
   destruct run_StackTrait_for_Stack.
+  pose proof run_MemoryTrait_for_Memory as run_MemoryTrait_for_Memory_copy.
   destruct run_MemoryTrait_for_Memory.
   destruct run_LoopControl_for_Control.
   destruct run_InputsTrait_for_Input.
@@ -68,8 +69,22 @@ Proof.
   destruct run_Host_for_H.
   destruct run_CfgGetter_for_Self.
   destruct run_Cfg_for_Cfg.
+  destruct (Impl_Host_for_RefMut.method_max_initcode_size H method_max_initcode_size).
   destruct (Impl_AsRef_for_Slice.run u8).
   destruct run_Deref_for_Synthetic.
   run_symbolic.
+  { eapply (@Impl_Interpreter.run_halt WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
+  { eapply (@Impl_Interpreter.run_halt_not_activated WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
+  { eapply (@Impl_Interpreter.run_halt WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
+  { eapply (@Impl_Interpreter.run_halt WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
+  { eapply (@Impl_Interpreter.run_halt_oog WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
+  { eapply (@Impl_Interpreter.run_halt WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
+  { eapply (@Impl_Interpreter.run_halt_memory_oog WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
+  { eapply (@Impl_Interpreter.run_halt_oog WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
+  { eapply (@Impl_Interpreter.run_halt_oog WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
+  { eapply (@Impl_Interpreter.run_halt_underflow WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
+  { eapply (@Impl_Interpreter.run_halt_oog WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
+  { eapply (@Impl_Interpreter.run_halt_oog WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
+  { eapply (@Impl_Interpreter.run_halt_underflow WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
 Defined.
 Global Opaque run_create.


### PR DESCRIPTION
Updates the v103 create contract link shape and exposes the Host max_initcode_size dependency used by the generated create body.