### PR TITLE
Revm: Automate interpreter halt link resolution

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/contract/links/call_helpers.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/contract/links/call_helpers.v
@@ -113,8 +113,7 @@ Proof.
   destruct run_MemoryTrait_for_Memory.
   run_symbolic.
   all: first [
-    eapply (@Impl_Interpreter.run_halt WIRE H WIRE_types H0 run_InterpreterTypes_for_WIRE)
-  | eapply (@interpreter.links.shared_memory.run_resize_memory
+    eapply (@interpreter.links.shared_memory.run_resize_memory
       WIRE_types.(InterpreterTypes.Types.Memory)
       WIRE_types.(InterpreterTypes.Types.Memory_Synthetic)
       WIRE_types.(InterpreterTypes.Types.Memory_Synthetic1)
@@ -122,7 +121,6 @@ Proof.
       H0.(InterpreterTypes.Types.H_Memory_Synthetic)
       H0.(InterpreterTypes.Types.H_Memory_Synthetic1)
       (run_InterpreterTypes_for_WIRE.(InterpreterTypes.run_MemoryTrait_for_Memory)))
-  | eapply (@Impl_Interpreter.run_halt_memory_oog WIRE H WIRE_types H0 run_InterpreterTypes_for_WIRE)
   ].
 Defined.
 Global Opaque run_resize_memory.
@@ -152,7 +150,6 @@ Proof.
   run_symbolic.
   all: first [
     eapply Impl_usize.run_saturating_add
-  | eapply (@Impl_Interpreter.run_halt_underflow WIRE H WIRE_types H0 run_InterpreterTypes_for_WIRE)
   ].
 Defined.
 Global Opaque run_get_memory_input_and_out_ranges.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/arithmetic.v
@@ -42,7 +42,6 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_add.
 
@@ -66,7 +65,6 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_mul.
 
@@ -90,7 +88,6 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_sub.
 
@@ -114,7 +111,6 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_div.
 
@@ -138,7 +134,6 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_sdiv.
 
@@ -162,7 +157,6 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_rem.
 
@@ -186,7 +180,6 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_smod.
 
@@ -210,7 +203,6 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_addmod.
 
@@ -234,7 +226,6 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_mulmod.
 
@@ -259,9 +250,6 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
-  { eapply Impl_Interpreter.run_halt_oog. }
-  { eapply Impl_Interpreter.run_halt_oog. }
 Defined.
 Global Opaque run_exp.
 
@@ -290,6 +278,5 @@ Proof.
   destruct (Impl_Shl_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   destruct (Impl_Not_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_signextend.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/bitand.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/bitand.v
@@ -29,6 +29,5 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct (Impl_BitAnd_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_bitwise_bitand.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/bitor.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/bitor.v
@@ -29,6 +29,5 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct (Impl_BitOr_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_bitwise_bitor.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/bitxor.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/bitxor.v
@@ -29,6 +29,5 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct (Impl_BitXor_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_bitwise_bitxor.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/byte.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/byte.v
@@ -33,6 +33,5 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct Impl_TryFrom_u64_for_usize.run.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_byte.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/eq.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/eq.v
@@ -27,6 +27,5 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_bitwise_eq.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/gt.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/gt.v
@@ -27,6 +27,5 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_gt.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/iszero.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/iszero.v
@@ -27,6 +27,5 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_bitwise_is_zero.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/lt.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/lt.v
@@ -27,6 +27,5 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_lt.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/not.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/not.v
@@ -29,6 +29,5 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct (Impl_Not_for_Uint.run {| Integer.value := 256 |} {| Integer.value := 4 |}).
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_bitwise_not.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/sgt.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/sgt.v
@@ -28,6 +28,5 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_sgt.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/slt.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/bitwise/slt.v
@@ -28,6 +28,5 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_slt.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/block_info.v
@@ -45,13 +45,11 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   destruct run_Host_for_H.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_not_activated. }
   { eapply (@Host.run_chain_id
       ('&mut H)
       _
       (@Impl_Host_for_RefMut.method_chain_id H _ method_chain_id)
       (Ref.cast_to Pointer.Kind.Ref sub_ref1)). }
-  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_chainid.
 
@@ -90,7 +88,6 @@ Proof.
       _
       (@Impl_Host_for_RefMut.method_beneficiary H _ method_beneficiary)
       (Ref.cast_to Pointer.Kind.Ref sub_ref1)). }
-  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_coinbase.
 
@@ -124,7 +121,6 @@ Proof.
       _
       (@Impl_Host_for_RefMut.method_timestamp H _ method_timestamp)
       (Ref.cast_to Pointer.Kind.Ref sub_ref1)). }
-  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_timestamp.
 
@@ -158,7 +154,6 @@ Proof.
       _
       (@Impl_Host_for_RefMut.method_block_number H _ method_block_number)
       (Ref.cast_to Pointer.Kind.Ref sub_ref1)). }
-  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_block_number.
 
@@ -203,13 +198,11 @@ Proof.
       _
       (@Impl_Host_for_RefMut.method_prevrandao H _ method_prevrandao)
       (Ref.cast_to Pointer.Kind.Ref sub_ref3)). }
-  { eapply Impl_Interpreter.run_halt_overflow. }
   { eapply (@Host.run_difficulty
       ('&mut H)
       _
       (@Impl_Host_for_RefMut.method_difficulty H _ method_difficulty)
       (Ref.cast_to Pointer.Kind.Ref sub_ref1)). }
-  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_difficulty.
 
@@ -243,7 +236,6 @@ Proof.
       _
       (@Impl_Host_for_RefMut.method_gas_limit H _ method_gas_limit)
       (Ref.cast_to Pointer.Kind.Ref sub_ref1)). }
-  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_gaslimit.
 
@@ -274,13 +266,11 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   destruct run_Host_for_H.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_not_activated. }
   { eapply (@Host.run_basefee
       ('&mut H)
       _
       (@Impl_Host_for_RefMut.method_basefee H _ method_basefee)
       (Ref.cast_to Pointer.Kind.Ref sub_ref1)). }
-  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_basefee.
 
@@ -311,12 +301,10 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   destruct run_Host_for_H.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_not_activated. }
   { eapply (@Host.run_blob_gasprice
       ('&mut H)
       _
       (@Impl_Host_for_RefMut.method_blob_gasprice H _ method_blob_gasprice)
       (Ref.cast_to Pointer.Kind.Ref sub_ref1)). }
-  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_blob_basefee.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/call.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/call.v
@@ -58,7 +58,6 @@ Proof.
   constructor.
   destruct (TryFrom_Uint_for_u64.method_try_from (BITS := {| Integer.value := 256 |}) (LIMBS := {| Integer.value := 4 |})).
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt. }
   {
     eapply (@Impl_Box.run_new CallInputs.t CallInputs.IsLink {|
       CallInputs.bytecode_address := value17;
@@ -73,6 +72,5 @@ Proof.
       CallInputs.value := CallValue.Transfer value20;
     |}).
   }
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_call.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/call_code.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/call_code.v
@@ -72,6 +72,5 @@ Proof.
       CallInputs.value := CallValue.Transfer value20;
     |}).
   }
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_call_code.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/delegate_call.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/delegate_call.v
@@ -58,7 +58,6 @@ Proof.
   constructor.
   destruct (TryFrom_Uint_for_u64.method_try_from (BITS := {| Integer.value := 256 |}) (LIMBS := {| Integer.value := 4 |})).
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_not_activated. }
   {
     eapply (@Impl_Box.run_new CallInputs.t CallInputs.IsLink {|
       CallInputs.bytecode_address := value15;
@@ -73,6 +72,5 @@ Proof.
       CallInputs.value := CallValue.Apparent value_inter4;
     |}).
   }
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_delegate_call.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/static_call.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/static_call.v
@@ -58,7 +58,6 @@ Proof.
   constructor.
   destruct (TryFrom_Uint_for_u64.method_try_from (BITS := {| Integer.value := 256 |}) (LIMBS := {| Integer.value := 4 |})).
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_not_activated. }
   {
     eapply (@Impl_Box.run_new CallInputs.t CallInputs.IsLink {|
       CallInputs.bytecode_address := value15;
@@ -73,6 +72,5 @@ Proof.
       CallInputs.value := CallValue.Transfer value18;
     |}).
   }
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_static_call.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/invalid.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/invalid.v
@@ -41,6 +41,5 @@ Proof.
   destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt. }
 Defined.
 Global Opaque run_invalid.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/jump.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/jump.v
@@ -44,6 +44,5 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct run_Jumps_for_Bytecode.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_jump.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/jump_inner.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/jump_inner.v
@@ -40,7 +40,5 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct run_Jumps_for_Bytecode.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt. }
-  { eapply Impl_Interpreter.run_halt. }
 Defined.
 Global Opaque run_jump_inner.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/jumpi.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/jumpi.v
@@ -44,6 +44,5 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct run_Jumps_for_Bytecode.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_jumpi.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/pc.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/pc.v
@@ -42,6 +42,5 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_Jumps_for_Bytecode.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_pc.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/return_inner.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/return_inner.v
@@ -50,9 +50,5 @@ Proof.
   destruct Impl_Default_for_Bytes.run.
   destruct (Impl_Into_for_From_T.run Impl_From_Vec_u8_for_Bytes.run).
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt. }
-  { eapply Impl_Interpreter.run_halt. }
-  { eapply Impl_Interpreter.run_halt_memory_oog. }
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_return_inner.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/revert.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/revert.v
@@ -43,6 +43,5 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_not_activated. }
 Defined.
 Global Opaque run_revert.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/stop.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/stop.v
@@ -41,6 +41,5 @@ Proof.
   destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt. }
 Defined.
 Global Opaque run_stop.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/control/unknown.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/control/unknown.v
@@ -41,6 +41,5 @@ Proof.
   destruct run_InterpreterTypes_for_WIRE eqn:?.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt. }
 Defined.
 Global Opaque run_unknown.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/host/blockhash.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/host/blockhash.v
@@ -55,12 +55,10 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_Host_for_H.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
   { eapply (@Host.run_block_number
       ('&mut H)
       _
       (@Impl_Host_for_RefMut.method_block_number H _ method_block_number)
       (Ref.cast_to Pointer.Kind.Ref sub_ref3)). }
-  { eapply Impl_Interpreter.run_halt_fatal. }
 Defined.
 Global Opaque run_blockhash.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/host/extcodecopy.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/host/extcodecopy.v
@@ -58,14 +58,6 @@ Proof.
   destruct bytes.Impl_Deref_for_Bytes.run.
   destruct links.mod.Impl_Deref_for_Bytes.run.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt. }
-  { eapply Impl_Interpreter.run_halt_oog. }
-  { eapply Impl_Interpreter.run_halt. }
-  { eapply Impl_Interpreter.run_halt_memory_oog. }
-  { eapply Impl_Interpreter.run_halt_oog. }
-  { eapply Impl_Interpreter.run_halt_oog. }
-  { eapply Impl_Interpreter.run_halt_oog. }
-  { eapply Impl_Interpreter.run_halt_fatal. }
   {
     eapply Run.CallPrimitiveGetTraitMethod.
     { exact Impl_Deref_for_AccountInfoLoad.method_deref.(deref.Deref.deref_is_method).(IsTraitMethod.Make). }
@@ -75,8 +67,5 @@ Proof.
     intros.
     run_symbolic.
   }
-  { eapply Impl_Interpreter.run_halt_oog. }
-  { eapply Impl_Interpreter.run_halt_fatal. }
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_extcodecopy.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/host/log.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/host/log.v
@@ -81,14 +81,6 @@ Proof.
   ).
   destruct Impl_From_U256_for_FixedBytes_32.run.
   run_symbolic.
-  all: try eapply (@Impl_Interpreter.run_halt
-    WIRE _ WIRE_types _ run_InterpreterTypes_for_WIRE_copy).
-  all: try eapply (@Impl_Interpreter.run_halt_oog
-    WIRE _ WIRE_types _ run_InterpreterTypes_for_WIRE_copy).
-  all: try eapply (@Impl_Interpreter.run_halt_memory_oog
-    WIRE _ WIRE_types _ run_InterpreterTypes_for_WIRE_copy).
-  all: try eapply (@Impl_Interpreter.run_halt_underflow
-    WIRE _ WIRE_types _ run_InterpreterTypes_for_WIRE_copy).
   all: try eapply run_resize_memory.
   all: try exact run_MemoryTrait_for_Memory_copy.
   all: try eapply method_map0.(iterator.Iterator.run_map).

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/host/selfdestruct.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/host/selfdestruct.v
@@ -62,9 +62,5 @@ Proof.
   all: try eapply Impl_Deref_for_StateLoad.run_deref.
   all: try eapply Impl_Gas.run_record_refund.
   all: try eapply run_SELFDESTRUCT_REFUND.
-  all: try eapply Impl_Interpreter.run_halt_oog.
-  all: try eapply Impl_Interpreter.run_halt_fatal.
-  all: try eapply Impl_Interpreter.run_halt.
-  all: try eapply Impl_Interpreter.run_halt_underflow.
 Defined.
 Global Opaque run_selfdestruct.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/memory/mcopy.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/memory/mcopy.v
@@ -40,13 +40,5 @@ Proof.
   destruct Impl_TryFrom_u64_for_usize.run.
   destruct Impl_Ord_for_usize.run.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_not_activated. }
-  { eapply Impl_Interpreter.run_halt. }
-  { eapply Impl_Interpreter.run_halt_oog. }
-  { eapply Impl_Interpreter.run_halt_oog. }
-  { eapply Impl_Interpreter.run_halt. }
-  { eapply Impl_Interpreter.run_halt. }
-  { eapply Impl_Interpreter.run_halt_memory_oog. }
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_mcopy.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/memory/mload.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/memory/mload.v
@@ -40,8 +40,5 @@ Proof.
   destruct run_Deref_for_Synthetic.
   destruct (Impl_AsRef_for_Slice.run u8).
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
-  { eapply Impl_Interpreter.run_halt. }
-  { eapply Impl_Interpreter.run_halt_memory_oog. }
 Defined.
 Global Opaque run_mload.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/memory/msize.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/memory/msize.v
@@ -37,6 +37,5 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   destruct run_MemoryTrait_for_Memory.
   run_symbolic.
-  eapply Impl_Interpreter.run_halt_overflow.
 Defined.
 Global Opaque run_msize.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/memory/mstore.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/memory/mstore.v
@@ -37,8 +37,5 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   destruct run_MemoryTrait_for_Memory.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt. }
-  { eapply Impl_Interpreter.run_halt_memory_oog. }
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_mstore.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/memory/mstore8.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/memory/mstore8.v
@@ -37,8 +37,5 @@ Proof.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   destruct run_MemoryTrait_for_Memory.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt. }
-  { eapply Impl_Interpreter.run_halt_memory_oog. }
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_mstore8.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/stack.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/stack.v
@@ -29,7 +29,6 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct run_StackTrait_for_Stack.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_underflow. }
 Defined.
 Global Opaque run_pop.
 
@@ -51,8 +50,6 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_RuntimeFlag_for_RuntimeFlag.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt_not_activated. }
-  { eapply Impl_Interpreter.run_halt_overflow. }
 Defined.
 Global Opaque run_push0.
 
@@ -78,7 +75,6 @@ Proof.
   destruct run_Jumps_for_Bytecode.
   destruct run_Immediates_for_Bytecode.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt. }
 Defined.
 Global Opaque run_push.
 
@@ -102,7 +98,6 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct run_StackTrait_for_Stack.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt. }
 Defined.
 Global Opaque run_dup.
 
@@ -126,6 +121,5 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct run_StackTrait_for_Stack.
   run_symbolic.
-  { eapply Impl_Interpreter.run_halt. }
 Defined.
 Global Opaque run_swap.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/address.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/address.v
@@ -47,11 +47,5 @@ Proof.
   destruct run_InputsTrait_for_Input.
   destruct (Impl_Into_for_From_T.run Impl_From_FixedBytes_32_for_U256.run).
   run_symbolic.
-  all: match goal with
-  | |- Run.Trait
-      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _)
-      _ _ _ _ =>
-      eapply Impl_Interpreter.run_halt_overflow
-  end.
 Defined.
 Global Opaque run_address.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/calldatacopy.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/calldatacopy.v
@@ -51,16 +51,6 @@ Proof.
   destruct Impl_TryFrom_u64_for_usize.run.
   destruct (Impl_Clone_for_Range.run usize).
   run_symbolic.
-  all: try match goal with
-  | |- Run.Trait
-      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_underflow _)
-      _ _ _ _ =>
-      eapply Impl_Interpreter.run_halt_underflow
-  | |- Run.Trait
-      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt _)
-      _ _ _ _ =>
-      eapply Impl_Interpreter.run_halt
-  end.
   all: admit.
 Admitted.
 Global Opaque run_calldatacopy.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/calldataload.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/calldataload.v
@@ -54,16 +54,6 @@ Proof.
   destruct (Impl_Into_for_From_T.run Impl_From_FixedBytes_32_for_U256.run).
   destruct Impl_Ord_for_usize.run.
   run_symbolic.
-  all: try match goal with
-  | |- Run.Trait
-      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_underflow _)
-      _ _ _ _ =>
-      eapply Impl_Interpreter.run_halt_underflow
-  | |- Run.Trait
-      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _)
-      _ _ _ _ =>
-      eapply Impl_Interpreter.run_halt_overflow
-  end.
   all: admit.
 Admitted.
 Global Opaque run_calldataload.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/calldatasize.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/calldatasize.v
@@ -47,11 +47,5 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct run_InputsTrait_for_Input.
   run_symbolic.
-  all: match goal with
-  | |- Run.Trait
-      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _)
-      _ _ _ _ =>
-      eapply Impl_Interpreter.run_halt_overflow
-  end.
 Defined.
 Global Opaque run_calldatasize.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/caller.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/caller.v
@@ -47,11 +47,5 @@ Proof.
   destruct run_InputsTrait_for_Input.
   destruct (Impl_Into_for_From_T.run Impl_From_FixedBytes_32_for_U256.run).
   run_symbolic.
-  all: match goal with
-  | |- Run.Trait
-      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _)
-      _ _ _ _ =>
-      eapply Impl_Interpreter.run_halt_overflow
-  end.
 Defined.
 Global Opaque run_caller.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/callvalue.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/callvalue.v
@@ -46,11 +46,5 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct run_InputsTrait_for_Input.
   run_symbolic.
-  all: match goal with
-  | |- Run.Trait
-      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _)
-      _ _ _ _ =>
-      eapply Impl_Interpreter.run_halt_overflow
-  end.
 Defined.
 Global Opaque run_callvalue.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/codesize.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/codesize.v
@@ -46,11 +46,5 @@ Proof.
   destruct run_LoopControl_for_Control.
   destruct run_LegacyBytecode_for_Bytecode.
   run_symbolic.
-  all: match goal with
-  | |- Run.Trait
-      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _)
-      _ _ _ _ =>
-      eapply Impl_Interpreter.run_halt_overflow
-  end.
 Defined.
 Global Opaque run_codesize.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/gas.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/gas.v
@@ -45,11 +45,5 @@ Proof.
   destruct run_StackTrait_for_Stack.
   destruct run_LoopControl_for_Control.
   run_symbolic.
-  all: match goal with
-  | |- Run.Trait
-      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _)
-      _ _ _ _ =>
-      eapply Impl_Interpreter.run_halt_overflow
-  end.
 Defined.
 Global Opaque run_gas.

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/system/memory_resize.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/system/memory_resize.v
@@ -49,21 +49,9 @@ Proof.
   run_symbolic.
   all: match goal with
   | |- Run.Trait
-      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_oog _)
-      _ _ _ _ =>
-      eapply Impl_Interpreter.run_halt_oog
-  | |- Run.Trait
-      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt _)
-      _ _ _ _ =>
-      eapply Impl_Interpreter.run_halt
-  | |- Run.Trait
       shared_memory.interpreter.shared_memory.resize_memory
       _ _ _ _ =>
       eapply (@shared_memory.run_resize_memory _ _ _ _ _ _ run_MemoryTrait_for_Memory_copy)
-  | |- Run.Trait
-      (interpreter.interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_memory_oog _)
-      _ _ _ _ =>
-      eapply Impl_Interpreter.run_halt_memory_oog
   end.
 Defined.
 Global Opaque run_memory_resize.

--- a/RocqOfRust/revm/revm_interpreter/links/interpreter.v
+++ b/RocqOfRust/revm/revm_interpreter/links/interpreter.v
@@ -67,6 +67,10 @@ Module Impl_Interpreter.
   Defined.
   Global Opaque run_halt.
 
+  #[export] Hint Extern 1
+    (Run.Trait (interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt _) _ _ _ _) =>
+    eapply run_halt : typeclass_instances.
+
   (* pub fn halt_fatal(&mut self) *)
   Instance run_halt_fatal
       (IW : Set) `{Link IW}
@@ -83,6 +87,10 @@ Module Impl_Interpreter.
   Defined.
   Global Opaque run_halt_fatal.
 
+  #[export] Hint Extern 1
+    (Run.Trait (interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_fatal _) _ _ _ _) =>
+    eapply run_halt_fatal : typeclass_instances.
+
   (* pub fn halt_oog(&mut self) *)
   Instance run_halt_oog
       (IW : Set) `{Link IW}
@@ -96,9 +104,12 @@ Module Impl_Interpreter.
   Proof.
     constructor.
     run_symbolic.
-    eapply (@run_halt IW H IW_types H0 run_InterpreterTypes_for_IW).
   Defined.
   Global Opaque run_halt_oog.
+
+  #[export] Hint Extern 1
+    (Run.Trait (interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_oog _) _ _ _ _) =>
+    eapply run_halt_oog : typeclass_instances.
 
   (* pub fn halt_underflow(&mut self) *)
   Instance run_halt_underflow
@@ -113,10 +124,13 @@ Module Impl_Interpreter.
   Proof.
     constructor.
     run_symbolic.
-    eapply (@run_halt IW H IW_types H0 run_InterpreterTypes_for_IW).
   Defined.
 
   Global Opaque run_halt_underflow.
+
+  #[export] Hint Extern 1
+    (Run.Trait (interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_underflow _) _ _ _ _) =>
+    eapply run_halt_underflow : typeclass_instances.
 
   (* pub fn halt_overflow(&mut self) *)
   Instance run_halt_overflow
@@ -131,9 +145,12 @@ Module Impl_Interpreter.
   Proof.
     constructor.
     run_symbolic.
-    eapply (@run_halt IW H IW_types H0 run_InterpreterTypes_for_IW).
   Defined.
   Global Opaque run_halt_overflow.
+
+  #[export] Hint Extern 1
+    (Run.Trait (interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_overflow _) _ _ _ _) =>
+    eapply run_halt_overflow : typeclass_instances.
 
   (* pub fn halt_memory_oog(&mut self) *)
   Instance run_halt_memory_oog
@@ -148,9 +165,32 @@ Module Impl_Interpreter.
   Proof.
     constructor.
     run_symbolic.
-    eapply (@run_halt IW H IW_types H0 run_InterpreterTypes_for_IW).
   Defined.
   Global Opaque run_halt_memory_oog.
+
+  #[export] Hint Extern 1
+    (Run.Trait (interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_memory_oog _) _ _ _ _) =>
+    eapply run_halt_memory_oog : typeclass_instances.
+
+  (* pub fn halt_memory_limit_oog(&mut self) *)
+  Instance run_halt_memory_limit_oog
+      (IW : Set) `{Link IW}
+      {IW_types : InterpreterTypes.Types.t} `{InterpreterTypes.Types.AreLinks IW_types}
+      {run_InterpreterTypes_for_IW : InterpreterTypes.Run IW IW_types}
+      (self : '&mut (Self IW run_InterpreterTypes_for_IW)) :
+    Run.Trait
+      (interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_memory_limit_oog (Φ IW))
+      [] [] [φ self]
+      unit.
+  Proof.
+    constructor.
+    run_symbolic.
+  Defined.
+  Global Opaque run_halt_memory_limit_oog.
+
+  #[export] Hint Extern 1
+    (Run.Trait (interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_memory_limit_oog _) _ _ _ _) =>
+    eapply run_halt_memory_limit_oog : typeclass_instances.
 
   (* pub fn halt_not_activated(&mut self) *)
   Instance run_halt_not_activated
@@ -165,9 +205,12 @@ Module Impl_Interpreter.
   Proof.
     constructor.
     run_symbolic.
-    eapply (@run_halt IW H IW_types H0 run_InterpreterTypes_for_IW).
   Defined.
   Global Opaque run_halt_not_activated.
+
+  #[export] Hint Extern 1
+    (Run.Trait (interpreter.Impl_revm_interpreter_interpreter_Interpreter_IW.halt_not_activated _) _ _ _ _) =>
+    eapply run_halt_not_activated : typeclass_instances.
 
   (* (*
   pub fn run<FN, H: Host>(

--- a/docs/proofs/links.md
+++ b/docs/proofs/links.md
@@ -131,11 +131,49 @@ Proof.
   constructor.
   run_symbolic.
 Defined.
+Global Opaque run_add.
 ```
 
 `constructor` starts the `Run.Trait` proof, and `run_symbolic` symbolically
 executes the mechanically generated Rocq program. For this straight-line
 function, the tactic can discharge the proof automatically.
+
+### Extending function-link inference
+
+First rely on the default typeclass inference mechanism to find a function's
+`Run.Trait` instance. When that mechanism is not enough, for example when
+`run_symbolic` leaves the call as an unresolved `Run.Trait` goal and callers
+would otherwise need an explicit `eapply run_add`, register a targeted fallback
+in the `typeclass_instances` hint database:
+
+```coq
+#[export] Hint Extern 1
+  (Run.Trait Demo.add.add _ _ _ _) =>
+  eapply run_add : typeclass_instances.
+```
+
+Place this hint after the instance definition and its `Global Opaque`
+declaration. The pattern identifies the generated function being called while
+leaving its generic arguments, runtime arguments, and result type available
+for unification. Use `eapply`, rather than supplying all arguments explicitly,
+so Rocq can create the remaining obligations and infer them through typeclass
+search.
+
+`run_symbolic` uses the `typeclass_instances` database when it encounters a
+function call. With the exported hint in scope, a caller can therefore remain:
+
+```coq
+Proof.
+  constructor.
+  run_symbolic.
+Defined.
+```
+
+without a repeated proof step such as `eapply run_add`. This fallback is
+especially useful for shared helper links called from many instruction proofs,
+but it should not be added when default inference already succeeds. Keep the
+hint pattern specific to the generated function head; a catch-all hint for
+arbitrary `Run.Trait` goals can cause ambiguous search or loops.
 
 ## Simulation File
 


### PR DESCRIPTION
The

```rocq
#[export] Hint Extern 1
```

helps to add more automation to the type-classes solver, for cases where due to weird evar resolutions order it does not work.

I added that to the documentation too.