### PR TITLE
Update Revm v103 bitwise clz instruction slice

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/clz.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/clz.v
@@ -1,0 +1,41 @@
+Require Import RocqOfRust.RocqOfRust.
+Require Import links.RocqOfRust.
+Require Import core.convert.links.num.
+Require Import core.links.cmp.
+Require Import core.links.option.
+Require Import core.links.result.
+Require Import core.num.links.error.
+Require Import core.num.links.mod.
+Require Import revm.revm_interpreter.gas.links.constants.
+Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
+Require Import revm.revm_interpreter.links.instruction_result.
+Require Import revm.revm_interpreter.links.interpreter.
+Require Import revm.revm_interpreter.links.interpreter_types.
+Require Import revm.revm_interpreter.instructions.bitwise.
+Require Import revm.revm_primitives.links.hardfork.
+Require Import ruint.links.bits.
+Require Import ruint.links.cmp.
+Require Import ruint.links.from.
+Require Import ruint.links.lib.
+
+Instance run_bitwise_clz
+    {WIRE H : Set} `{Link WIRE} `{Link H}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+    (context : InstructionContext.t H WIRE WIRE_types) :
+  Run.Trait
+    instructions.bitwise.clz [] [ Φ WIRE; Φ H ] [ φ context ]
+    unit.
+Proof.
+  constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_LoopControl_for_Control.
+  destruct run_RuntimeFlag_for_RuntimeFlag.
+  destruct (TryFrom_usize_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
+  run_symbolic.
+  { eapply Impl_Interpreter.run_halt_not_activated. }
+  { eapply Impl_Interpreter.run_halt_underflow. }
+Defined.
+Global Opaque run_bitwise_clz.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/bitwise/clz.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/bitwise/clz.v
@@ -1,0 +1,86 @@
+Require Import simulate.RocqOfRust.
+Require Import alloy_primitives.links.aliases.
+Require Import core.links.array.
+Require Import core.links.cmp.
+Require Import core.simulate.cmp.
+Require Import core.simulate.option.
+Require Import revm.revm_context_interface.links.host.
+Require Import revm.revm_interpreter.gas.simulate.constants.
+Require Import revm.revm_interpreter.instructions.links.bitwise.clz.
+Require Import revm.revm_interpreter.instructions.simulate.macros.
+Require Import revm.revm_interpreter.links.instruction_context.
+Require Import revm.revm_interpreter.links.interpreter.
+Require Import revm.revm_interpreter.links.interpreter_types.
+Require Import revm.revm_interpreter.simulate.interpreter_types.
+Require Import revm.revm_primitives.links.hardfork.
+Require Import revm.revm_primitives.simulate.hardfork.
+Require Import ruint.links.lib.
+Require Import ruint.simulate.bits.
+Require Import ruint.simulate.cmp.
+Require Import ruint.simulate.from.
+
+Definition op_clz
+    {WIRE : Set} `{Link WIRE}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {IInterpreterTypes : InterpreterTypes.C WIRE_types}
+    (interpreter : Interpreter.t WIRE WIRE_types) :
+    Interpreter.t WIRE WIRE_types :=
+  check_macro interpreter SpecId.OSAKA id (fun interpreter =>
+  popn_top_macro interpreter 0 id (fun arr top interpreter =>
+    let op1 := top.(RefStub.projection) interpreter.(Interpreter.stack) in
+    let leading_zeros := Impl_Uint.leading_zeros op1 in
+    let result : aliases.U256.t := Impl_Uint.from leading_zeros in
+    let stack :=
+      top.(RefStub.injection)
+        interpreter.(Interpreter.stack) result in
+    interpreter
+      <| Interpreter.stack := stack |>
+  )).
+
+Lemma op_clz_eq
+    {WIRE H : Set} `{Link WIRE} `{Link H}
+    {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
+    {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
+    (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
+    (IInterpreterTypes : InterpreterTypes.C WIRE_types)
+    (InterpreterTypesEq :
+      InterpreterTypes.Eq.t WIRE WIRE_types run_InterpreterTypes_for_WIRE IInterpreterTypes)
+    (interpreter : Interpreter.t WIRE WIRE_types)
+    (_host : H) :
+  let ref_interpreter : '&mut (Interpreter.t WIRE WIRE_types) := make_ref 0 in
+  let ref_host : '&mut H := make_ref 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
+  {{
+    SimulateM.eval_f
+      (run_bitwise_clz run_InterpreterTypes_for_WIRE context)
+      ([interpreter; _host]%stack) 🌲
+    (
+      Output.Success tt,
+      [
+        op_clz interpreter;
+        _host
+      ]%stack
+    )
+  }}.
+Proof.
+  intros.
+  unfold op_clz.
+  check_macro_eq InterpreterTypesEq.
+  popn_top_macro_eq InterpreterTypesEq.
+  eapply Run.Call; [
+    eapply Impl_Option.unwrap_unchecked_eq;
+    reflexivity
+  |].
+  cbn.
+  lu.
+  s. {
+    apply Impl_Uint.leading_zeros_eq; repeat unshelve econstructor.
+  }
+  s. {
+    apply Impl_Uint.from_eq; [typeclasses eauto | easy].
+  }
+  s.
+Qed.

--- a/RocqOfRust/revm/revm_interpreter/instructions/tests/bitwise.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/tests/bitwise.v
@@ -2,6 +2,7 @@ Require Import simulate.RocqOfRust.
 Require Import revm.revm_context_interface.links.host.
 Require Import revm.revm_interpreter.instructions.simulate.bitwise.lt.
 Require Import revm.revm_interpreter.instructions.simulate.bitwise.gt.
+Require Import revm.revm_interpreter.instructions.simulate.bitwise.clz.
 Require Import revm.revm_interpreter.instructions.simulate.bitwise.eq.
 Require Import revm.revm_interpreter.instructions.simulate.bitwise.slt.
 Require Import revm.revm_interpreter.instructions.simulate.bitwise.sgt.
@@ -17,7 +18,23 @@ Require Import revm.revm_interpreter.instructions.simulate.bitwise.sar.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.tests.interpreter.
 Require Import revm.revm_interpreter.tests.interpreter_types.
+Require Import revm.revm_primitives.links.hardfork.
 Require Import ruint.links.lib.
+
+Definition make_interpreter_osaka (stack : Stack.t) : Interpreter.t WIRE WIRE_types :=
+  let interpreter := make_interpreter stack in
+  {|
+    Interpreter.bytecode := interpreter.(Interpreter.bytecode);
+    Interpreter.gas := interpreter.(Interpreter.gas);
+    Interpreter.stack := interpreter.(Interpreter.stack);
+    Interpreter.return_data := interpreter.(Interpreter.return_data);
+    Interpreter.memory := interpreter.(Interpreter.memory);
+    Interpreter.input := interpreter.(Interpreter.input);
+    Interpreter.sub_routine := interpreter.(Interpreter.sub_routine);
+    Interpreter.control := interpreter.(Interpreter.control);
+    Interpreter.runtime_flag := SpecId.OSAKA;
+    Interpreter.extend := interpreter.(Interpreter.extend);
+  |}.
 
 (** Test that LT correctly computes 25 < 23 = false, resulting in 0 on stack *)
 Goal
@@ -100,6 +117,34 @@ Goal
   let interpreter := make_interpreter stack in
   let result := op_gt interpreter in
   result.(Interpreter.stack).(Stack.value) = [{| Uint.value := 0 |}].
+Proof.
+  timeout 1 vm_compute.
+  reflexivity.
+Qed.
+
+(** ** CLZ tests *)
+
+(** Test that CLZ returns 256 for zero *)
+Goal
+  let stack := {| Stack.value := [
+    {| Uint.value := 0 |}
+  ] |} in
+  let interpreter := make_interpreter_osaka stack in
+  let result := op_clz interpreter in
+  result.(Interpreter.stack).(Stack.value) = [{| Uint.value := 256 |}].
+Proof.
+  timeout 1 vm_compute.
+  reflexivity.
+Qed.
+
+(** Test that CLZ returns 255 for one *)
+Goal
+  let stack := {| Stack.value := [
+    {| Uint.value := 1 |}
+  ] |} in
+  let interpreter := make_interpreter_osaka stack in
+  let result := op_clz interpreter in
+  result.(Interpreter.stack).(Stack.value) = [{| Uint.value := 255 |}].
 Proof.
   timeout 1 vm_compute.
   reflexivity.

--- a/RocqOfRust/ruint/links/bits.v
+++ b/RocqOfRust/ruint/links/bits.v
@@ -29,6 +29,16 @@ Module Impl_Uint.
   Admitted.
   Global Opaque run_byte.
 
+  (* pub fn leading_zeros(&self) -> usize *)
+  Instance run_leading_zeros
+    (BITS LIMBS : usize)
+    (self : '& (Self BITS LIMBS)) :
+    Run.Trait
+      (bits.Impl_ruint_Uint_BITS_LIMBS.leading_zeros (φ BITS) (φ LIMBS)) [] [] [ φ self ]
+      usize.
+  Admitted.
+  Global Opaque run_leading_zeros.
+
   (* pub fn arithmetic_shr(self, rhs: usize) -> Self *)
   Instance run_arithmetic_shr
     (BITS LIMBS : usize)

--- a/RocqOfRust/ruint/simulate/bits.v
+++ b/RocqOfRust/ruint/simulate/bits.v
@@ -165,6 +165,31 @@ Module Impl_Uint.
     }}.
   Admitted.
 
+  Definition leading_zeros {BITS LIMBS : usize} (self : Self BITS LIMBS) : usize :=
+    let value := self.(Uint.value) mod (2 ^ BITS.(Integer.value)) in
+    {|
+      Integer.value :=
+        if value =? 0 then
+          BITS.(Integer.value)
+        else
+          BITS.(Integer.value) - 1 - Z.log2 value
+    |}.
+
+  Lemma leading_zeros_eq (stack : Stack.t)
+      {BITS LIMBS : usize} (ref_self : '& (Self BITS LIMBS))
+      (self : Self BITS LIMBS) :
+    CanRead.t stack self ref_self ->
+    {{
+      SimulateM.eval_f
+        (ruint.links.bits.Impl_Uint.run_leading_zeros BITS LIMBS ref_self)
+        stack 🌲
+      (
+        Output.Success (leading_zeros self),
+        stack
+      )
+    }}.
+  Admitted.
+
   (* Arithmetic (sign-extending) right shift *)
   Definition arithmetic_shr {BITS LIMBS : usize} (x : Self BITS LIMBS) (n : usize) : Self BITS LIMBS :=
     let sign_bit := 2 ^ (BITS.(Integer.value) - 1) in


### PR DESCRIPTION
Adds the v103 clz link/simulate slice and bitwise tests. The ruint leading_zeros link/simulate boundary is added in its owner files and left admitted for now because proving it goes through the generated as_limbs / iterator / Option.map_or path, so I kept that as dependency proof debt instead of folding it into the clz instruction slice.