### PR TITLE
Update Revm v103 keccak256 system slice

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/keccak256.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/keccak256.v
@@ -22,6 +22,7 @@ Require Import revm.revm_interpreter.gas.links.constants.
 Require Import revm.revm_interpreter.instructions.system.
 Require Import revm.revm_interpreter.interpreter.links.shared_memory.
 Require Import revm.revm_interpreter.links.gas.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.instruction_result.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
@@ -34,14 +35,13 @@ Instance run_keccak256
   {WIRE H : Set} `{Link WIRE} `{Link H}
   {WIRE_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks WIRE_types}
   (run_InterpreterTypes_for_WIRE : InterpreterTypes.Run WIRE WIRE_types)
-  (interpreter : '&mut (Interpreter.t WIRE WIRE_types))
-  (_host : '&mut H) :
+  (context : InstructionContext.t H WIRE WIRE_types) :
   Run.Trait
-    instructions.system.keccak256 [] [ Φ WIRE; Φ H ] [ φ interpreter; φ _host ]
+    instructions.system.keccak256 [] [ Φ WIRE; Φ H ] [ φ context ]
     unit.
 Proof.
   constructor.
-  destruct run_InterpreterTypes_for_WIRE.
+  destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   destruct run_MemoryTrait_for_Memory.
@@ -49,5 +49,11 @@ Proof.
   destruct (Impl_Into_for_From_T.run Impl_From_FixedBytes_32_for_U256.run).
   destruct (Impl_AsRef_for_Slice.run u8).
   run_symbolic.
+  { eapply Impl_Interpreter.run_halt_underflow. }
+  { eapply Impl_Interpreter.run_halt. }
+  { eapply Impl_Interpreter.run_halt_oog. }
+  { eapply Impl_Interpreter.run_halt_oog. }
+  { eapply Impl_Interpreter.run_halt. }
+  { eapply Impl_Interpreter.run_halt_memory_oog. }
 Defined.
 Global Opaque run_keccak256.

--- a/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/keccak256.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/simulate/system/keccak256.v
@@ -9,6 +9,7 @@ Require Import core.ops.simulate.deref.
 Require Import revm.revm_interpreter.gas.simulate.calc.
 Require Import revm.revm_interpreter.instructions.links.system.keccak256.
 Require Import revm.revm_interpreter.instructions.simulate.macros.
+Require Import revm.revm_interpreter.links.instruction_context.
 Require Import revm.revm_interpreter.links.interpreter.
 Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.simulate.interpreter_types.
@@ -64,9 +65,13 @@ Lemma keccak256_eq
     (host : H) :
   let ref_interpreter := make_ref 0 in
   let ref_host := make_ref (A := H) 1 in
+  let context := {|
+    instruction_context.InstructionContext.interpreter := ref_interpreter;
+    instruction_context.InstructionContext.host := ref_host;
+  |} in
     {{
       SimulateM.eval_f
-        (run_keccak256 run_InterpreterTypes_for_WIRE ref_interpreter ref_host)
+        (run_keccak256 run_InterpreterTypes_for_WIRE context)
         [interpreter; host]%stack 🌲
       (
         Output.Success tt,
@@ -97,20 +102,18 @@ Proof.
   }
   { as_usize_or_fail_macro_eq InterpreterTypesEq.
     resize_memory_macro_eq InterpreterTypesEq.
-    s. {
-      apply InterpreterTypesEq.
-    }
-    s. {
-      apply InterpreterTypesEq.
-    }
-    s. {
-      pose proof (simulate.mod.keccak256_eq (T := '& (list u8))) as H_apply.
+    - apply InterpreterTypesEq.
+    - apply InterpreterTypesEq.
+    - pose proof (simulate.mod.keccak256_eq (T := '& (list u8))) as H_apply.
       apply H_apply.
-    }
-    s. {
-      apply Impl_Into_for_From_T.Eq.I.
-    }
-    s.
-    now destruct _.(MemoryTrait.resize).
+    - do 5 (eapply Stack.Nth.ConsSucc).
+      apply Stack.Nth.ConsZero.
+    - s. {
+        apply Impl_From_FixedBytes_32_for_U256.from_eq.
+      }
+    - s.
+      unfold RefStub.apply, RefStub.apply_core, Ref.immediate, Ref.cast_to.
+      cbn.
+      reflexivity.
   }
 Qed.


### PR DESCRIPTION
Updates keccak256 to the v103 InstructionContext link/simulate shape and keeps the dynamic gas, memory resize, and hashing flow matching the generated body.