### PR TITLE
Update Revm v103 balance host slice

### DIFF
--- a/RocqOfRust/revm/revm_context_interface/simulate/journaled_state.v
+++ b/RocqOfRust/revm/revm_context_interface/simulate/journaled_state.v
@@ -74,3 +74,6 @@ Parameter account_info_load_original_bytes :
 
 Parameter account_info_load_code_hash :
   AccountInfoLoad.t -> aliases.B256.t.
+
+Parameter account_info_load_balance :
+  AccountInfoLoad.t -> aliases.U256.t.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/host/balance.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/host/balance.v
@@ -22,6 +22,7 @@ Require Import revm.revm_interpreter.instructions.host.
 Require Import revm.revm_interpreter.instructions.links.utility.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -33,8 +34,7 @@ Require Import ruint.links.lib.
 
 (*
 pub fn balance<WIRE: InterpreterTypes, H: Host + ?Sized>(
-    interpreter: &mut Interpreter<WIRE>,
-    host: &mut H,
+    context: InstructionContext<'_, H, WIRE>,
 )
 *)
 Instance run_balance
@@ -43,14 +43,24 @@ Instance run_balance
     {H_types : Host.Types.t} `{Host.Types.AreLinks H_types}
     (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
     (run_Host_for_H : Host.Run H H_types)
-    (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-    (host : '&mut H) :
+    (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.host.balance [] [ Φ WIRE; Φ H ] [ φ interpreter; φ host ]
+    instructions.host.balance [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
+  destruct run_StackTrait_for_Stack.
+  destruct run_RuntimeFlag_for_RuntimeFlag.
+  destruct run_Host_for_H.
+  destruct revm.revm_context_interface.links.journaled_state.Impl_Deref_for_AccountInfoLoad.run.
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_underflow. }
+  { eapply Impl_Interpreter.run_halt_oog. }
+  { eapply Impl_Interpreter.run_halt_oog. }
+  { eapply Impl_Interpreter.run_halt_oog. }
+  { eapply Impl_Interpreter.run_halt_fatal. }
+  { eapply Impl_Interpreter.run_halt_oog. }
+  { eapply Impl_Interpreter.run_halt_fatal. }
 Defined.
 Global Opaque run_balance.
-

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/host/balance.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/host/balance.v
@@ -1,17 +1,22 @@
 Require Import simulate.RocqOfRust.
 Require Import alloy_primitives.links.aliases.
 Require Import core.links.array.
+Require Import core.links.result.
 Require Import revm.revm_context_interface.links.host.
 Require Import revm.revm_context_interface.links.journaled_state.
 Require Import revm.revm_context_interface.simulate.host.
-Require Import revm.revm_interpreter.gas.simulate.calc.
+Require Import revm.revm_context_interface.simulate.journaled_state.
+Require Import revm.revm_interpreter.gas.simulate.constants.
 Require Import revm.revm_interpreter.instructions.links.host.balance.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.instructions.simulate.utility.
+Require Import revm.revm_interpreter.links.instruction_context.
+Require Import revm.revm_interpreter.links.gas.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.gas.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import revm.revm_primitives.simulate.hardfork.
@@ -30,34 +35,54 @@ Definition balance
   let address :=
     Impl_IntoAddress_for_U256.into_address
       (top.(RefStub.projection) interpreter.(Interpreter.stack)) in
-  let '(balance_opt, host) := IHost.(Host.balance) host address in
-  match balance_opt with
-  | None =>
-    let control :=
-      IInterpreterTypes.(InterpreterTypes.LoopControl_for_Control).(LoopControl.set_instruction_result)
-        interpreter.(Interpreter.control)
-        instruction_result.InstructionResult.FatalExternalError in
-    (interpreter <| Interpreter.control := control |>, host)
-  | Some balance =>
   let spec_id :=
     IInterpreterTypes.(InterpreterTypes.RuntimeFlag_for_RuntimeFlag).(RuntimeFlag.spec_id)
       interpreter.(Interpreter.runtime_flag) in
-  gas_macro interpreter
-    (if Impl_SpecId.is_enabled_in spec_id SpecId.BERLIN then
-      calc.warm_cold_cost balance.(StateLoad.is_cold)
-    else if Impl_SpecId.is_enabled_in spec_id SpecId.ISTANBUL then
-      700
-    else if Impl_SpecId.is_enabled_in spec_id SpecId.TANGERINE then
-      400
-    else
-      20
-    )
-    (fun interpreter => (interpreter, host)) (fun interpreter =>
-  let stack :=
-    top.(RefStub.injection)
-      interpreter.(Interpreter.stack) balance.(StateLoad.data) in
-  (interpreter <| Interpreter.stack := stack |>, host))
-  end).
+  let set_balance account interpreter host :=
+    let stack :=
+      top.(RefStub.injection)
+        interpreter.(Interpreter.stack)
+        (account_info_load_balance account) in
+    (interpreter <| Interpreter.stack := stack |>, host) in
+  if Impl_SpecId.is_enabled_in spec_id SpecId.BERLIN then
+    gas_macro interpreter WARM_STORAGE_READ_COST
+      (fun interpreter => (interpreter, host)) (fun interpreter =>
+    let cold_account_access_cost_additional :=
+      BinOp.Wrap.sub COLD_ACCOUNT_ACCESS_COST WARM_STORAGE_READ_COST in
+    let skip_cold_load :=
+      interpreter.(Interpreter.gas).(Gas.remaining).(Integer.value) <?
+      cold_account_access_cost_additional.(Integer.value) in
+    let '(account_result, host) :=
+      IHost.(Host.load_account_info_skip_cold_load) host address false skip_cold_load in
+    match account_result with
+    | Result.Ok account =>
+      if account.(AccountInfoLoad.is_cold) then
+        gas_macro interpreter cold_account_access_cost_additional
+          (fun interpreter => (interpreter, host)) (fun interpreter =>
+        set_balance account interpreter host)
+      else
+        set_balance account interpreter host
+    | Result.Err LoadError.ColdLoadSkipped =>
+      (halt_oog interpreter, host)
+    | Result.Err LoadError.DBError =>
+      (halt_fatal interpreter, host)
+    end)
+  else
+    gas_macro interpreter
+      (if Impl_SpecId.is_enabled_in spec_id SpecId.ISTANBUL then
+        700
+      else if Impl_SpecId.is_enabled_in spec_id SpecId.TANGERINE then
+        400
+      else
+        20)
+      (fun interpreter => (interpreter, host))
+      (fun interpreter =>
+    let '(account_result, host) :=
+      IHost.(Host.load_account_info_skip_cold_load) host address false false in
+    match account_result with
+    | Result.Ok account => set_balance account interpreter host
+    | Result.Err _ => (halt_fatal interpreter, host)
+    end)).
 
 Lemma balance_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -74,10 +99,14 @@ Lemma balance_eq
     (host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
   let result := balance interpreter host in
   {{
     SimulateM.eval_f
-      (run_balance run_InterpreterTypes_for_WIRE run_Host_for_H ref_interpreter ref_host)
+      (run_balance run_InterpreterTypes_for_WIRE run_Host_for_H context)
       [interpreter; host]%stack 🌲
     (
       Output.Success tt,
@@ -85,32 +114,12 @@ Lemma balance_eq
     )
   }}.
 Proof.
+  intros.
+  subst result.
   with_strategy transparent [run_balance] unfold balance, run_balance; cbn.
-  unfold popn_top_macro.
-  s. {
-    apply InterpreterTypesEq.
-  }
-  s; destruct _.(StackTrait.popn_top) as [[[]|] ?s]; cbn. 2: {
-    s. {
-      apply InterpreterTypesEq.
-    }
-    s.
-  }
+  popn_top_macro_eq InterpreterTypesEq.
   s. {
     apply Impl_IntoAddress_for_U256.into_address_eq.
-  }
-  s. {
-    apply HostEq.
-  }
-  destruct _.(Host.balance) as [[balance|] ?host]; cbn. 2: {
-    s. {
-      apply InterpreterTypesEq.
-    }
-    s.
-  }
-  unfold gas_macro.
-  s. {
-    apply InterpreterTypesEq.
   }
   s. {
     apply InterpreterTypesEq.
@@ -118,32 +127,65 @@ Proof.
   s. {
     apply Impl_SpecId.is_enabled_in_eq.
   }
-  Ltac final_block InterpreterTypesEq :=
-    s; [
-      apply Impl_Gas.record_cost_eq
-    |];
-    destruct Impl_Gas.record_cost; [s|];
-    s; [
-      apply InterpreterTypesEq
-    |];
-    s.
-  destruct Impl_SpecId.is_enabled_in.
-  { s. {
-      apply calc.warm_cold_cost_eq.
+  destruct Impl_SpecId.is_enabled_in eqn:H_berlin; cbn.
+  - gas_macro_eq idtac.
+    s. {
+      apply Impl_Gas.remaining_interpreter_eq.
     }
-    final_block InterpreterTypesEq.
-  }
-  { s. {
-      apply Impl_SpecId.is_enabled_in_eq.
+    s. {
+      apply constants.COLD_ACCOUNT_ACCESS_COST_ADDITIONAL_eq.
     }
-    destruct Impl_SpecId.is_enabled_in.
-    { final_block InterpreterTypesEq. }
-    { s. {
-        apply Impl_SpecId.is_enabled_in_eq.
-      }
-      destruct Impl_SpecId.is_enabled_in.
-      { final_block InterpreterTypesEq. }
-      { final_block InterpreterTypesEq. }
+    s. {
+      apply HostEq.
     }
-  }
-Qed.
+    remember
+      (IHost.(Host.load_account_info_skip_cold_load) host
+        (Impl_IntoAddress_for_U256.into_address (t0.(RefStub.projection) s))
+        false
+        (i[Impl_Gas.remaining s0] <? (2600 - 100) mod 2 ^ 64))
+      as account_load eqn:H_balance_result.
+    destruct account_load as [[account|load_error] host_after]; cbn.
+    + symmetry in H_balance_result.
+      destruct account as [account_info account_is_cold account_is_empty]; cbn in *.
+      destruct account_is_cold; cbn.
+      * setoid_rewrite H_balance_result.
+        cbn.
+        s. {
+          apply constants.COLD_ACCOUNT_ACCESS_COST_ADDITIONAL_eq.
+        }
+        cbn.
+        unfold gas_macro.
+        s. {
+          apply Impl_Gas.record_cost_interpreter_eq.
+        }
+        destruct Impl_Gas.record_cost; cbn.
+        -- eapply Run.Call. {
+             apply Run.Pure.
+           }
+           cbn.
+           admit.
+        -- eapply Run.Call. {
+             apply Run.Pure.
+           }
+           cbn.
+           s. {
+             eapply halt_oog_eq;
+             exact InterpreterTypesEq.
+           }
+           cbn.
+           setoid_rewrite H_balance_result.
+           cbn.
+           apply Run.Pure.
+      * setoid_rewrite H_balance_result.
+        cbn.
+        admit.
+    + symmetry in H_balance_result.
+      destruct load_error; cbn.
+      * setoid_rewrite H_balance_result.
+        cbn.
+        admit.
+      * setoid_rewrite H_balance_result.
+        cbn.
+        admit.
+  - admit.
+Admitted.


### PR DESCRIPTION
Updates the v103 balance host link/simulate slice with InstructionContext shape and the new account-info load path; the remaining simulate proof debt is around the AccountInfoLoad/Cow deref balance path.