### PR TITLE
Update Revm v103 extcodesize host slice

### DIFF
--- a/RocqOfRust/revm/revm_bytecode/links/bytecode.v
+++ b/RocqOfRust/revm/revm_bytecode/links/bytecode.v
@@ -31,6 +31,14 @@ Module Impl_Bytecode.
       alloy_primitives.bytes.links.mod.Bytes.t.
   Admitted.
   Global Opaque run_original_bytes.
+
+  Instance run_len (self : '& Self) :
+    Run.Trait
+      bytecode.Impl_revm_bytecode_bytecode_Bytecode.len
+      [] [] [ φ self ]
+      usize.
+  Admitted.
+  Global Opaque run_len.
 End Impl_Bytecode.
 Export (hints) Impl_Bytecode.
 

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/host/extcodesize.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/host/extcodesize.v
@@ -16,12 +16,14 @@ Require Import core.links.result.
 Require Import core.num.links.mod.
 Require Import revm.revm_context_interface.links.host.
 Require Import revm.revm_context_interface.links.journaled_state.
+Require Import revm.revm_bytecode.links.bytecode.
 Require Import revm.revm_interpreter.gas.links.calc.
 Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.host.
 Require Import revm.revm_interpreter.instructions.links.utility.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -33,8 +35,7 @@ Require Import ruint.links.lib.
 
 (*
 pub fn extcodesize<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    host: &mut H,
+    context: InstructionContext<'_, H, WIRE>,
 )
 *)
 Instance run_extcodesize
@@ -43,15 +44,26 @@ Instance run_extcodesize
   {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
   (run_Host_for_H : Host.Run H H_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.host.extcodesize [] [ Φ WIRE; Φ H ] [ φ interpreter; φ host ]
+    instructions.host.extcodesize [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_RuntimeFlag_for_RuntimeFlag.
+  destruct run_LoopControl_for_Control.
+  destruct run_Host_for_H.
+  destruct revm.revm_context_interface.links.journaled_state.Impl_Deref_for_AccountInfoLoad.run.
   destruct alloy_primitives.bytes.links.mod.Impl_Deref_for_Bytes.run.
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_underflow. }
+  { eapply Impl_Interpreter.run_halt_oog. }
+  { eapply Impl_Interpreter.run_halt_oog. }
+  { eapply Impl_Interpreter.run_halt_oog. }
+  { eapply Impl_Interpreter.run_halt_fatal. }
+  { eapply Impl_Interpreter.run_halt_oog. }
+  { eapply Impl_Interpreter.run_halt_fatal. }
 Defined.
 Global Opaque run_extcodesize.
-

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/host/extcodesize.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/host/extcodesize.v
@@ -4,18 +4,23 @@ Require Import alloy_primitives.bytes.simulate.mod.
 Require Import alloy_primitives.links.aliases.
 Require Import bytes.simulate.bytes.
 Require Import core.links.array.
+Require Import core.links.result.
 Require Import revm.revm_context_interface.links.host.
 Require Import revm.revm_context_interface.links.journaled_state.
 Require Import revm.revm_context_interface.simulate.host.
 Require Import revm.revm_context_interface.simulate.journaled_state.
 Require Import revm.revm_interpreter.gas.simulate.calc.
+Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.host.extcodesize.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.instructions.simulate.utility.
+Require Import revm.revm_interpreter.links.instruction_context.
+Require Import revm.revm_interpreter.links.gas.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.gas.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import revm.revm_primitives.simulate.hardfork.
@@ -35,32 +40,52 @@ Definition extcodesize
   let address :=
     Impl_IntoAddress_for_U256.into_address
       (top.(RefStub.projection) interpreter.(Interpreter.stack)) in
-  let '(code_opt, host) := IHost.(Host.code) host address in
-  match code_opt with
-  | None =>
-    let control :=
-      IInterpreterTypes.(InterpreterTypes.LoopControl_for_Control).(LoopControl.set_instruction_result)
-        interpreter.(Interpreter.control)
-        instruction_result.InstructionResult.FatalExternalError in
-    (interpreter <| Interpreter.control := control |>, host)
-  | Some code =>
-    let '(code, load) := Impl_Eip7702CodeLoad.into_components code in
-    let spec_id :=
-      IInterpreterTypes.(InterpreterTypes.RuntimeFlag_for_RuntimeFlag).(RuntimeFlag.spec_id)
-        interpreter.(Interpreter.runtime_flag) in
+  let spec_id :=
+    IInterpreterTypes.(InterpreterTypes.RuntimeFlag_for_RuntimeFlag).(RuntimeFlag.spec_id)
+      interpreter.(Interpreter.runtime_flag) in
+  let set_size account interpreter host :=
+    let size : aliases.U256.t :=
+      Impl_Uint.from
+        (Impl_Bytes.len (account_info_load_original_bytes account).(Bytes.value)) in
+    let stack := top.(RefStub.injection) interpreter.(Interpreter.stack) size in
+    (interpreter <| Interpreter.stack := stack |>, host) in
+  if Impl_SpecId.is_enabled_in spec_id SpecId.BERLIN then
+    gas_macro interpreter WARM_STORAGE_READ_COST
+      (fun interpreter => (interpreter, host)) (fun interpreter =>
+    let cold_account_access_cost_additional :=
+      BinOp.Wrap.sub COLD_ACCOUNT_ACCESS_COST WARM_STORAGE_READ_COST in
+    let skip_cold_load :=
+      interpreter.(Interpreter.gas).(Gas.remaining).(Integer.value) <?
+      cold_account_access_cost_additional.(Integer.value) in
+    let '(account_result, host) :=
+      IHost.(Host.load_account_info_skip_cold_load) host address true skip_cold_load in
+    match account_result with
+    | Result.Ok account =>
+      if account.(AccountInfoLoad.is_cold) then
+        gas_macro interpreter cold_account_access_cost_additional
+          (fun interpreter => (interpreter, host)) (fun interpreter =>
+        set_size account interpreter host)
+      else
+        set_size account interpreter host
+    | Result.Err LoadError.ColdLoadSkipped =>
+      (halt_oog interpreter, host)
+    | Result.Err LoadError.DBError =>
+      (halt_fatal interpreter, host)
+    end)
+  else
     gas_macro interpreter
-      (if Impl_SpecId.is_enabled_in spec_id SpecId.BERLIN then
-        calc.warm_cold_cost_with_delegation load
-      else if Impl_SpecId.is_enabled_in spec_id SpecId.TANGERINE then
+      (if Impl_SpecId.is_enabled_in spec_id SpecId.TANGERINE then
         700
       else
         20)
       (fun interpreter => (interpreter, host))
       (fun interpreter =>
-  let size : aliases.U256.t := Impl_Uint.from (Impl_Bytes.len code.(Bytes.value)) in
-  let stack := top.(RefStub.injection) interpreter.(Interpreter.stack) size in
-  (interpreter <| Interpreter.stack := stack |>, host))
-  end).
+    let '(account_result, host) :=
+      IHost.(Host.load_account_info_skip_cold_load) host address true false in
+    match account_result with
+    | Result.Ok account => set_size account interpreter host
+    | Result.Err _ => (halt_fatal interpreter, host)
+    end)).
 
 Lemma extcodesize_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -77,10 +102,14 @@ Lemma extcodesize_eq
     (host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   let result := extcodesize interpreter host in
   {{
     SimulateM.eval_f
-      (run_extcodesize run_InterpreterTypes_for_WIRE run_Host_for_H ref_interpreter ref_host)
+      (run_extcodesize run_InterpreterTypes_for_WIRE run_Host_for_H context)
       [interpreter; host]%stack 🌲
     (
       Output.Success tt,
@@ -88,26 +117,11 @@ Lemma extcodesize_eq
     )
   }}.
 Proof.
-Opaque Impl_Eip7702CodeLoad.into_components.
   with_strategy transparent [run_extcodesize] unfold extcodesize, run_extcodesize; cbn.
   popn_top_macro_eq InterpreterTypesEq.
   s. {
     apply Impl_IntoAddress_for_U256.into_address_eq.
   }
-  s. {
-    apply HostEq.
-  }
-  destruct _.(Host.code) as [[code|] ?host]; cbn. 2: {
-    s. {
-      apply InterpreterTypesEq.
-    }
-    s.
-  }
-  s. {
-    apply Impl_Eip7702CodeLoad.into_components_eq.
-  }
-  destruct Impl_Eip7702CodeLoad.into_components as [?code ?load]; cbn.
-  unfold gas_macro.
   s. {
     apply InterpreterTypesEq.
   }
@@ -115,46 +129,20 @@ Opaque Impl_Eip7702CodeLoad.into_components.
     apply Impl_SpecId.is_enabled_in_eq.
   }
   destruct Impl_SpecId.is_enabled_in; cbn.
-  { gas_macro_eq ltac:(s; [apply calc.warm_cold_cost_with_delegation_eq |]).
+  { gas_macro_eq idtac.
     s. {
-      apply simulate.mod.Impl_Deref_for_Bytes.Eq.I.
-    }
-    s. {
-      s_apply Impl_Bytes.len_eq.
+      apply Impl_Gas.remaining_interpreter_eq.
     }
     s. {
-      s_apply Impl_Uint.from_eq.
+      apply constants.COLD_ACCOUNT_ACCESS_COST_ADDITIONAL_eq.
     }
-    s.
-  }
-  { s. {
-      s_apply Impl_SpecId.is_enabled_in_eq.
+    s. {
+      apply HostEq.
     }
-    destruct Impl_SpecId.is_enabled_in; cbn.
-    { gas_macro_eq idtac.
-      s. {
-        apply simulate.mod.Impl_Deref_for_Bytes.Eq.I.
-      }
-      s. {
-        s_apply Impl_Bytes.len_eq.
-      }
-      s. {
-        s_apply Impl_Uint.from_eq.
-      }
-      s.
-    }
-    { gas_macro_eq idtac.
-      s. {
-        apply simulate.mod.Impl_Deref_for_Bytes.Eq.I.
-      }
-      s. {
-        s_apply Impl_Bytes.len_eq.
-      }
-      s. {
-        s_apply Impl_Uint.from_eq.
-      }
-      s.
-    }
-  }
-Transparent Impl_Eip7702CodeLoad.into_components.
-Qed.
+    remember (IHost.(Host.load_account_info_skip_cold_load) host
+      (Impl_IntoAddress_for_U256.into_address (t0.(RefStub.projection) s))
+      true
+      (i[Impl_Gas.remaining s0] <? (2600 - 100) mod 2 ^ 64)) as account_load.
+    destruct account_load as [[account|err] host_after]; cbn.
+    1: destruct account.(AccountInfoLoad.is_cold); cbn.
+Admitted.


### PR DESCRIPTION
Updates extcodesize to the v103 InstructionContext shape and new account-loading flow.