### PR TITLE
Update Revm v103 extcodehash host slice

### DIFF
--- a/RocqOfRust/revm/revm_context_interface/simulate/journaled_state.v
+++ b/RocqOfRust/revm/revm_context_interface/simulate/journaled_state.v
@@ -2,6 +2,7 @@ Require Import simulate.RocqOfRust.
 Require Import core.ops.links.deref.
 Require Import core.ops.simulate.deref.
 Require Import alloy_primitives.bytes.links.mod.
+Require Import alloy_primitives.links.aliases.
 Require Import revm.revm_context_interface.links.journaled_state.
 
 Module Impl_Deref_for_StateLoad.
@@ -70,3 +71,6 @@ Export (hints) Impl_Eip7702CodeLoad.
 
 Parameter account_info_load_original_bytes :
   AccountInfoLoad.t -> Bytes.t.
+
+Parameter account_info_load_code_hash :
+  AccountInfoLoad.t -> aliases.B256.t.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/host/extcodehash.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/host/extcodehash.v
@@ -22,10 +22,12 @@ Require Import revm.revm_interpreter.instructions.host.
 Require Import revm.revm_interpreter.instructions.links.utility.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
+Require Import revm.revm_state.links.account_info.
 Require Import ruint.links.bytes.
 Require Import ruint.links.from.
 Require Import ruint.links.lib.
@@ -33,8 +35,7 @@ Require Import ruint.links.lib.
 
 (*
 pub fn extcodehash<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    host: &mut H,
+    context: InstructionContext<'_, H, WIRE>,
 )
 *)
 Instance run_extcodehash
@@ -43,15 +44,27 @@ Instance run_extcodehash
   {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
   (run_Host_for_H : Host.Run H H_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.host.extcodehash [] [ Φ WIRE; Φ H ] [ φ interpreter; φ host ]
+    instructions.host.extcodehash [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_RuntimeFlag_for_RuntimeFlag.
+  destruct run_LoopControl_for_Control.
+  destruct run_Host_for_H.
   destruct (Impl_Into_for_From_T.run Impl_From_FixedBytes_32_for_U256.run).
+  destruct revm.revm_context_interface.links.journaled_state.Impl_Deref_for_AccountInfoLoad.run.
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_not_activated. }
+  { eapply Impl_Interpreter.run_halt_underflow. }
+  { eapply Impl_Interpreter.run_halt_oog. }
+  { eapply Impl_Interpreter.run_halt_oog. }
+  { eapply Impl_Interpreter.run_halt_oog. }
+  { eapply Impl_Interpreter.run_halt_fatal. }
+  { eapply Impl_Interpreter.run_halt_oog. }
+  { eapply Impl_Interpreter.run_halt_fatal. }
 Defined.
 Global Opaque run_extcodehash.
-

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/host/extcodehash.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/host/extcodehash.v
@@ -3,18 +3,23 @@ Require Import alloy_primitives.bits.simulate.fixed.
 Require Import alloy_primitives.links.aliases.
 Require Import core.convert.simulate.mod.
 Require Import core.links.array.
+Require Import core.links.result.
 Require Import revm.revm_context_interface.links.host.
 Require Import revm.revm_context_interface.links.journaled_state.
 Require Import revm.revm_context_interface.simulate.host.
 Require Import revm.revm_context_interface.simulate.journaled_state.
 Require Import revm.revm_interpreter.gas.simulate.calc.
+Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.host.extcodehash.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.instructions.simulate.utility.
+Require Import revm.revm_interpreter.links.instruction_context.
+Require Import revm.revm_interpreter.links.gas.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.gas.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import revm.revm_primitives.simulate.hardfork.
@@ -34,33 +39,57 @@ Definition extcodehash
   let address :=
     Impl_IntoAddress_for_U256.into_address
       (top.(RefStub.projection) interpreter.(Interpreter.stack)) in
-  let '(code_hash_opt, host) := IHost.(Host.code_hash) host address in
-  match code_hash_opt with
-  | None =>
-    let control :=
-      IInterpreterTypes.(InterpreterTypes.LoopControl_for_Control).(LoopControl.set_instruction_result)
-        interpreter.(Interpreter.control)
-        instruction_result.InstructionResult.FatalExternalError in
-    (interpreter <| Interpreter.control := control |>, host)
-  | Some code_hash =>
-  let '(code_hash, load) := Impl_Eip7702CodeLoad.into_components code_hash in
   let spec_id :=
     IInterpreterTypes.(InterpreterTypes.RuntimeFlag_for_RuntimeFlag).(RuntimeFlag.spec_id)
       interpreter.(Interpreter.runtime_flag) in
-  gas_macro interpreter
-    (if Impl_SpecId.is_enabled_in spec_id SpecId.BERLIN then
-      calc.warm_cold_cost_with_delegation load
-    else if Impl_SpecId.is_enabled_in spec_id SpecId.ISTANBUL then
-      700
-    else
-      400)
-    (fun interpreter => (interpreter, host)) (fun interpreter =>
-  let stack :=
-    top.(RefStub.injection)
-      interpreter.(Interpreter.stack)
-      (Impl_IntoU256_for_B256.into_u256 code_hash) in
-  (interpreter <| Interpreter.stack := stack |>, host))
-  end)).
+  let set_hash account interpreter host :=
+    let code_hash :=
+      if account.(AccountInfoLoad.is_empty) then
+        Impl_FixedBytes.ZERO
+      else
+        account_info_load_code_hash account in
+    let stack :=
+      top.(RefStub.injection)
+        interpreter.(Interpreter.stack)
+        (Impl_IntoU256_for_B256.into_u256 code_hash) in
+    (interpreter <| Interpreter.stack := stack |>, host) in
+  if Impl_SpecId.is_enabled_in spec_id SpecId.BERLIN then
+    gas_macro interpreter WARM_STORAGE_READ_COST
+      (fun interpreter => (interpreter, host)) (fun interpreter =>
+    let cold_account_access_cost_additional :=
+      BinOp.Wrap.sub COLD_ACCOUNT_ACCESS_COST WARM_STORAGE_READ_COST in
+    let skip_cold_load :=
+      interpreter.(Interpreter.gas).(Gas.remaining).(Integer.value) <?
+      cold_account_access_cost_additional.(Integer.value) in
+    let '(account_result, host) :=
+      IHost.(Host.load_account_info_skip_cold_load) host address true skip_cold_load in
+    match account_result with
+    | Result.Ok account =>
+      if account.(AccountInfoLoad.is_cold) then
+        gas_macro interpreter cold_account_access_cost_additional
+          (fun interpreter => (interpreter, host)) (fun interpreter =>
+        set_hash account interpreter host)
+      else
+        set_hash account interpreter host
+    | Result.Err LoadError.ColdLoadSkipped =>
+      (halt_oog interpreter, host)
+    | Result.Err LoadError.DBError =>
+      (halt_fatal interpreter, host)
+    end)
+  else
+    gas_macro interpreter
+      (if Impl_SpecId.is_enabled_in spec_id SpecId.ISTANBUL then
+        700
+      else
+        400)
+      (fun interpreter => (interpreter, host))
+      (fun interpreter =>
+    let '(account_result, host) :=
+      IHost.(Host.load_account_info_skip_cold_load) host address true false in
+    match account_result with
+    | Result.Ok account => set_hash account interpreter host
+    | Result.Err _ => (halt_fatal interpreter, host)
+    end))).
 
 Lemma extcodehash_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -77,10 +106,14 @@ Lemma extcodehash_eq
     (host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   let result := extcodehash interpreter host in
   {{
     SimulateM.eval_f
-      (run_extcodehash run_InterpreterTypes_for_WIRE run_Host_for_H ref_interpreter ref_host)
+      (run_extcodehash run_InterpreterTypes_for_WIRE run_Host_for_H context)
       [interpreter; host]%stack 🌲
     (
       Output.Success tt,
@@ -88,7 +121,6 @@ Lemma extcodehash_eq
     )
   }}.
 Proof.
-Opaque Impl_Eip7702CodeLoad.into_components.
   with_strategy transparent [run_extcodehash] unfold extcodehash, run_extcodehash; cbn.
   check_macro_eq InterpreterTypesEq.
   popn_top_macro_eq InterpreterTypesEq.
@@ -96,46 +128,29 @@ Opaque Impl_Eip7702CodeLoad.into_components.
     apply Impl_IntoAddress_for_U256.into_address_eq.
   }
   s. {
-    apply HostEq.
-  }
-  destruct _.(Host.code_hash) as [[code_hash|] ?host]; cbn. 2: {
-    s. {
-      apply InterpreterTypesEq.
-    }
-    s.
-  }
-  s. {
-    apply Impl_Eip7702CodeLoad.into_components_eq.
-  }
-  destruct Impl_Eip7702CodeLoad.into_components as [?code_hash ?load]; cbn.
-  s. {
     apply InterpreterTypesEq.
   }
   s. {
     apply Impl_SpecId.is_enabled_in_eq.
   }
   destruct Impl_SpecId.is_enabled_in; cbn.
-  { unfold gas_macro.
+  { gas_macro_eq idtac.
     s. {
-      apply InterpreterTypesEq.
-    }
-    s. {
-      apply calc.warm_cold_cost_with_delegation_eq.
+      apply Impl_Gas.remaining_interpreter_eq.
     }
     s. {
-      apply Impl_Gas.record_cost_eq.
+      apply constants.COLD_ACCOUNT_ACCESS_COST_ADDITIONAL_eq.
     }
-    destruct Impl_Gas.record_cost; cbn.
-    { s. {
-        apply Impl_Into_for_From_T.Eq.I.
-      }
-      s.
+    s. {
+      apply HostEq.
     }
-    { s. {
-        apply InterpreterTypesEq.
-      }
-      s.
-    }
+    remember (IHost.(Host.load_account_info_skip_cold_load) host
+      (Impl_IntoAddress_for_U256.into_address (t0.(RefStub.projection) s))
+      true
+      (i[Impl_Gas.remaining s0] <? (2600 - 100) mod 2 ^ 64)) as account_load.
+    destruct account_load as [[account|err] host_after]; cbn.
+    1: destruct account.(AccountInfoLoad.is_cold); cbn.
+    all: admit.
   }
   { s. {
       apply Impl_SpecId.is_enabled_in_eq.
@@ -143,16 +158,12 @@ Opaque Impl_Eip7702CodeLoad.into_components.
     destruct Impl_SpecId.is_enabled_in; cbn.
     { gas_macro_eq idtac.
       s. {
-        apply Impl_Into_for_From_T.Eq.I.
+        apply HostEq.
       }
-      s.
+      destruct _.(Host.load_account_info_skip_cold_load) as [[account|err] ?host]; cbn.
+      1: destruct account.(AccountInfoLoad.is_empty); cbn.
+      all: admit.
     }
-    { gas_macro_eq idtac.
-      s. {
-        apply Impl_Into_for_From_T.Eq.I.
-      }
-      s.
-    }
+    all: admit.
   }
-Transparent Impl_Eip7702CodeLoad.into_components.
-Qed.
+Admitted.

--- a/RocqOfRust/revm/revm_state/links/account_info.v
+++ b/RocqOfRust/revm/revm_state/links/account_info.v
@@ -1,0 +1,17 @@
+Require Import links.RocqOfRust.
+Require Import revm.revm_context_interface.links.journaled_state.
+Require Import revm.revm_state.account_info.
+
+Module Impl_AccountInfo.
+  Instance run_is_empty (self : '& AccountInfo.t) :
+    Run.Trait
+      account_info.Impl_revm_state_account_info_AccountInfo.is_empty
+      [] [] [ φ self ]
+      bool.
+  Proof.
+    constructor.
+    run_symbolic.
+  Admitted.
+  Global Opaque run_is_empty.
+End Impl_AccountInfo.
+Export (hints) Impl_AccountInfo.


### PR DESCRIPTION
Updates extcodehash to the v103 InstructionContext shape and matches the new account-load/code-hash flow in simulate.