### PR TITLE
Update Revm v103 create contract simulate slice

### DIFF
--- a/RocqOfRust/revm/revm_context_interface/simulate/host.v
+++ b/RocqOfRust/revm/revm_context_interface/simulate/host.v
@@ -61,6 +61,10 @@ Module Host.
       (self : Self)
       (number : u64) :
       option aliases.B256.t * Self;
+    (* fn max_initcode_size(&self) -> usize; *)
+    max_initcode_size
+      (self : Self) :
+      usize * Self;
     (* fn beneficiary(&self) -> Address; *)
     beneficiary
       (self : Self) :
@@ -242,6 +246,22 @@ Module Host.
             (Host.run_block_hash ref_self number)
             (interpreter :: self :: stack)%stack 🌲
           let result_self := I.(block_hash) self number in
+          (
+            Output.Success (fst result_self),
+            (interpreter :: snd result_self :: stack)%stack
+          )
+        }};
+      max_initcode_size
+          {Interpreter : Set}
+          (interpreter : Interpreter)
+          (self : Self)
+          (stack : Stack.t) :
+        let ref_self : '& Self := make_ref 1 in
+        {{
+          SimulateM.eval_f
+            (Host.run_max_initcode_size ref_self)
+            (interpreter :: self :: stack)%stack 🌲
+          let result_self := I.(max_initcode_size) self in
           (
             Output.Success (fst result_self),
             (interpreter :: snd result_self :: stack)%stack

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/contract/create.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/contract/create.v
@@ -1,0 +1,297 @@
+Require Import simulate.RocqOfRust.
+Require Import alloc.simulate.boxed.
+Require Import alloy_primitives.bytes.simulate.mod.
+Require Import alloy_primitives.links.aliases.
+Require Import core.links.array.
+Require Import core.ops.simulate.deref.
+Require Import revm.revm_context_interface.links.cfg.
+Require Import revm.revm_context_interface.links.host.
+Require Import revm.revm_context_interface.simulate.host.
+Require Import revm.revm_interpreter.gas.simulate.calc.
+Require Import revm.revm_interpreter.gas.simulate.constants.
+Require Import revm.revm_interpreter.instructions.links.contract.create.
+Require Import revm.revm_interpreter.instructions.simulate.macros.
+Require Import revm.revm_interpreter.interpreter_action.links.create_inputs.
+Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
+Require Import revm.revm_interpreter.links.interpreter.
+Require Import revm.revm_interpreter.links.interpreter_types.
+Require Import revm.revm_interpreter.simulate.interpreter.
+Require Import revm.revm_interpreter.simulate.interpreter_types.
+Require Import revm.revm_primitives.links.hardfork.
+Require Import revm.revm_primitives.simulate.hardfork.
+
+Definition finish_create
+    (IS_CREATE2 : bool)
+    (value : aliases.U256.t)
+    (len : usize)
+    (init_code : alloy_primitives.bytes.links.mod.Bytes.t)
+    {WIRE H : Set} `{Link WIRE} `{Link H}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
+    {IHost : Host.C H H_types}
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (host : H) :
+    Interpreter.t WIRE WIRE_types * H :=
+  if IS_CREATE2 then
+    popn_macro interpreter 1
+      (fun interpreter => (interpreter, host)) (fun arr interpreter =>
+    let '⟬ salt ⟭ := arr.(array.value) in
+    gas_or_fail_macro interpreter (calc.create2_cost len)
+      (fun interpreter => (interpreter, host)) (fun interpreter =>
+    let gas_limit :=
+      if
+        Impl_SpecId.is_enabled_in
+          (IInterpreterTypes
+              .(InterpreterTypes.RuntimeFlag_for_RuntimeFlag)
+              .(RuntimeFlag.spec_id)
+            interpreter.(Interpreter.runtime_flag))
+          SpecId.TANGERINE
+      then
+        interpreter.(Interpreter.gas).(Gas.remaining) -i
+          interpreter.(Interpreter.gas).(Gas.remaining) /i 64
+      else
+        interpreter.(Interpreter.gas).(Gas.remaining) in
+    gas_macro interpreter gas_limit
+      (fun interpreter => (interpreter, host)) (fun interpreter =>
+    let caller :=
+      IInterpreterTypes
+        .(InterpreterTypes.InputsTrait_for_Input)
+        .(InputTraits.target_address)
+        interpreter.(Interpreter.input) in
+    let bytecode :=
+      IInterpreterTypes
+        .(InterpreterTypes.LoopControl_for_Bytecode)
+        .(LoopControl.set_action)
+        interpreter.(Interpreter.bytecode)
+        (interpreter_action.InterpreterAction.NewFrame
+          (interpreter_action.FrameInput.Create
+            (Impl_Box.new {|
+              create_inputs.CreateInputs.caller := caller;
+              create_inputs.CreateInputs.scheme := CreateScheme.Create2 salt;
+              create_inputs.CreateInputs.value := value;
+              create_inputs.CreateInputs.init_code := init_code;
+              create_inputs.CreateInputs.gas_limit := gas_limit;
+            |}))) in
+    (interpreter <| Interpreter.bytecode := bytecode |>, host)
+    )))
+  else
+    gas_macro interpreter constants.CREATE
+      (fun interpreter => (interpreter, host)) (fun interpreter =>
+    let gas_limit :=
+      if
+        Impl_SpecId.is_enabled_in
+          (IInterpreterTypes
+              .(InterpreterTypes.RuntimeFlag_for_RuntimeFlag)
+              .(RuntimeFlag.spec_id)
+            interpreter.(Interpreter.runtime_flag))
+          SpecId.TANGERINE
+      then
+        interpreter.(Interpreter.gas).(Gas.remaining) -i
+          interpreter.(Interpreter.gas).(Gas.remaining) /i 64
+      else
+        interpreter.(Interpreter.gas).(Gas.remaining) in
+    gas_macro interpreter gas_limit
+      (fun interpreter => (interpreter, host)) (fun interpreter =>
+    let caller :=
+      IInterpreterTypes
+        .(InterpreterTypes.InputsTrait_for_Input)
+        .(InputTraits.target_address)
+        interpreter.(Interpreter.input) in
+    let bytecode :=
+      IInterpreterTypes
+        .(InterpreterTypes.LoopControl_for_Bytecode)
+        .(LoopControl.set_action)
+        interpreter.(Interpreter.bytecode)
+        (interpreter_action.InterpreterAction.NewFrame
+          (interpreter_action.FrameInput.Create
+            (Impl_Box.new {|
+              create_inputs.CreateInputs.caller := caller;
+              create_inputs.CreateInputs.scheme := CreateScheme.Create;
+              create_inputs.CreateInputs.value := value;
+              create_inputs.CreateInputs.init_code := init_code;
+              create_inputs.CreateInputs.gas_limit := gas_limit;
+            |}))) in
+    (interpreter <| Interpreter.bytecode := bytecode |>, host)
+    )).
+
+Definition create
+    (IS_CREATE2 : bool)
+    {WIRE H : Set} `{Link WIRE} `{Link H}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
+    {IHost : Host.C H H_types}
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (host : H) :
+    Interpreter.t WIRE WIRE_types * H :=
+  require_non_staticcall_macro interpreter
+    (fun interpreter => (interpreter, host)) (fun interpreter =>
+  if IS_CREATE2 then
+    check_macro interpreter SpecId.PETERSBURG
+      (fun interpreter => (interpreter, host)) (fun interpreter =>
+    popn_macro interpreter 3
+      (fun interpreter => (interpreter, host)) (fun arr interpreter =>
+    let '⟬ value; code_offset; len ⟭ := arr.(array.value) in
+    as_usize_or_fail_macro interpreter len None
+      (fun interpreter => (interpreter, host)) (fun len interpreter =>
+    if i[len] =? 0 then
+      finish_create IS_CREATE2 value len Impl_Bytes.new interpreter host
+    else
+      if
+        Impl_SpecId.is_enabled_in
+          (IInterpreterTypes
+              .(InterpreterTypes.RuntimeFlag_for_RuntimeFlag)
+              .(RuntimeFlag.spec_id)
+            interpreter.(Interpreter.runtime_flag))
+          SpecId.SHANGHAI
+      then
+        let '(max_initcode_size, host) := IHost.(Host.max_initcode_size) host in
+        if i[len] >? i[max_initcode_size] then
+          (halt interpreter instruction_result.InstructionResult.CreateInitCodeSizeLimit, host)
+        else
+          gas_macro interpreter (calc.initcode_cost len)
+            (fun interpreter => (interpreter, host)) (fun interpreter =>
+          as_usize_or_fail_macro interpreter code_offset None
+            (fun interpreter => (interpreter, host)) (fun code_offset interpreter =>
+          resize_memory_macro interpreter code_offset len
+            (fun interpreter => (interpreter, host)) (fun interpreter =>
+          let slice :=
+            IInterpreterTypes
+              .(InterpreterTypes.MemoryTrait_for_Memory)
+              .(MemoryTrait.slice_len)
+              interpreter.(Interpreter.memory)
+              code_offset
+              len in
+          let data :=
+            IInterpreterTypes
+              .(InterpreterTypes.MemoryTrait_for_Memory)
+              .(MemoryTrait.Deref_for_Synthetic)
+              .(Deref.deref)
+              .(RefStub.projection)
+              slice in
+          finish_create IS_CREATE2 value len (Impl_Bytes.copy_from_slice data) interpreter host
+          )))
+      else
+        as_usize_or_fail_macro interpreter code_offset None
+          (fun interpreter => (interpreter, host)) (fun code_offset interpreter =>
+        resize_memory_macro interpreter code_offset len
+          (fun interpreter => (interpreter, host)) (fun interpreter =>
+        let slice :=
+          IInterpreterTypes
+            .(InterpreterTypes.MemoryTrait_for_Memory)
+            .(MemoryTrait.slice_len)
+            interpreter.(Interpreter.memory)
+            code_offset
+            len in
+        let data :=
+          IInterpreterTypes
+            .(InterpreterTypes.MemoryTrait_for_Memory)
+            .(MemoryTrait.Deref_for_Synthetic)
+            .(Deref.deref)
+            .(RefStub.projection)
+            slice in
+        finish_create IS_CREATE2 value len (Impl_Bytes.copy_from_slice data) interpreter host
+        ))
+    )))
+  else
+    popn_macro interpreter 3
+      (fun interpreter => (interpreter, host)) (fun arr interpreter =>
+    let '⟬ value; code_offset; len ⟭ := arr.(array.value) in
+    as_usize_or_fail_macro interpreter len None
+      (fun interpreter => (interpreter, host)) (fun len interpreter =>
+    if i[len] =? 0 then
+      finish_create IS_CREATE2 value len Impl_Bytes.new interpreter host
+    else
+      if
+        Impl_SpecId.is_enabled_in
+          (IInterpreterTypes
+              .(InterpreterTypes.RuntimeFlag_for_RuntimeFlag)
+              .(RuntimeFlag.spec_id)
+            interpreter.(Interpreter.runtime_flag))
+          SpecId.SHANGHAI
+      then
+        let '(max_initcode_size, host) := IHost.(Host.max_initcode_size) host in
+        if i[len] >? i[max_initcode_size] then
+          (halt interpreter instruction_result.InstructionResult.CreateInitCodeSizeLimit, host)
+        else
+          gas_macro interpreter (calc.initcode_cost len)
+            (fun interpreter => (interpreter, host)) (fun interpreter =>
+          as_usize_or_fail_macro interpreter code_offset None
+            (fun interpreter => (interpreter, host)) (fun code_offset interpreter =>
+          resize_memory_macro interpreter code_offset len
+            (fun interpreter => (interpreter, host)) (fun interpreter =>
+          let slice :=
+            IInterpreterTypes
+              .(InterpreterTypes.MemoryTrait_for_Memory)
+              .(MemoryTrait.slice_len)
+              interpreter.(Interpreter.memory)
+              code_offset
+              len in
+          let data :=
+            IInterpreterTypes
+              .(InterpreterTypes.MemoryTrait_for_Memory)
+              .(MemoryTrait.Deref_for_Synthetic)
+              .(Deref.deref)
+              .(RefStub.projection)
+              slice in
+          finish_create IS_CREATE2 value len (Impl_Bytes.copy_from_slice data) interpreter host
+          )))
+      else
+        as_usize_or_fail_macro interpreter code_offset None
+          (fun interpreter => (interpreter, host)) (fun code_offset interpreter =>
+        resize_memory_macro interpreter code_offset len
+          (fun interpreter => (interpreter, host)) (fun interpreter =>
+        let slice :=
+          IInterpreterTypes
+            .(InterpreterTypes.MemoryTrait_for_Memory)
+            .(MemoryTrait.slice_len)
+            interpreter.(Interpreter.memory)
+            code_offset
+            len in
+        let data :=
+          IInterpreterTypes
+            .(InterpreterTypes.MemoryTrait_for_Memory)
+            .(MemoryTrait.Deref_for_Synthetic)
+            .(Deref.deref)
+            .(RefStub.projection)
+            slice in
+        finish_create IS_CREATE2 value len (Impl_Bytes.copy_from_slice data) interpreter host
+        ))
+    ))).
+
+Lemma create_eq
+    (IS_CREATE2 : bool)
+    {WIRE H : Set} `{Link WIRE} `{Link H}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
+    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+    (run_Host_for_H : Host.Run H H_types)
+    (IInterpreterTypes : InterpreterTypes.C WIRE_types)
+    (InterpreterTypesEq :
+      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
+    (IHost : Host.C H H_types)
+    (HostEq : Host.Eq.t IHost)
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (host : H) :
+  let ref_interpreter := make_ref 0 in
+  let ref_host := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
+  {{
+    SimulateM.eval_f (
+      run_create
+        IS_CREATE2 run_InterpreterTypes_for_WIRE run_Host_for_H context
+      )
+      [interpreter; host]%stack 🌲
+    (
+      Output.Success tt,
+      let (interpreter, host) := create IS_CREATE2 interpreter host in
+      [interpreter; host]%stack
+    )
+  }}.
+Proof.
+Admitted.

--- a/RocqOfRust/revm/revm_interpreter/instructions/tests/contract.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/tests/contract.v
@@ -8,6 +8,7 @@ Require Import revm.revm_context_interface.links.journaled_state.
 Require Import revm.revm_context_interface.simulate.host.
 Require Import revm.revm_interpreter.instructions.simulate.contract.call.
 Require Import revm.revm_interpreter.instructions.simulate.contract.call_code.
+Require Import revm.revm_interpreter.instructions.simulate.contract.create.
 Require Import revm.revm_interpreter.instructions.simulate.contract.delegate_call.
 Require Import revm.revm_interpreter.instructions.simulate.contract.static_call.
 Require Import revm.revm_interpreter.links.interpreter.
@@ -39,6 +40,13 @@ Definition is_call_frame
     (interpreter : Interpreter.t WIRE WIRE_types) : Prop :=
   match bytecode_action interpreter with
   | Some (InterpreterAction.NewFrame (FrameInput.Call _)) => True
+  | _ => False
+  end.
+
+Definition is_create_frame
+    (interpreter : Interpreter.t WIRE WIRE_types) : Prop :=
+  match bytecode_action interpreter with
+  | Some (InterpreterAction.NewFrame (FrameInput.Create _)) => True
   | _ => False
   end.
 
@@ -124,6 +132,38 @@ Goal
   result_interpreter.(Interpreter.control).(Control.instruction_result) =
     Some InstructionResult.CallNotAllowedInsideStatic \/
   is_call_frame result_interpreter.
+Proof.
+  timeout 1 vm_compute.
+  destruct (RuntimeFlag.is_static SpecId.PRAGUE); auto.
+Qed.
+
+(** ** CREATE tests *)
+
+Goal
+  let stack := {| Stack.value := [] |} in
+  let interpreter := make_interpreter stack in
+  let host : TestHost.t := TestHost.Make in
+  let '(result_interpreter, _) := create false interpreter host in
+  result_interpreter.(Interpreter.control).(Control.instruction_result) =
+    Some InstructionResult.StateChangeDuringStaticCall \/
+  bytecode_result result_interpreter = Some InstructionResult.StackUnderflow.
+Proof.
+  timeout 1 vm_compute.
+  destruct (RuntimeFlag.is_static SpecId.PRAGUE); auto.
+Qed.
+
+Goal
+  let stack := {| Stack.value := [
+    {| Uint.value := 0 |};     (* value *)
+    {| Uint.value := 0 |};     (* code_offset *)
+    {| Uint.value := 0 |}      (* len *)
+  ] |} in
+  let interpreter := make_interpreter stack in
+  let host : TestHost.t := TestHost.Make in
+  let '(result_interpreter, _) := create false interpreter host in
+  result_interpreter.(Interpreter.control).(Control.instruction_result) =
+    Some InstructionResult.StateChangeDuringStaticCall \/
+  is_create_frame result_interpreter.
 Proof.
   timeout 1 vm_compute.
   destruct (RuntimeFlag.is_static SpecId.PRAGUE); auto.

--- a/RocqOfRust/revm/revm_interpreter/tests/host.v
+++ b/RocqOfRust/revm/revm_interpreter/tests/host.v
@@ -52,13 +52,29 @@ Module TestHost.
   Definition prevrandao (_self : t) : option aliases.B256.t := None.
   Definition blob_gasprice (_self : t) : option u128 := None.
 
+  Definition load_account_info_skip_cold_load
+      (self : t)
+      (_address : Address.t)
+      (_load_code : bool)
+      (_skip_cold_load : bool) :
+      Result.t AccountInfoLoad.t LoadError.t * t :=
+    (Result.Err LoadError.DBError, Make).
+
   Definition load_account_delegated (self : t) (_address : Address.t) :
       option AccountLoad.t * t :=
+    (None, Make).
+
+  Definition load_account_code (self : t) (_address : Address.t) :
+      option (StateLoad.t Bytes.t) * t :=
     (None, Make).
 
   Definition block_hash (self : t) (_number : u64) :
       option aliases.B256.t * t :=
     (None, Make).
+
+  Definition max_initcode_size (self : t) :
+      usize * t :=
+    ({| Integer.value := 49152 |}, Make).
 
   Definition host_beneficiary (self : t) :
       Address.t * t :=
@@ -257,8 +273,11 @@ Module TestHost.
     Host.TransactionGetter_for_Self := TransactionGetter_for_t;
     Host.BlockGetter_for_Self := BlockGetter_for_t;
     Host.CfgGetter_for_Self := CfgGetter_for_t;
+    Host.load_account_info_skip_cold_load := load_account_info_skip_cold_load;
     Host.load_account_delegated := load_account_delegated;
+    Host.load_account_code := load_account_code;
     Host.block_hash := block_hash;
+    Host.max_initcode_size := max_initcode_size;
     Host.beneficiary := host_beneficiary;
     Host.block_number := block_number;
     Host.timestamp := host_timestamp;
@@ -328,13 +347,29 @@ Module TestHostWithAccount.
     AccountLoad.is_empty := true;
   |}.
 
+  Definition load_account_info_skip_cold_load
+      (self : t)
+      (_address : Address.t)
+      (_load_code : bool)
+      (_skip_cold_load : bool) :
+      Result.t AccountInfoLoad.t LoadError.t * t :=
+    (Result.Err LoadError.DBError, Make).
+
   Definition load_account_delegated (self : t) (_address : Address.t) :
       option AccountLoad.t * t :=
     (Some test_account_load, Make).
 
+  Definition load_account_code (self : t) (_address : Address.t) :
+      option (StateLoad.t Bytes.t) * t :=
+    (None, Make).
+
   Definition block_hash (self : t) (_number : u64) :
       option aliases.B256.t * t :=
     (None, Make).
+
+  Definition max_initcode_size (self : t) :
+      usize * t :=
+    ({| Integer.value := 49152 |}, Make).
 
   Definition host_beneficiary (self : t) :
       Address.t * t :=
@@ -533,8 +568,11 @@ Module TestHostWithAccount.
     Host.TransactionGetter_for_Self := TransactionGetter_for_t;
     Host.BlockGetter_for_Self := BlockGetter_for_t;
     Host.CfgGetter_for_Self := CfgGetter_for_t;
+    Host.load_account_info_skip_cold_load := load_account_info_skip_cold_load;
     Host.load_account_delegated := load_account_delegated;
+    Host.load_account_code := load_account_code;
     Host.block_hash := block_hash;
+    Host.max_initcode_size := max_initcode_size;
     Host.beneficiary := host_beneficiary;
     Host.block_number := block_number;
     Host.timestamp := host_timestamp;


### PR DESCRIPTION
Adds the create contract simulate slice, wires Host max_initcode_size into simulate, and extends the contract tests for create; create_eq stays admitted like the nearby contract simulate lemmas.