### PR TITLE
Update Revm v103 bitwise shift slice

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/sar.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/sar.v
@@ -2,11 +2,13 @@ Require Import RocqOfRust.RocqOfRust.
 Require Import links.RocqOfRust.
 Require Import core.convert.links.num.
 Require Import core.links.cmp.
+Require Import core.links.option.
 Require Import core.links.result.
 Require Import core.num.links.error.
 Require Import core.num.links.mod.
 Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -21,14 +23,19 @@ Instance run_bitwise_sar
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.bitwise.sar [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.bitwise.sar [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_LoopControl_for_Control.
+  destruct run_RuntimeFlag_for_RuntimeFlag.
   destruct Impl_TryFrom_u64_for_usize.run.
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_not_activated. }
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_bitwise_sar.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/shl.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/shl.v
@@ -2,11 +2,13 @@ Require Import RocqOfRust.RocqOfRust.
 Require Import links.RocqOfRust.
 Require Import core.convert.links.num.
 Require Import core.links.cmp.
+Require Import core.links.option.
 Require Import core.links.result.
 Require Import core.num.links.error.
 Require Import core.num.links.mod.
 Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -21,15 +23,20 @@ Instance run_bitwise_shl
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.bitwise.shl [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.bitwise.shl [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_LoopControl_for_Control.
+  destruct run_RuntimeFlag_for_RuntimeFlag.
   destruct Impl_TryFrom_u64_for_usize.run.
   destruct (Impl_Shl_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_not_activated. }
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_bitwise_shl.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/shr.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/shr.v
@@ -2,11 +2,13 @@ Require Import RocqOfRust.RocqOfRust.
 Require Import links.RocqOfRust.
 Require Import core.convert.links.num.
 Require Import core.links.cmp.
+Require Import core.links.option.
 Require Import core.links.result.
 Require Import core.num.links.error.
 Require Import core.num.links.mod.
 Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -21,15 +23,20 @@ Instance run_bitwise_shr
     {WIRE H : Set} `{Link WIRE} `{Link H}
     {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (_host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.bitwise.shr [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.bitwise.shr [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_LoopControl_for_Control.
+  destruct run_RuntimeFlag_for_RuntimeFlag.
   destruct Impl_TryFrom_u64_for_usize.run.
   destruct (Impl_Shr_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_not_activated. }
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_bitwise_shr.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/bitwise/sar.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/bitwise/sar.v
@@ -4,10 +4,12 @@ Require Import core.links.array.
 Require Import core.links.cmp.
 Require Import core.ops.simulate.bit.
 Require Import core.simulate.cmp.
+Require Import core.simulate.option.
 Require Import revm.revm_context_interface.links.host.
 Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.bitwise.sar.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
@@ -26,7 +28,6 @@ Definition op_sar
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
   check_macro interpreter SpecId.CONSTANTINOPLE id (fun interpreter =>
-  gas_macro interpreter constants.VERYLOW id (fun interpreter =>
   popn_top_macro interpreter 1 id (fun arr top interpreter =>
     let '⟬ shift_op ⟭ := arr.(array.value) in
     let value := top.(RefStub.projection) interpreter.(Interpreter.stack) in
@@ -44,7 +45,7 @@ Definition op_sar
         interpreter.(Interpreter.stack) result in
     interpreter
       <| Interpreter.stack := stack |>
-  ))).
+  )).
 
 Lemma op_sar_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -58,9 +59,13 @@ Lemma op_sar_eq
     (_host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_bitwise_sar run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_bitwise_sar run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -75,8 +80,12 @@ Opaque Impl_Uint.bit.
   intros.
   unfold op_sar.
   check_macro_eq InterpreterTypesEq.
-  gas_macro_eq idtac.
   popn_top_macro_eq InterpreterTypesEq.
+  eapply Run.Call; [
+    eapply Impl_Option.unwrap_unchecked_eq;
+    reflexivity
+  |].
+  cbn.
   match goal with
   | array : array.t aliases.U256.t _ |- _ => destruct array as [[op1 []]]; cbn
   end.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/bitwise/shl.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/bitwise/shl.v
@@ -4,10 +4,12 @@ Require Import core.links.array.
 Require Import core.links.cmp.
 Require Import core.ops.simulate.bit.
 Require Import core.simulate.cmp.
+Require Import core.simulate.option.
 Require Import revm.revm_context_interface.links.host.
 Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.bitwise.shl.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
@@ -26,7 +28,6 @@ Definition op_shl
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
   check_macro interpreter SpecId.CONSTANTINOPLE id (fun interpreter =>
-  gas_macro interpreter constants.VERYLOW id (fun interpreter =>
   popn_top_macro interpreter 1 id (fun arr top interpreter =>
     let '⟬ shift_op ⟭ := arr.(array.value) in
     let op2 := top.(RefStub.projection) interpreter.(Interpreter.stack) in
@@ -40,7 +41,7 @@ Definition op_shl
         interpreter.(Interpreter.stack) result in
     interpreter
       <| Interpreter.stack := stack |>
-  ))).
+  )).
 
 Lemma op_shl_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -54,9 +55,13 @@ Lemma op_shl_eq
     (_host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_bitwise_shl run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_bitwise_shl run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -70,8 +75,12 @@ Proof.
   intros.
   unfold op_shl.
   check_macro_eq InterpreterTypesEq.
-  gas_macro_eq idtac.
   popn_top_macro_eq InterpreterTypesEq.
+  eapply Run.Call; [
+    eapply Impl_Option.unwrap_unchecked_eq;
+    reflexivity
+  |].
+  cbn.
   match goal with
   | array : array.t aliases.U256.t _ |- _ => destruct array as [[op1 []]]; cbn
   end.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/bitwise/shr.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/bitwise/shr.v
@@ -4,10 +4,12 @@ Require Import core.links.array.
 Require Import core.links.cmp.
 Require Import core.ops.simulate.bit.
 Require Import core.simulate.cmp.
+Require Import core.simulate.option.
 Require Import revm.revm_context_interface.links.host.
 Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.bitwise.shr.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
@@ -26,7 +28,6 @@ Definition op_shr
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
   check_macro interpreter SpecId.CONSTANTINOPLE id (fun interpreter =>
-  gas_macro interpreter constants.VERYLOW id (fun interpreter =>
   popn_top_macro interpreter 1 id (fun arr top interpreter =>
     let '⟬ shift_op ⟭ := arr.(array.value) in
     let op2 := top.(RefStub.projection) interpreter.(Interpreter.stack) in
@@ -40,7 +41,7 @@ Definition op_shr
         interpreter.(Interpreter.stack) result in
     interpreter
       <| Interpreter.stack := stack |>
-  ))).
+  )).
 
 Lemma op_shr_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -54,9 +55,13 @@ Lemma op_shr_eq
     (_host : H) :
   let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
   let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   {{
     SimulateM.eval_f
-      (run_bitwise_shr run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+      (run_bitwise_shr run_InterpreterTypes_for_WIRE context)
       ([interpreter; _host]%stack) 🌲
     (
       Output.Success tt,
@@ -70,8 +75,12 @@ Proof.
   intros.
   unfold op_shr.
   check_macro_eq InterpreterTypesEq.
-  gas_macro_eq idtac.
   popn_top_macro_eq InterpreterTypesEq.
+  eapply Run.Call; [
+    eapply Impl_Option.unwrap_unchecked_eq;
+    reflexivity
+  |].
+  cbn.
   match goal with
   | array : array.t aliases.U256.t _ |- _ => destruct array as [[op1 []]]; cbn
   end.


### PR DESCRIPTION
Updates `shl`, `shr`, and `sar` to the v103 `InstructionContext` shape and removes the stale body-level gas macro from their simulations.