### PR TITLE
Update Revm v103 return data system slice

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/returndatacopy.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/returndatacopy.v
@@ -1,8 +1,10 @@
 Require Import links.RocqOfRust.
+Require Import alloy_primitives.bytes.links.mod.
 Require Import alloy_primitives.links.aliases.
 Require Import alloy_primitives.bits.links.address.
 Require Import alloy_primitives.bits.links.fixed.
 Require Import alloy_primitives.utils.links.mod.
+Require Import bytes.links.bytes.
 Require Import core.array.links.mod.
 Require Import core.convert.links.mod.
 Require Import core.convert.links.num.
@@ -23,6 +25,7 @@ Require Import revm.revm_interpreter.instructions.system.
 Require Import revm.revm_interpreter.instructions.links.system.memory_resize.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -35,10 +38,9 @@ Instance run_returndatacopy
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.system.returndatacopy [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.system.returndatacopy [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
@@ -49,6 +51,12 @@ Proof.
   destruct run_ReturnData_for_ReturnData.
   destruct run_MemoryTrait_for_Memory.
   destruct Impl_TryFrom_u64_for_usize.run.
+  destruct alloy_primitives.bytes.links.mod.Impl_Deref_for_Bytes.run.
+  destruct bytes.Impl_Deref_for_Bytes.run.
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_not_activated. }
+  { eapply Impl_Interpreter.run_halt. }
+  { eapply Impl_Interpreter.run_halt. }
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_returndatacopy.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/returndatasize.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/returndatasize.v
@@ -1,8 +1,10 @@
 Require Import links.RocqOfRust.
+Require Import alloy_primitives.bytes.links.mod.
 Require Import alloy_primitives.links.aliases.
 Require Import alloy_primitives.bits.links.address.
 Require Import alloy_primitives.bits.links.fixed.
 Require Import alloy_primitives.utils.links.mod.
+Require Import bytes.links.bytes.
 Require Import core.array.links.mod.
 Require Import core.convert.links.mod.
 Require Import core.convert.links.num.
@@ -22,6 +24,7 @@ Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.system.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -34,18 +37,21 @@ Instance run_returndatasize
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.system.returndatasize [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.system.returndatasize [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   destruct run_ReturnData_for_ReturnData.
+  destruct alloy_primitives.bytes.links.mod.Impl_Deref_for_Bytes.run.
+  destruct bytes.Impl_Deref_for_Bytes.run.
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_not_activated. }
+  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_returndatasize.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/returndatacopy.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/returndatacopy.v
@@ -1,5 +1,8 @@
 Require Import simulate.RocqOfRust.
+Require Import alloy_primitives.bytes.links.mod.
+Require Import alloy_primitives.bytes.simulate.mod.
 Require Import alloy_primitives.links.aliases.
+Require Import bytes.simulate.bytes.
 Require Import core.links.array.
 Require Import core.slice.simulate.mod.
 Require Import core.num.simulate.mod.
@@ -8,8 +11,10 @@ Require Import revm.revm_interpreter.instructions.links.system.returndatacopy.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_primitives.links.hardfork.
 Require Import revm.revm_interpreter.links.instruction_result.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
+Require Import revm.revm_interpreter.simulate.interpreter.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
 
 Definition returndatacopy
@@ -30,16 +35,10 @@ Definition returndatacopy
   let return_data :=
     IInterpreterTypes.(InterpreterTypes.ReturnData_for_ReturnData).(ReturnData.buffer)
       .(RefStub.projection) interpreter.(Interpreter.return_data) in
-  let return_data_len := Impl_Slice.len return_data in
-  let is_eof :=
-    IInterpreterTypes.(InterpreterTypes.RuntimeFlag_for_RuntimeFlag).(RuntimeFlag.is_eof)
-      interpreter.(Interpreter.runtime_flag) in
-  if (i[data_end] >? i[return_data_len]) && negb is_eof then
-    let control :=
-      IInterpreterTypes.(InterpreterTypes.LoopControl_for_Control).(LoopControl.set_instruction_result)
-        interpreter.(Interpreter.control)
-        instruction_result.InstructionResult.OutOfOffset in
-    interpreter <| Interpreter.control := control |>
+  let return_data := return_data.(Bytes.value) in
+  let return_data_len := Impl_Bytes.len return_data in
+  if i[data_end] >? i[return_data_len] then
+    halt interpreter instruction_result.InstructionResult.OutOfOffset
   else
     let '(memory_offset_opt, interpreter) := memory_resize interpreter memory_offset len in
     match memory_offset_opt with
@@ -48,6 +47,7 @@ Definition returndatacopy
       let return_data :=
         IInterpreterTypes.(InterpreterTypes.ReturnData_for_ReturnData).(ReturnData.buffer)
           .(RefStub.projection) interpreter.(Interpreter.return_data) in
+      let return_data := return_data.(Bytes.value).(bytes.Bytes.value) in
       let memory :=
         IInterpreterTypes.(InterpreterTypes.MemoryTrait_for_Memory).(MemoryTrait.set_data)
           interpreter.(Interpreter.memory)
@@ -70,9 +70,13 @@ Lemma returndatacopy_eq
     (host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
     {{
       SimulateM.eval_f
-        (run_returndatacopy run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+        (run_returndatacopy run_InterpreterTypes_for_WIRE context)
         [interpreter; host]%stack 🌲
       (
         Output.Success tt,
@@ -100,34 +104,36 @@ Opaque memory_resize.
     apply InterpreterTypesEq.
   }
   s. {
-    pose proof (Impl_Slice.len_eq (T := u8)) as H_apply.
+    apply alloy_primitives.bytes.simulate.mod.Impl_Deref_for_Bytes.Eq.I.
+  }
+  s. {
+    pose proof bytes.simulate.bytes.Impl_Bytes.len_eq as H_apply.
     s_apply H_apply.
   }
   s.
   destruct (_ >? _) eqn:H_lt_eq; cbn.
   { s. {
-      apply InterpreterTypesEq.
+      eapply halt_eq;
+        try exact InterpreterTypesEq.
     }
     s.
-    destruct negb; cbn.
-    Ltac common_end InterpreterTypesEq :=
-      s; [
-        apply memory_resize_eq
-      |];
-      destruct memory_resize as [[?memory_offset|] ?interpreter]; cbn; [|s];
-      s; [
-        apply InterpreterTypesEq
-      |];
-      s; [
-        s_apply InterpreterTypesEq
-      |];
-      s.
-    { s. {
-        apply InterpreterTypesEq.
-      }
-      s.
-    }
-    { common_end InterpreterTypesEq. }
   }
-  { common_end InterpreterTypesEq. }
+  { s. {
+      apply memory_resize_eq.
+    }
+    destruct memory_resize as [[?memory_offset|] ?interpreter]; cbn; [|s].
+    s. {
+      apply InterpreterTypesEq.
+    }
+    s. {
+      apply alloy_primitives.bytes.simulate.mod.Impl_Deref_for_Bytes.Eq.I.
+    }
+    s. {
+      apply bytes.simulate.bytes.Impl_Deref_for_Bytes.Eq.I.
+    }
+    s. {
+      s_apply InterpreterTypesEq.
+    }
+    s.
+  }
 Qed.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/returndatasize.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/returndatasize.v
@@ -1,8 +1,11 @@
 Require Import simulate.RocqOfRust.
+Require Import alloy_primitives.bytes.links.mod.
+Require Import alloy_primitives.bytes.simulate.mod.
+Require Import bytes.simulate.bytes.
 Require Import core.slice.simulate.mod.
 Require Import revm.revm_interpreter.instructions.links.system.returndatasize.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
-Require Import revm.revm_interpreter.gas.simulate.constants.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
@@ -17,15 +20,14 @@ Definition returndatasize
     (interpreter : Interpreter.t WIRE WIRE_types) :
     Interpreter.t WIRE WIRE_types :=
   check_macro interpreter SpecId.BYZANTIUM id (fun interpreter =>
-  gas_macro interpreter constants.BASE id (fun interpreter =>
   let return_data :=
     IInterpreterTypes.(InterpreterTypes.ReturnData_for_ReturnData).(ReturnData.buffer)
       .(RefStub.projection) interpreter.(Interpreter.return_data) in
-  let length : usize := Impl_Slice.len return_data in
+  let length : usize := Impl_Bytes.len return_data.(Bytes.value) in
   push_macro interpreter
     (Impl_Uint.from length)
     id id
-  )).
+  ).
 
 Lemma returndatasize_eq
     {WIRE H : Set} `{Link WIRE} `{Link H}
@@ -38,9 +40,13 @@ Lemma returndatasize_eq
     (host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
     {{
       SimulateM.eval_f
-        (run_returndatasize run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+        (run_returndatasize run_InterpreterTypes_for_WIRE context)
         [interpreter; host]%stack 🌲
       (
         Output.Success tt,
@@ -50,12 +56,14 @@ Lemma returndatasize_eq
 Proof.
   with_strategy transparent [run_returndatasize] unfold returndatasize, run_returndatasize; cbn.
   check_macro_eq InterpreterTypesEq.
-  gas_macro_eq idtac.
   s. {
     apply InterpreterTypesEq.
   }
   s. {
-    pose proof (Impl_Slice.len_eq (T := u8)) as H_apply.
+    apply alloy_primitives.bytes.simulate.mod.Impl_Deref_for_Bytes.Eq.I.
+  }
+  s. {
+    pose proof bytes.simulate.bytes.Impl_Bytes.len_eq as H_apply.
     s_apply H_apply.
   }
   s. {

--- a/RocqOfRust/revm/revm_interpreter/links/interpreter_types.v
+++ b/RocqOfRust/revm/revm_interpreter/links/interpreter_types.v
@@ -627,7 +627,7 @@ Export (hints) EofData.
 
 (*
 pub trait ReturnData {
-    fn buffer(&self) -> &[u8];
+    fn buffer(&self) -> &Bytes;
     fn buffer_mut(&mut self) -> &mut Bytes;
 }
 *)
@@ -643,7 +643,7 @@ Module ReturnData.
   Class Method_buffer (Self : Set) `{Link Self} : Set := {
     buffer : PolymorphicFunction.t;
     buffer_is_method :: IsTraitMethod.C (trait Self) "buffer" buffer;
-    run_buffer (self : '& Self) :: Run.Trait buffer [] [] [ φ self ] ('& (list u8));
+    run_buffer (self : '& Self) :: Run.Trait buffer [] [] [ φ self ] ('& Bytes.t);
   }.
 
   Class Method_buffer_mut (Self : Set) `{Link Self} : Set := {

--- a/RocqOfRust/revm/revm_interpreter/simulate/interpreter_types.v
+++ b/RocqOfRust/revm/revm_interpreter/simulate/interpreter_types.v
@@ -1522,8 +1522,8 @@ Export (hints) SubRoutineStack.
 
 Module ReturnData.
   Class C (Self : Set) `{Link Self} : Set := {
-    (* fn buffer(&self) -> &[u8]; *)
-    buffer : RefStub.t Self (list u8);
+    (* fn buffer(&self) -> &Bytes; *)
+    buffer : RefStub.t Self Bytes.t;
     (* fn buffer_mut(&mut self) -> &mut Bytes; *)
     buffer_mut : RefStub.t Self Bytes.t;
   }.


### PR DESCRIPTION
Updates returndatasize and returndatacopy to the v103 InstructionContext shape, and adjusts ReturnData.buffer to the current Bytes-based interface.