### PR TITLE
Update Revm v103 codecopy system slice

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/codecopy.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/codecopy.v
@@ -23,6 +23,7 @@ Require Import revm.revm_interpreter.instructions.system.
 Require Import revm.revm_interpreter.instructions.links.system.memory_resize.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -35,10 +36,9 @@ Instance run_codecopy
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.system.codecopy [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.system.codecopy [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
@@ -49,5 +49,7 @@ Proof.
   destruct run_LegacyBytecode_for_Bytecode.
   destruct Impl_TryFrom_u64_for_usize.run.
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt. }
+  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_codecopy.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/codecopy.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/codecopy.v
@@ -4,6 +4,7 @@ Require Import core.links.array.
 Require Import revm.revm_interpreter.instructions.links.system.codecopy.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
 Require Import revm.revm_interpreter.instructions.simulate.system.memory_resize.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
@@ -46,9 +47,13 @@ Lemma codecopy_eq
     (host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
     {{
       SimulateM.eval_f
-        (run_codecopy run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+        (run_codecopy run_InterpreterTypes_for_WIRE context)
         [interpreter; host]%stack 🌲
       (
         Output.Success tt,


### PR DESCRIPTION
Updates codecopy to the v103 InstructionContext link/simulate shape and keeps the local proof obligations explicit.