### PR TITLE
Use links plugin for journaled state generic types

### DIFF
--- a/RocqOfRust/plugin/link_model.ml
+++ b/RocqOfRust/plugin/link_model.ml
@@ -21,7 +21,6 @@ type command =
   | EnumDecl of {
       path : string;
       type_params : string list;
-      linked_type_params : string list;
       variants : variant list;
     }
   | RecordDecl of {
@@ -63,7 +62,7 @@ let validate (command : command) : unit =
   | RecordDecl { type_params; fields; _ } ->
       validate_unique "type parameter" type_params;
       validate_fields fields
-  | EnumDecl { type_params; linked_type_params; variants; _ } ->
-      validate_unique "type parameter" (type_params @ linked_type_params);
+  | EnumDecl { type_params; variants; _ } ->
+      validate_unique "type parameter" type_params;
       validate_unique "variant" (List.map (fun variant -> variant.name) variants);
       List.iter validate_variant variants

--- a/RocqOfRust/plugin/link_model.ml
+++ b/RocqOfRust/plugin/link_model.ml
@@ -21,10 +21,12 @@ type command =
   | EnumDecl of {
       path : string;
       type_params : string list;
+      linked_type_params : string list;
       variants : variant list;
     }
   | RecordDecl of {
       path : string;
+      type_params : string list;
       fields : field list;
     }
 
@@ -58,8 +60,10 @@ let validate_variant (variant : variant) : unit =
 
 let validate (command : command) : unit =
   match command with
-  | RecordDecl { fields; _ } -> validate_fields fields
-  | EnumDecl { type_params; variants; _ } ->
+  | RecordDecl { type_params; fields; _ } ->
       validate_unique "type parameter" type_params;
+      validate_fields fields
+  | EnumDecl { type_params; linked_type_params; variants; _ } ->
+      validate_unique "type parameter" (type_params @ linked_type_params);
       validate_unique "variant" (List.map (fun variant -> variant.name) variants);
       List.iter validate_variant variants

--- a/RocqOfRust/plugin/link_render.ml
+++ b/RocqOfRust/plugin/link_render.ml
@@ -34,6 +34,16 @@ let path_ty_with_args (path : string) (args : string list) : string =
 let type_param_binders (type_params : string list) : string =
   String.concat " " (List.map (fun param -> "(" ^ param ^ " : Set)") type_params)
 
+let linked_type_param_binders (type_params : string list) : string =
+  String.concat " " (List.map (fun param -> "(" ^ param ^ " : Set) {H_" ^ param ^ " : Link " ^ param ^ "}") type_params)
+
+let inductive_type_param_binders (type_params : string list) (linked_type_params : string list) : string =
+  String.concat " " [ type_param_binders type_params; linked_type_param_binders linked_type_params ]
+  |> String.trim
+
+let implicit_type_param_binders (type_params : string list) : string =
+  String.concat " " (List.map (fun param -> "{" ^ param ^ " : Set}") type_params)
+
 let type_param_link_binders (type_params : string list) : string =
   String.concat " " (List.map (fun param -> "{H_" ^ param ^ " : Link " ^ param ^ "}") type_params)
 
@@ -56,11 +66,41 @@ let type_app_of_ty (type_params : string list) : string =
       ^ String.concat " " (List.map (fun param -> "H_" ^ param ^ ".(OfTy.A)") type_params)
       ^ ")"
 
+let is_ident_char (c : char) : bool =
+  match c with
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '\'' -> true
+  | _ -> false
+
+let replace_type_params (type_params : string list) (field_ty : string) : string =
+  let replacements =
+    List.map (fun param -> (param, "H_" ^ param ^ ".(OfTy.A)")) type_params
+  in
+  let lookup word =
+    match List.assoc_opt word replacements with
+    | Some replacement -> replacement
+    | None -> word
+  in
+  let length = String.length field_ty in
+  let buffer = Buffer.create length in
+  let rec aux index =
+    if index >= length then
+      ()
+    else if is_ident_char field_ty.[index] then
+      let stop = ref index in
+      while !stop < length && is_ident_char field_ty.[!stop] do
+        incr stop
+      done;
+      Buffer.add_string buffer (lookup (String.sub field_ty index (!stop - index)));
+      aux !stop
+    else (
+      Buffer.add_char buffer field_ty.[index];
+      aux (index + 1))
+  in
+  aux 0;
+  Buffer.contents buffer
+
 let field_ty_for_of_ty (type_params : string list) (field_ty : string) : string =
-  if List.exists (( = ) field_ty) type_params then
-    "H_" ^ field_ty ^ ".(OfTy.A)"
-  else
-    field_ty
+  replace_type_params type_params field_ty
 
 let variant_path (path : string) (variant : variant) : string =
   path ^ "::" ^ variant.rust_name
@@ -87,11 +127,12 @@ let constructor_value ?(type_args = []) (variant : variant) (fields : field list
               (fun field -> "      H_" ^ field.field_name ^ ".(OfValueWith.value)")
               fields)
 
-let render_inductive (type_params : string list) (variants : variant list) : string list =
+let render_inductive (type_params : string list) (linked_type_params : string list) (variants : variant list) : string list =
+  let all_type_params = type_params @ linked_type_params in
   let header =
-    match type_params with
+    match all_type_params with
     | [] -> "Inductive t : Set :="
-    | _ -> "Inductive t " ^ type_param_binders type_params ^ " : Set :="
+    | _ -> "Inductive t " ^ inductive_type_param_binders type_params linked_type_params ^ " : Set :="
   in
   [ header ]
   @ List.map
@@ -108,15 +149,20 @@ let render_inductive (type_params : string list) (variants : variant list) : str
       variants
   @ [ "." ]
 
-let render_constructor_arguments (type_params : string list) (variant : variant) : string list =
-  match type_params with
+let render_constructor_arguments (type_params : string list) (linked_type_params : string list) (variant : variant) : string list =
+  let all_type_params = type_params @ linked_type_params in
+  match all_type_params with
   | [] -> []
   | _ ->
       let fields =
         match variant.payload with
         | TuplePayload fields | RecordPayload fields -> fields
       in
-      let implicit_params = String.concat " " (List.map (fun param -> "{" ^ param ^ "}") type_params) in
+      let implicit_params =
+        String.concat " "
+          (List.map (fun param -> "{" ^ param ^ "}") type_params
+           @ List.map (fun param -> "{" ^ param ^ " H_" ^ param ^ "}") linked_type_params)
+      in
       let field_names = String.concat " " (List.map (fun field -> field.field_name) fields) in
       let suffix =
         if field_names = "" then
@@ -126,10 +172,19 @@ let render_constructor_arguments (type_params : string list) (variant : variant)
       in
       [ "Arguments " ^ variant.name ^ " " ^ suffix ^ "." ]
 
-let render_record_decl (fields : field list) : string list =
-  [ "Record t : Set := {" ]
+let render_record_decl (type_params : string list) (fields : field list) : string list =
+  let header =
+    match type_params with
+    | [] -> "Record t : Set := {"
+    | _ -> "Record t " ^ implicit_type_param_binders type_params ^ " : Set := {"
+  in
+  [ header ]
   @ List.map (fun field -> "  " ^ field.field_name ^ " : " ^ field.field_ty ^ ";") fields
   @ [ "}." ]
+  @
+    match type_params with
+    | [] -> []
+    | _ -> [ "Arguments t : clear implicits." ]
 
 let render_record_value
     ?(type_args = "[]") (path : string) (fields : field list) (value_of : field -> string) : string list =
@@ -179,12 +234,21 @@ let render_enum_link (path : string) (type_params : string list) (variants : var
   @ [ "    end";
       "}." ]
 
-let render_record_link (path : string) (fields : field list) : string list =
-  [ "Instance IsLink : Link t := {";
-    "  Φ := " ^ path_ty path ^ ";";
+let render_record_link (path : string) (type_params : string list) (fields : field list) : string list =
+  let instance_head =
+    match type_params with
+    | [] -> "Instance IsLink : Link t := {"
+    | _ ->
+        "Instance IsLink "
+        ^ type_param_binders type_params ^ " "
+        ^ type_param_link_binders type_params
+        ^ " : Link " ^ type_app type_params ^ " := {"
+  in
+  [ instance_head;
+    "  Φ := " ^ path_ty_with_args path (List.map (fun param -> "Φ " ^ param) type_params) ^ ";";
     "  φ x :=" ]
   @ indent "    "
-      (render_record_value path (sorted_fields fields)
+      (render_record_value ~type_args:(type_param_ty_args type_params) path (sorted_fields fields)
          (fun field -> "φ x.(" ^ field.field_name ^ ")"))
   @ [ "}." ]
 
@@ -233,6 +297,45 @@ let render_enum_inductive_of_ty (path : string) (type_params : string list) : st
         ^ "); subst; reflexivity).";
         "Smpl Add eapply of_ty : of_ty." ]
 
+let render_type_of_ty (path : string) (type_params : string list) : string list =
+  match type_params with
+  | [] -> render_of_ty path
+  | _ ->
+      let params =
+        List.map
+          (fun param -> "(" ^ param ^ "' : Ty.t) {H_" ^ param ^ " : OfTy.C " ^ param ^ "'}")
+          type_params
+      in
+      [ "Instance IsOfTy" ]
+      @ List.map (fun param -> "    " ^ param) params
+      @ [ "    : OfTy.C ("
+          ^ path_ty_with_args path (List.map (fun param -> param ^ "'") type_params)
+          ^ ") := {";
+          "  A := " ^ type_app_of_ty type_params ^ ";";
+          "  eq := ltac:(sauto lq: on);";
+          "}." ]
+
+let render_type_inductive_of_ty (path : string) (type_params : string list) : string list =
+  match type_params with
+  | [] -> []
+  | _ ->
+      let ty_params = List.map (fun param -> param ^ "'") type_params in
+      let intros = List.map (fun param -> "[" ^ param ^ "]") type_params in
+      [ "Definition of_ty " ^ String.concat " " ty_params ^ " :";
+        "  "
+        ^ String.concat " -> "
+            (List.map
+               (fun param -> "OfTy.t " ^ param)
+               ty_params
+             @ [ "OfTy.t ("
+                 ^ path_ty_with_args path ty_params
+                 ^ ")" ])
+        ^ " :=";
+        "  ltac:(intros " ^ String.concat " " intros
+        ^ "; eapply OfTy.Make with (A := " ^ type_app type_params
+        ^ "); subst; reflexivity).";
+        "Smpl Add eapply of_ty : of_ty." ]
+
 let render_instance_params ?(type_params = []) ?(use_of_ty = false) (fields : field list) : string list =
   List.map
     (fun field ->
@@ -252,48 +355,12 @@ let render_value_fields ?(type_args = "[]") (path : string) (fields : field list
 (* Record constructors still receive fields in declaration order; only the
    StructRecord value used for matching is sorted. *)
 let render_record_of_value
-    (kind : [ `Plain | `With ]) (path : string) (fields : field list) : string list =
+    (kind : [ `Plain | `With ]) (path : string) (type_params : string list) (fields : field list) : string list =
   let sorted = sorted_fields fields in
   let head =
     match kind with
     | `With -> "Instance IsOfValueWith"
     | `Plain -> "Instance IsOfValue"
-  in
-  let class_head =
-    match kind with
-    | `With -> "OfValueWith.C t"
-    | `Plain -> "OfValue.C"
-  in
-  [ head ]
-  @ render_instance_params sorted
-  @ [ "    :";
-      "  " ^ class_head ^ " (" ]
-  @ indent "    " (render_value_fields path sorted)
-  @ [ "  ) := {";
-      "  value := Build_t" ]
-  @ List.map
-      (fun field -> "    H_" ^ field.field_name ^ ".(OfValueWith.value)")
-      fields
-  @ [ "  ;";
-      "  eq := ltac:(sauto lq: on);";
-      "}." ]
-
-let render_enum_of_value
-    (kind : [ `Plain | `With ]) (path : string) (type_params : string list) (variant : variant) : string list =
-  let fields =
-    match variant.payload with
-    | TuplePayload fields -> fields
-    | RecordPayload fields -> sorted_fields fields
-  in
-  let constructor_fields =
-    match variant.payload with
-    | TuplePayload fields | RecordPayload fields -> fields
-  in
-  let vpath = variant_path path variant in
-  let head =
-    match kind with
-    | `With -> "Instance IsOfValueWith_" ^ variant.name
-    | `Plain -> "Instance IsOfValue_" ^ variant.name
   in
   let class_head =
     match kind with
@@ -330,8 +397,92 @@ let render_enum_of_value
     | `With -> []
     | `Plain -> [ "  A := " ^ type_app_of_ty type_params ^ ";" ]
   in
+  let constructor =
+    match constructor_type_args with
+    | [] -> "Build_t"
+    | _ -> "@Build_t " ^ String.concat " " (List.map (fun arg -> "(" ^ arg ^ ")") constructor_type_args)
+  in
+  [ head ]
+  @ params
+  @ render_instance_params ~type_params ~use_of_ty:(kind = `Plain) sorted
+  @ [ "    :";
+      "  " ^ class_head ^ " (" ]
+  @ indent "    " (render_value_fields ~type_args path sorted)
+  @ [ "  ) := {" ]
+  @ of_value_body_prefix
+  @ [ "  value := " ^ constructor ]
+  @ List.map
+      (fun field -> "    H_" ^ field.field_name ^ ".(OfValueWith.value)")
+      fields
+  @ [ "  ;";
+      "  eq := ltac:(sauto lq: on);";
+      "}." ]
+
+let constructor_type_arguments
+    (kind : [ `Plain | `With ]) (type_params : string list) (linked_type_params : string list) : string list =
+  let type_arg param =
+    match kind with
+    | `With -> param
+    | `Plain -> "H_" ^ param ^ ".(OfTy.A)"
+  in
+  let linked_type_args param =
+    match kind with
+    | `With -> [ param; "H_" ^ param ]
+    | `Plain -> [ "H_" ^ param ^ ".(OfTy.A)"; "H_" ^ param ^ ".(OfTy.H)" ]
+  in
+  List.map type_arg type_params @ List.concat (List.map linked_type_args linked_type_params)
+
+let render_enum_of_value
+    (kind : [ `Plain | `With ]) (path : string) (type_params : string list) (linked_type_params : string list) (variant : variant) : string list =
+  let all_type_params = type_params @ linked_type_params in
+  let fields =
+    match variant.payload with
+    | TuplePayload fields -> fields
+    | RecordPayload fields -> sorted_fields fields
+  in
+  let constructor_fields =
+    match variant.payload with
+    | TuplePayload fields | RecordPayload fields -> fields
+  in
+  let vpath = variant_path path variant in
+  let head =
+    match kind with
+    | `With -> "Instance IsOfValueWith_" ^ variant.name
+    | `Plain -> "Instance IsOfValue_" ^ variant.name
+  in
+  let class_head =
+    match kind with
+    | `With -> "OfValueWith.C " ^ type_app all_type_params
+    | `Plain -> "OfValue.C"
+  in
+  let params =
+    match kind with
+    | `With ->
+        (match all_type_params with
+         | [] -> []
+         | _ ->
+             [ "    "
+               ^ type_param_binders all_type_params
+               ^ " "
+               ^ type_param_link_binders all_type_params ])
+    | `Plain ->
+        List.map
+          (fun param -> "    (" ^ param ^ "' : Ty.t) {H_" ^ param ^ " : OfTy.C " ^ param ^ "'}")
+          all_type_params
+  in
+  let type_args =
+    match kind with
+    | `With -> type_param_ty_args all_type_params
+    | `Plain -> type_param_of_ty_args all_type_params
+  in
+  let constructor_type_args = constructor_type_arguments kind type_params linked_type_params in
+  let of_value_body_prefix =
+    match kind with
+    | `With -> []
+    | `Plain -> [ "  A := " ^ type_app_of_ty all_type_params ^ ";" ]
+  in
   let no_field_eq =
-    match kind, type_params with
+    match kind, all_type_params with
     | `Plain, _ :: _ -> "ltac:(sauto lq: on)"
     | _ -> "eq_refl"
   in
@@ -355,7 +506,7 @@ let render_enum_of_value
   else
     [ head ]
     @ params
-    @ render_instance_params ~type_params ~use_of_ty:(kind = `Plain) fields
+    @ render_instance_params ~type_params:all_type_params ~use_of_ty:(kind = `Plain) fields
     @ [ "    :";
         "  " ^ class_head ^ " (" ]
     @ indent "    " value_lines
@@ -369,17 +520,40 @@ let render_enum_of_value
 (* SubPointer proofs are emitted as proof terms with ltac:(...), because the
    plugin interprets complete vernacular sentences rather than entering proof
    mode for generated tactic commands. *)
-let render_record_subpointer (path : string) (field : field) : string list =
+let render_record_subpointer (path : string) (type_params : string list) (field : field) : string list =
   let get = "get_" ^ field.field_name in
-  [ "Definition " ^ get ^ " : SubPointer.Runner.t t";
+  let definition_head =
+    match type_params with
+    | [] -> "Definition " ^ get ^ " : SubPointer.Runner.t t"
+    | _ ->
+        "Definition " ^ get ^ " "
+        ^ type_param_binders type_params ^ " "
+        ^ type_param_link_binders type_params
+        ^ " : SubPointer.Runner.t " ^ type_app type_params
+  in
+  let get_applied =
+    match type_params with
+    | [] -> get
+    | _ -> "(" ^ get ^ " " ^ String.concat " " type_params ^ ")"
+  in
+  let validity_head =
+    match type_params with
+    | [] -> "Definition " ^ get ^ "_is_valid :"
+    | _ ->
+        "Definition " ^ get ^ "_is_valid "
+        ^ type_param_binders type_params ^ " "
+        ^ type_param_link_binders type_params
+        ^ " :"
+  in
+  [ definition_head;
     "  (Pointer.Index.StructRecord " ^ quote path ^ " " ^ quote field.field_name ^ ") :=";
     "{|";
     "  SubPointer.Runner.projection x := Datatypes.Some x.(" ^ field.field_name ^ ");";
     "  SubPointer.Runner.injection x y := Datatypes.Some (x <| " ^ field.field_name ^ " := y |>);";
     "|}.";
     "";
-    "Definition " ^ get ^ "_is_valid :";
-    "  SubPointer.Runner.Valid.t " ^ get ^ " :=";
+    validity_head;
+    "  SubPointer.Runner.Valid.t " ^ get_applied ^ " :=";
     "  ltac:(now constructor).";
     "Smpl Add apply " ^ get ^ "_is_valid : run_sub_pointer." ]
 
@@ -470,43 +644,46 @@ let render_subpointer_module (body : string list) : string list =
 
 (* Top-level renderers validate first so all downstream functions can assume a
    well-formed declaration. *)
-let render_record (path : string) (fields : field list) : string list =
-  validate (RecordDecl { path; fields });
-  render_record_decl fields
+let render_record (path : string) (type_params : string list) (fields : field list) : string list =
+  validate (RecordDecl { path; type_params; fields });
+  render_record_decl type_params fields
   @ [ "" ]
-  @ render_record_link path fields
+  @ render_record_link path type_params fields
   @ [ "" ]
-  @ render_of_ty path
+  @ render_type_of_ty path type_params
   @ [ "" ]
-  @ render_record_of_value `With path fields
+  @ render_type_inductive_of_ty path type_params
   @ [ "" ]
-  @ render_record_of_value `Plain path fields
+  @ render_record_of_value `With path type_params fields
+  @ [ "" ]
+  @ render_record_of_value `Plain path type_params fields
   @ [ "" ]
   @ render_subpointer_module
       (List.concat
          (List.mapi
             (fun i field ->
-              let lines = render_record_subpointer path field in
+              let lines = render_record_subpointer path type_params field in
               if i = List.length fields - 1 then lines else lines @ [ "" ])
             fields))
 
-let render_enum (path : string) (type_params : string list) (variants : variant list) : string list =
-  validate (EnumDecl { path; type_params; variants });
-  render_inductive type_params variants
-  @ List.concat (List.map (render_constructor_arguments type_params) variants)
+let render_enum (path : string) (type_params : string list) (linked_type_params : string list) (variants : variant list) : string list =
+  let all_type_params = type_params @ linked_type_params in
+  validate (EnumDecl { path; type_params; linked_type_params; variants });
+  render_inductive type_params linked_type_params variants
+  @ List.concat (List.map (render_constructor_arguments type_params linked_type_params) variants)
   @ [ "" ]
-  @ render_enum_link path type_params variants
+  @ render_enum_link path all_type_params variants
   @ [ "" ]
-  @ render_enum_of_ty path type_params
+  @ render_enum_of_ty path all_type_params
   @ [ "" ]
-  @ render_enum_inductive_of_ty path type_params
+  @ render_enum_inductive_of_ty path all_type_params
   @ [ "" ]
   @ List.concat
       (List.map
          (fun variant ->
-           render_enum_of_value `With path type_params variant
+           render_enum_of_value `With path type_params linked_type_params variant
            @ [ "" ]
-           @ render_enum_of_value `Plain path type_params variant
+           @ render_enum_of_value `Plain path type_params linked_type_params variant
            @ [ "" ])
          variants)
   @ render_subpointer_module
@@ -519,11 +696,11 @@ let render_enum (path : string) (type_params : string list) (variants : variant 
               in
               List.concat
                 (List.mapi
-                   (fun i field -> render_enum_subpointer path type_params variant i field @ [ "" ])
+                   (fun i field -> render_enum_subpointer path all_type_params variant i field @ [ "" ])
                    fields))
             variants))
 
 let render (command : command) : string list =
   match command with
-  | RecordDecl { path; fields } -> render_record path fields
-  | EnumDecl { path; type_params; variants } -> render_enum path type_params variants
+  | RecordDecl { path; type_params; fields } -> render_record path type_params fields
+  | EnumDecl { path; type_params; linked_type_params; variants } -> render_enum path type_params linked_type_params variants

--- a/RocqOfRust/plugin/link_render.ml
+++ b/RocqOfRust/plugin/link_render.ml
@@ -34,18 +34,15 @@ let path_ty_with_args (path : string) (args : string list) : string =
 let type_param_binders (type_params : string list) : string =
   String.concat " " (List.map (fun param -> "(" ^ param ^ " : Set)") type_params)
 
-let linked_type_param_binders (type_params : string list) : string =
-  String.concat " " (List.map (fun param -> "(" ^ param ^ " : Set) {H_" ^ param ^ " : Link " ^ param ^ "}") type_params)
-
-let inductive_type_param_binders (type_params : string list) (linked_type_params : string list) : string =
-  String.concat " " [ type_param_binders type_params; linked_type_param_binders linked_type_params ]
-  |> String.trim
-
-let implicit_type_param_binders (type_params : string list) : string =
-  String.concat " " (List.map (fun param -> "{" ^ param ^ " : Set}") type_params)
-
 let type_param_link_binders (type_params : string list) : string =
   String.concat " " (List.map (fun param -> "{H_" ^ param ^ " : Link " ^ param ^ "}") type_params)
+
+let type_param_set_link_binders (type_params : string list) : string =
+  String.concat " " [ type_param_binders type_params; type_param_link_binders type_params ]
+  |> String.trim
+
+let implicit_type_param_set_link_binders (type_params : string list) : string =
+  String.concat " " (List.map (fun param -> "{" ^ param ^ " : Set} {H_" ^ param ^ " : Link " ^ param ^ "}") type_params)
 
 let type_param_ty_args (type_params : string list) : string =
   ty_args (List.map (fun param -> "Φ " ^ param) type_params)
@@ -127,12 +124,11 @@ let constructor_value ?(type_args = []) (variant : variant) (fields : field list
               (fun field -> "      H_" ^ field.field_name ^ ".(OfValueWith.value)")
               fields)
 
-let render_inductive (type_params : string list) (linked_type_params : string list) (variants : variant list) : string list =
-  let all_type_params = type_params @ linked_type_params in
+let render_inductive (type_params : string list) (variants : variant list) : string list =
   let header =
-    match all_type_params with
+    match type_params with
     | [] -> "Inductive t : Set :="
-    | _ -> "Inductive t " ^ inductive_type_param_binders type_params linked_type_params ^ " : Set :="
+    | _ -> "Inductive t " ^ type_param_set_link_binders type_params ^ " : Set :="
   in
   [ header ]
   @ List.map
@@ -149,9 +145,8 @@ let render_inductive (type_params : string list) (linked_type_params : string li
       variants
   @ [ "." ]
 
-let render_constructor_arguments (type_params : string list) (linked_type_params : string list) (variant : variant) : string list =
-  let all_type_params = type_params @ linked_type_params in
-  match all_type_params with
+let render_constructor_arguments (type_params : string list) (variant : variant) : string list =
+  match type_params with
   | [] -> []
   | _ ->
       let fields =
@@ -160,8 +155,7 @@ let render_constructor_arguments (type_params : string list) (linked_type_params
       in
       let implicit_params =
         String.concat " "
-          (List.map (fun param -> "{" ^ param ^ "}") type_params
-           @ List.map (fun param -> "{" ^ param ^ " H_" ^ param ^ "}") linked_type_params)
+          (List.map (fun param -> "{" ^ param ^ " H_" ^ param ^ "}") type_params)
       in
       let field_names = String.concat " " (List.map (fun field -> field.field_name) fields) in
       let suffix =
@@ -176,7 +170,7 @@ let render_record_decl (type_params : string list) (fields : field list) : strin
   let header =
     match type_params with
     | [] -> "Record t : Set := {"
-    | _ -> "Record t " ^ implicit_type_param_binders type_params ^ " : Set := {"
+    | _ -> "Record t " ^ implicit_type_param_set_link_binders type_params ^ " : Set := {"
   in
   [ header ]
   @ List.map (fun field -> "  " ^ field.field_name ^ " : " ^ field.field_ty ^ ";") fields
@@ -184,7 +178,7 @@ let render_record_decl (type_params : string list) (fields : field list) : strin
   @
     match type_params with
     | [] -> []
-    | _ -> [ "Arguments t : clear implicits." ]
+    | _ -> [ "Arguments t " ^ String.concat " " (List.map (fun _ -> "_ {_}") type_params) ^ "." ]
 
 let render_record_value
     ?(type_args = "[]") (path : string) (fields : field list) (value_of : field -> string) : string list =
@@ -216,8 +210,7 @@ let render_enum_link (path : string) (type_params : string list) (variants : var
     | [] -> "Instance IsLink : Link t := {"
     | _ ->
         "Instance IsLink "
-        ^ type_param_binders type_params ^ " "
-        ^ type_param_link_binders type_params
+        ^ type_param_set_link_binders type_params
         ^ " : Link " ^ type_app type_params ^ " := {"
   in
   [ instance_head;
@@ -240,8 +233,7 @@ let render_record_link (path : string) (type_params : string list) (fields : fie
     | [] -> "Instance IsLink : Link t := {"
     | _ ->
         "Instance IsLink "
-        ^ type_param_binders type_params ^ " "
-        ^ type_param_link_binders type_params
+        ^ type_param_set_link_binders type_params
         ^ " : Link " ^ type_app type_params ^ " := {"
   in
   [ instance_head;
@@ -374,9 +366,7 @@ let render_record_of_value
          | [] -> []
          | _ ->
              [ "    "
-               ^ type_param_binders type_params
-               ^ " "
-               ^ type_param_link_binders type_params ])
+               ^ type_param_set_link_binders type_params ])
     | `Plain ->
         List.map
           (fun param -> "    (" ^ param ^ "' : Ty.t) {H_" ^ param ^ " : OfTy.C " ^ param ^ "'}")
@@ -388,9 +378,12 @@ let render_record_of_value
     | `Plain -> type_param_of_ty_args type_params
   in
   let constructor_type_args =
-    match kind with
-    | `With -> type_params
-    | `Plain -> List.map (fun param -> "H_" ^ param ^ ".(OfTy.A)") type_params
+    let type_args param =
+      match kind with
+      | `With -> [ param; "H_" ^ param ]
+      | `Plain -> [ "H_" ^ param ^ ".(OfTy.A)"; "H_" ^ param ^ ".(OfTy.H)" ]
+    in
+    List.concat (List.map type_args type_params)
   in
   let of_value_body_prefix =
     match kind with
@@ -419,22 +412,16 @@ let render_record_of_value
       "}." ]
 
 let constructor_type_arguments
-    (kind : [ `Plain | `With ]) (type_params : string list) (linked_type_params : string list) : string list =
-  let type_arg param =
-    match kind with
-    | `With -> param
-    | `Plain -> "H_" ^ param ^ ".(OfTy.A)"
-  in
-  let linked_type_args param =
+    (kind : [ `Plain | `With ]) (type_params : string list) : string list =
+  let type_args param =
     match kind with
     | `With -> [ param; "H_" ^ param ]
     | `Plain -> [ "H_" ^ param ^ ".(OfTy.A)"; "H_" ^ param ^ ".(OfTy.H)" ]
   in
-  List.map type_arg type_params @ List.concat (List.map linked_type_args linked_type_params)
+  List.concat (List.map type_args type_params)
 
 let render_enum_of_value
-    (kind : [ `Plain | `With ]) (path : string) (type_params : string list) (linked_type_params : string list) (variant : variant) : string list =
-  let all_type_params = type_params @ linked_type_params in
+    (kind : [ `Plain | `With ]) (path : string) (type_params : string list) (variant : variant) : string list =
   let fields =
     match variant.payload with
     | TuplePayload fields -> fields
@@ -452,37 +439,35 @@ let render_enum_of_value
   in
   let class_head =
     match kind with
-    | `With -> "OfValueWith.C " ^ type_app all_type_params
+    | `With -> "OfValueWith.C " ^ type_app type_params
     | `Plain -> "OfValue.C"
   in
   let params =
     match kind with
     | `With ->
-        (match all_type_params with
+        (match type_params with
          | [] -> []
          | _ ->
              [ "    "
-               ^ type_param_binders all_type_params
-               ^ " "
-               ^ type_param_link_binders all_type_params ])
+               ^ type_param_set_link_binders type_params ])
     | `Plain ->
         List.map
           (fun param -> "    (" ^ param ^ "' : Ty.t) {H_" ^ param ^ " : OfTy.C " ^ param ^ "'}")
-          all_type_params
+          type_params
   in
   let type_args =
     match kind with
-    | `With -> type_param_ty_args all_type_params
-    | `Plain -> type_param_of_ty_args all_type_params
+    | `With -> type_param_ty_args type_params
+    | `Plain -> type_param_of_ty_args type_params
   in
-  let constructor_type_args = constructor_type_arguments kind type_params linked_type_params in
+  let constructor_type_args = constructor_type_arguments kind type_params in
   let of_value_body_prefix =
     match kind with
     | `With -> []
-    | `Plain -> [ "  A := " ^ type_app_of_ty all_type_params ^ ";" ]
+    | `Plain -> [ "  A := " ^ type_app_of_ty type_params ^ ";" ]
   in
   let no_field_eq =
-    match kind, all_type_params with
+    match kind, type_params with
     | `Plain, _ :: _ -> "ltac:(sauto lq: on)"
     | _ -> "eq_refl"
   in
@@ -506,7 +491,7 @@ let render_enum_of_value
   else
     [ head ]
     @ params
-    @ render_instance_params ~type_params:all_type_params ~use_of_ty:(kind = `Plain) fields
+    @ render_instance_params ~type_params ~use_of_ty:(kind = `Plain) fields
     @ [ "    :";
         "  " ^ class_head ^ " (" ]
     @ indent "    " value_lines
@@ -527,8 +512,7 @@ let render_record_subpointer (path : string) (type_params : string list) (field 
     | [] -> "Definition " ^ get ^ " : SubPointer.Runner.t t"
     | _ ->
         "Definition " ^ get ^ " "
-        ^ type_param_binders type_params ^ " "
-        ^ type_param_link_binders type_params
+        ^ type_param_set_link_binders type_params
         ^ " : SubPointer.Runner.t " ^ type_app type_params
   in
   let get_applied =
@@ -541,8 +525,7 @@ let render_record_subpointer (path : string) (type_params : string list) (field 
     | [] -> "Definition " ^ get ^ "_is_valid :"
     | _ ->
         "Definition " ^ get ^ "_is_valid "
-        ^ type_param_binders type_params ^ " "
-        ^ type_param_link_binders type_params
+        ^ type_param_set_link_binders type_params
         ^ " :"
   in
   [ definition_head;
@@ -601,8 +584,7 @@ let render_enum_subpointer
     | [] -> "Definition " ^ get ^ " : SubPointer.Runner.t t"
     | _ ->
         "Definition " ^ get ^ " "
-        ^ type_param_binders type_params ^ " "
-        ^ type_param_link_binders type_params
+        ^ type_param_set_link_binders type_params
         ^ " : SubPointer.Runner.t " ^ type_app type_params
   in
   let get_applied =
@@ -615,8 +597,7 @@ let render_enum_subpointer
     | [] -> "Definition " ^ get ^ "_is_valid :"
     | _ ->
         "Definition " ^ get ^ "_is_valid "
-        ^ type_param_binders type_params ^ " "
-        ^ type_param_link_binders type_params
+        ^ type_param_set_link_binders type_params
         ^ " :"
   in
   [ definition_head;
@@ -666,24 +647,23 @@ let render_record (path : string) (type_params : string list) (fields : field li
               if i = List.length fields - 1 then lines else lines @ [ "" ])
             fields))
 
-let render_enum (path : string) (type_params : string list) (linked_type_params : string list) (variants : variant list) : string list =
-  let all_type_params = type_params @ linked_type_params in
-  validate (EnumDecl { path; type_params; linked_type_params; variants });
-  render_inductive type_params linked_type_params variants
-  @ List.concat (List.map (render_constructor_arguments type_params linked_type_params) variants)
+let render_enum (path : string) (type_params : string list) (variants : variant list) : string list =
+  validate (EnumDecl { path; type_params; variants });
+  render_inductive type_params variants
+  @ List.concat (List.map (render_constructor_arguments type_params) variants)
   @ [ "" ]
-  @ render_enum_link path all_type_params variants
+  @ render_enum_link path type_params variants
   @ [ "" ]
-  @ render_enum_of_ty path all_type_params
+  @ render_enum_of_ty path type_params
   @ [ "" ]
-  @ render_enum_inductive_of_ty path all_type_params
+  @ render_enum_inductive_of_ty path type_params
   @ [ "" ]
   @ List.concat
       (List.map
          (fun variant ->
-           render_enum_of_value `With path type_params linked_type_params variant
+           render_enum_of_value `With path type_params variant
            @ [ "" ]
-           @ render_enum_of_value `Plain path type_params linked_type_params variant
+           @ render_enum_of_value `Plain path type_params variant
            @ [ "" ])
          variants)
   @ render_subpointer_module
@@ -696,11 +676,11 @@ let render_enum (path : string) (type_params : string list) (linked_type_params 
               in
               List.concat
                 (List.mapi
-                   (fun i field -> render_enum_subpointer path all_type_params variant i field @ [ "" ])
+                   (fun i field -> render_enum_subpointer path type_params variant i field @ [ "" ])
                    fields))
             variants))
 
 let render (command : command) : string list =
   match command with
   | RecordDecl { path; type_params; fields } -> render_record path type_params fields
-  | EnumDecl { path; type_params; linked_type_params; variants } -> render_enum path type_params linked_type_params variants
+  | EnumDecl { path; type_params; variants } -> render_enum path type_params variants

--- a/RocqOfRust/plugin/rocqofrust_link_plugin.ml
+++ b/RocqOfRust/plugin/rocqofrust_link_plugin.ml
@@ -336,7 +336,37 @@ let () : unit =
                               Vernacextend.TyTerminal ("}", Vernacextend.TyNil) ) ) ) ) ),
           (fun path fields ?loc:_ ~atts () ->
             Attributes.unsupported_attributes atts;
-            command_typed_vernac (Link_model.RecordDecl { path; fields })),
+            command_typed_vernac (Link_model.RecordDecl { path; type_params = []; fields })),
+          None );
+    ]
+
+(* Generic record command.  This handles Rust structs such as [Foo<T>] whose
+   link type is represented with [Ty.apply] and whose StructRecord values carry
+   type arguments. *)
+let () : unit =
+  Vernacextend.static_vernac_extend
+    ~plugin:(Some plugin_name)
+    ~command:"RocqOfRustLinkGenericRecord"
+    ~classifier:(fun _ -> Vernacextend.classify_as_sideeff)
+    [
+      Vernacextend.TyML
+        ( false,
+          Vernacextend.TyTerminal
+            ( "RocqOfRustLinkGenericRecord",
+              Vernacextend.TyNonTerminal
+                ( Extend.TUentry (Genarg.get_arg_tag wit_string),
+                  Vernacextend.TyNonTerminal
+                    ( Extend.TUentry (Genarg.get_arg_tag wit_link_type_params),
+                      Vernacextend.TyTerminal
+                        ( ":=",
+                          Vernacextend.TyTerminal
+                            ( "{",
+                              Vernacextend.TyNonTerminal
+                                ( Extend.TUentry (Genarg.get_arg_tag wit_link_fields),
+                                  Vernacextend.TyTerminal ("}", Vernacextend.TyNil) ) ) ) ) ) ),
+          (fun path type_params fields ?loc:_ ~atts () ->
+            Attributes.unsupported_attributes atts;
+            command_typed_vernac (Link_model.RecordDecl { path; type_params; fields })),
           None );
     ]
 
@@ -362,7 +392,7 @@ let () : unit =
                           Vernacextend.TyNil ) ) ) ),
           (fun path variants ?loc:_ ~atts () ->
             Attributes.unsupported_attributes atts;
-            command_typed_vernac (Link_model.EnumDecl { path; type_params = []; variants })),
+            command_typed_vernac (Link_model.EnumDecl { path; type_params = []; linked_type_params = []; variants })),
           None );
     ]
 
@@ -391,6 +421,35 @@ let () : unit =
                               Vernacextend.TyNil ) ) ) ) ),
           (fun path type_params variants ?loc:_ ~atts () ->
             Attributes.unsupported_attributes atts;
-            command_typed_vernac (Link_model.EnumDecl { path; type_params; variants })),
+            command_typed_vernac (Link_model.EnumDecl { path; type_params; linked_type_params = []; variants })),
+          None );
+    ]
+
+(* Linked generic enum command.  This is for generic enums whose own Rocq
+   inductive needs [Link] evidence for its type parameters, for example when a
+   variant directly stores a reference ['& T]. *)
+let () : unit =
+  Vernacextend.static_vernac_extend
+    ~plugin:(Some plugin_name)
+    ~command:"RocqOfRustLinkLinkedGenericEnum"
+    ~classifier:(fun _ -> Vernacextend.classify_as_sideeff)
+    [
+      Vernacextend.TyML
+        ( false,
+          Vernacextend.TyTerminal
+            ( "RocqOfRustLinkLinkedGenericEnum",
+              Vernacextend.TyNonTerminal
+                ( Extend.TUentry (Genarg.get_arg_tag wit_string),
+                  Vernacextend.TyNonTerminal
+                    ( Extend.TUentry (Genarg.get_arg_tag wit_link_type_params),
+                      Vernacextend.TyTerminal
+                        ( ":=",
+                          Vernacextend.TyNonTerminal
+                            ( Extend.TUlist1
+                                (Extend.TUentry (Genarg.get_arg_tag wit_link_variant)),
+                              Vernacextend.TyNil ) ) ) ) ),
+          (fun path linked_type_params variants ?loc:_ ~atts () ->
+            Attributes.unsupported_attributes atts;
+            command_typed_vernac (Link_model.EnumDecl { path; type_params = []; linked_type_params; variants })),
           None );
     ]

--- a/RocqOfRust/plugin/rocqofrust_link_plugin.ml
+++ b/RocqOfRust/plugin/rocqofrust_link_plugin.ml
@@ -392,7 +392,7 @@ let () : unit =
                           Vernacextend.TyNil ) ) ) ),
           (fun path variants ?loc:_ ~atts () ->
             Attributes.unsupported_attributes atts;
-            command_typed_vernac (Link_model.EnumDecl { path; type_params = []; linked_type_params = []; variants })),
+            command_typed_vernac (Link_model.EnumDecl { path; type_params = []; variants })),
           None );
     ]
 
@@ -421,35 +421,6 @@ let () : unit =
                               Vernacextend.TyNil ) ) ) ) ),
           (fun path type_params variants ?loc:_ ~atts () ->
             Attributes.unsupported_attributes atts;
-            command_typed_vernac (Link_model.EnumDecl { path; type_params; linked_type_params = []; variants })),
-          None );
-    ]
-
-(* Linked generic enum command.  This is for generic enums whose own Rocq
-   inductive needs [Link] evidence for its type parameters, for example when a
-   variant directly stores a reference ['& T]. *)
-let () : unit =
-  Vernacextend.static_vernac_extend
-    ~plugin:(Some plugin_name)
-    ~command:"RocqOfRustLinkLinkedGenericEnum"
-    ~classifier:(fun _ -> Vernacextend.classify_as_sideeff)
-    [
-      Vernacextend.TyML
-        ( false,
-          Vernacextend.TyTerminal
-            ( "RocqOfRustLinkLinkedGenericEnum",
-              Vernacextend.TyNonTerminal
-                ( Extend.TUentry (Genarg.get_arg_tag wit_string),
-                  Vernacextend.TyNonTerminal
-                    ( Extend.TUentry (Genarg.get_arg_tag wit_link_type_params),
-                      Vernacextend.TyTerminal
-                        ( ":=",
-                          Vernacextend.TyNonTerminal
-                            ( Extend.TUlist1
-                                (Extend.TUentry (Genarg.get_arg_tag wit_link_variant)),
-                              Vernacextend.TyNil ) ) ) ) ),
-          (fun path linked_type_params variants ?loc:_ ~atts () ->
-            Attributes.unsupported_attributes atts;
-            command_typed_vernac (Link_model.EnumDecl { path; type_params = []; linked_type_params; variants })),
+            command_typed_vernac (Link_model.EnumDecl { path; type_params; variants })),
           None );
     ]

--- a/RocqOfRust/plugin/test_inline_print.expected
+++ b/RocqOfRust/plugin/test_inline_print.expected
@@ -37,12 +37,12 @@ DebugOrdering.IsOfValue_Less =
 |}
      : OfValue.C (Value.StructTuple "core::cmp::Ordering::Less" [] [] [])
 Module DebugOrdering.SubPointer := Struct  End
-Inductive t (T : Set) : Set :=
+Inductive t (T : Set) (H_T : Link T) : Set :=
     WithValue : T -> DebugGeneric.t T | Empty : DebugGeneric.t T.
 
-Arguments DebugGeneric.t T%type_scope
-Arguments DebugGeneric.WithValue {T}%type_scope value
-Arguments DebugGeneric.Empty {T}%type_scope
+Arguments DebugGeneric.t T%type_scope {H_T}
+Arguments DebugGeneric.WithValue {T}%type_scope {H_T} value
+Arguments DebugGeneric.Empty {T}%type_scope {H_T}
 DebugGeneric.IsLink =
 fun (T : Set) (H_T : Link T) =>
 {|
@@ -57,7 +57,7 @@ fun (T : Set) (H_T : Link T) =>
         Value.StructTuple "debug::Generic::Empty" [] [H_T.(Φ _)] []
     end
 |}
-     : forall T : Set, Link T -> Link (DebugGeneric.t T)
+     : forall (T : Set) {H_T : Link T}, Link (DebugGeneric.t T)
 
 Arguments DebugGeneric.IsLink T%type_scope {H_T}
 DebugGeneric.IsOfTy =
@@ -190,13 +190,14 @@ DebugLinkedGeneric.SubPointer.get_RefValue_0
      : forall (T : Set) (H_T : Link T),
        SubPointer.Runner.t (DebugLinkedGeneric.t T)
          (Pointer.Index.StructTuple "debug::LinkedGeneric::RefValue" 0)
-Record t (T : Set) : Set := Build_t { payload : T;  flag : bool }.
+Record t (T : Set) (H_T : Link T) : Set := Build_t
+  { payload : T;  flag : bool }.
 
 t has primitive projections with eta conversion.
-Arguments DebugGenericRecord.t T%type_scope
-Arguments DebugGenericRecord.Build_t T%type_scope payload flag%bool_scope
-Arguments DebugGenericRecord.payload {T}%type_scope t
-Arguments DebugGenericRecord.flag {T}%type_scope t
+Arguments DebugGenericRecord.t T%type_scope {H_T}
+Arguments DebugGenericRecord.Build_t T%type_scope H_T payload flag%bool_scope
+Arguments DebugGenericRecord.payload {T}%type_scope {H_T} t
+Arguments DebugGenericRecord.flag {T}%type_scope {H_T} t
 DebugGenericRecord.IsLink =
 fun (T : Set) (H_T : Link T) =>
 {|
@@ -208,7 +209,7 @@ fun (T : Set) (H_T : Link T) =>
       [("flag", Bool.IsLink.(φ) x.(DebugGenericRecord.flag));
        ("payload", H_T.(φ) x.(DebugGenericRecord.payload))]
 |}
-     : forall T : Set, Link T -> Link (DebugGenericRecord.t T)
+     : forall (T : Set) {H_T : Link T}, Link (DebugGenericRecord.t T)
 
 Arguments DebugGenericRecord.IsLink T%type_scope {H_T}
 DebugGenericRecord.IsOfTy =

--- a/RocqOfRust/plugin/test_inline_print.expected
+++ b/RocqOfRust/plugin/test_inline_print.expected
@@ -112,3 +112,160 @@ DebugGeneric.SubPointer.get_WithValue_0
      : forall (T : Set) (H_T : Link T),
        SubPointer.Runner.t (DebugGeneric.t T)
          (Pointer.Index.StructTuple "debug::Generic::WithValue" 0)
+Inductive t (T : Set) (H_T : Link T) : Set :=
+    RefValue : '& T -> DebugLinkedGeneric.t T
+  | OwnedValue : T -> DebugLinkedGeneric.t T.
+
+Arguments DebugLinkedGeneric.t T%type_scope {H_T}
+Arguments DebugLinkedGeneric.RefValue {T}%type_scope {H_T} value
+Arguments DebugLinkedGeneric.OwnedValue {T}%type_scope {H_T} value
+DebugLinkedGeneric.IsLink =
+fun (T : Set) (H_T : Link T) =>
+{|
+  Φ := Ty.apply (Ty.path "debug::LinkedGeneric") [] [H_T.(Φ _)];
+  φ :=
+    fun x : DebugLinkedGeneric.t T =>
+    match x with
+    | DebugLinkedGeneric.RefValue value =>
+        Value.StructTuple "debug::LinkedGeneric::RefValue" [] [
+          H_T.(Φ _)] [Ref.IsLink.(φ) value]
+    | DebugLinkedGeneric.OwnedValue value =>
+        Value.StructTuple "debug::LinkedGeneric::OwnedValue" [] [
+          H_T.(Φ _)] [H_T.(φ) value]
+    end
+|}
+     : forall (T : Set) {H_T : Link T}, Link (DebugLinkedGeneric.t T)
+
+Arguments DebugLinkedGeneric.IsLink T%type_scope {H_T}
+DebugLinkedGeneric.IsOfTy =
+fun (T' : Ty.t) (H_T : OfTy.C T') =>
+{|
+  OfTy.A := DebugLinkedGeneric.t H_T.(OfTy.A);
+  OfTy.H := DebugLinkedGeneric.IsLink H_T.(OfTy.A);
+  OfTy.eq :=
+    ((fun (A : Set) (H : Link A) (eq0 : T' = H.(Φ _)) =>
+      EqdepFacts.internal_eq_rew_r_dep
+        (fun (T'0 : Ty.t) (eq1 : T'0 = H.(Φ _)) =>
+         Ty.apply (Ty.path "debug::LinkedGeneric") [] [T'0] =
+         (DebugLinkedGeneric.IsLink
+            {| OfTy.A := A; OfTy.H := H; OfTy.eq := eq1 |}.(OfTy.A))
+         .(Φ _))
+        ((eq_refl
+          :
+          Ty.apply (Ty.path "debug::LinkedGeneric") [] [H.(Φ _)] =
+          (DebugLinkedGeneric.IsLink
+             {| OfTy.A := A; OfTy.H := H; OfTy.eq := eq_refl |}.(OfTy.A))
+          .(Φ _))
+         :
+         Ty.apply (Ty.path "debug::LinkedGeneric") [] [H.(Φ _)] =
+         (DebugLinkedGeneric.IsLink
+            {| OfTy.A := A; OfTy.H := H; OfTy.eq := eq_refl |}.(OfTy.A))
+         .(Φ _))
+        eq0)
+       H_T.(OfTy.A) H_T.(OfTy.H) H_T.(OfTy.eq)
+     :
+     Ty.apply (Ty.path "debug::LinkedGeneric") [] [T'] =
+     (DebugLinkedGeneric.IsLink H_T.(OfTy.A)).(Φ _))
+    :
+    Ty.apply (Ty.path "debug::LinkedGeneric") [] [T'] =
+    (DebugLinkedGeneric.IsLink H_T.(OfTy.A)).(Φ _)
+|}
+     : forall T' : Ty.t,
+       OfTy.C T' ->
+       OfTy.C (Ty.apply (Ty.path "debug::LinkedGeneric") [] [T'])
+
+Arguments DebugLinkedGeneric.IsOfTy T' {H_T}
+DebugLinkedGeneric.IsOfValueWith_RefValue
+     : forall (T : Set) (H_T : Link T) (value' : Value.t),
+       OfValueWith.C ('& T) value' ->
+       OfValueWith.C (DebugLinkedGeneric.t T)
+         (Value.StructTuple "debug::LinkedGeneric::RefValue" [] [
+            H_T.(Φ _)] [value'])
+DebugLinkedGeneric.IsOfValue_RefValue
+     : forall (T' : Ty.t) (H_T : OfTy.C T') (value' : Value.t),
+       OfValueWith.C ('& H_T.(OfTy.A)) value' ->
+       OfValue.C
+         (Value.StructTuple "debug::LinkedGeneric::RefValue" [] [T'] [value'])
+DebugLinkedGeneric.SubPointer.get_RefValue_0
+     : forall (T : Set) (H_T : Link T),
+       SubPointer.Runner.t (DebugLinkedGeneric.t T)
+         (Pointer.Index.StructTuple "debug::LinkedGeneric::RefValue" 0)
+Record t (T : Set) : Set := Build_t { payload : T;  flag : bool }.
+
+t has primitive projections with eta conversion.
+Arguments DebugGenericRecord.t T%type_scope
+Arguments DebugGenericRecord.Build_t T%type_scope payload flag%bool_scope
+Arguments DebugGenericRecord.payload {T}%type_scope t
+Arguments DebugGenericRecord.flag {T}%type_scope t
+DebugGenericRecord.IsLink =
+fun (T : Set) (H_T : Link T) =>
+{|
+  Φ := Ty.apply (Ty.path "debug::GenericRecord") [] [H_T.(Φ _)];
+  φ :=
+    fun x : DebugGenericRecord.t T =>
+    Value.StructRecord "debug::GenericRecord" [] [
+      H_T.(Φ _)]
+      [("flag", Bool.IsLink.(φ) x.(DebugGenericRecord.flag));
+       ("payload", H_T.(φ) x.(DebugGenericRecord.payload))]
+|}
+     : forall T : Set, Link T -> Link (DebugGenericRecord.t T)
+
+Arguments DebugGenericRecord.IsLink T%type_scope {H_T}
+DebugGenericRecord.IsOfTy =
+fun (T' : Ty.t) (H_T : OfTy.C T') =>
+{|
+  OfTy.A := DebugGenericRecord.t H_T.(OfTy.A);
+  OfTy.H := DebugGenericRecord.IsLink H_T.(OfTy.A);
+  OfTy.eq :=
+    ((fun (A : Set) (H : Link A) (eq0 : T' = H.(Φ _)) =>
+      EqdepFacts.internal_eq_rew_r_dep
+        (fun (T'0 : Ty.t) (eq1 : T'0 = H.(Φ _)) =>
+         Ty.apply (Ty.path "debug::GenericRecord") [] [T'0] =
+         (DebugGenericRecord.IsLink
+            {| OfTy.A := A; OfTy.H := H; OfTy.eq := eq1 |}.(OfTy.A))
+         .(Φ _))
+        ((eq_refl
+          :
+          Ty.apply (Ty.path "debug::GenericRecord") [] [H.(Φ _)] =
+          (DebugGenericRecord.IsLink
+             {| OfTy.A := A; OfTy.H := H; OfTy.eq := eq_refl |}.(OfTy.A))
+          .(Φ _))
+         :
+         Ty.apply (Ty.path "debug::GenericRecord") [] [H.(Φ _)] =
+         (DebugGenericRecord.IsLink
+            {| OfTy.A := A; OfTy.H := H; OfTy.eq := eq_refl |}.(OfTy.A))
+         .(Φ _))
+        eq0)
+       H_T.(OfTy.A) H_T.(OfTy.H) H_T.(OfTy.eq)
+     :
+     Ty.apply (Ty.path "debug::GenericRecord") [] [T'] =
+     (DebugGenericRecord.IsLink H_T.(OfTy.A)).(Φ _))
+    :
+    Ty.apply (Ty.path "debug::GenericRecord") [] [T'] =
+    (DebugGenericRecord.IsLink H_T.(OfTy.A)).(Φ _)
+|}
+     : forall T' : Ty.t,
+       OfTy.C T' ->
+       OfTy.C (Ty.apply (Ty.path "debug::GenericRecord") [] [T'])
+
+Arguments DebugGenericRecord.IsOfTy T' {H_T}
+DebugGenericRecord.IsOfValueWith
+     : forall (T : Set) (H_T : Link T) (flag' : Value.t),
+       OfValueWith.C bool flag' ->
+       forall payload' : Value.t,
+       OfValueWith.C T payload' ->
+       OfValueWith.C (DebugGenericRecord.t T)
+         (Value.StructRecord "debug::GenericRecord" [] [
+            H_T.(Φ _)] [("flag", flag'); ("payload", payload')])
+DebugGenericRecord.IsOfValue
+     : forall (T' : Ty.t) (H_T : OfTy.C T') (flag' : Value.t),
+       OfValueWith.C bool flag' ->
+       forall payload' : Value.t,
+       OfValueWith.C H_T.(OfTy.A) payload' ->
+       OfValue.C
+         (Value.StructRecord "debug::GenericRecord" [] [T']
+            [("flag", flag'); ("payload", payload')])
+DebugGenericRecord.SubPointer.get_payload
+     : forall (T : Set) (H_T : Link T),
+       SubPointer.Runner.t (DebugGenericRecord.t T)
+         (Pointer.Index.StructRecord "debug::GenericRecord" "payload")

--- a/RocqOfRust/plugin/test_inline_print.v
+++ b/RocqOfRust/plugin/test_inline_print.v
@@ -30,7 +30,7 @@ Check DebugGeneric.IsOfValue_WithValue.
 Check DebugGeneric.SubPointer.get_WithValue_0.
 
 Module DebugLinkedGeneric.
-  RocqOfRustLinkLinkedGenericEnum "debug::LinkedGeneric" [ T ] :=
+  RocqOfRustLinkGenericEnum "debug::LinkedGeneric" [ T ] :=
   | RefValue (value : ('& T))
   | OwnedValue (value : T)
   .

--- a/RocqOfRust/plugin/test_inline_print.v
+++ b/RocqOfRust/plugin/test_inline_print.v
@@ -28,3 +28,31 @@ Print DebugGeneric.IsOfTy.
 Check DebugGeneric.IsOfValueWith_WithValue.
 Check DebugGeneric.IsOfValue_WithValue.
 Check DebugGeneric.SubPointer.get_WithValue_0.
+
+Module DebugLinkedGeneric.
+  RocqOfRustLinkLinkedGenericEnum "debug::LinkedGeneric" [ T ] :=
+  | RefValue (value : ('& T))
+  | OwnedValue (value : T)
+  .
+End DebugLinkedGeneric.
+
+Print DebugLinkedGeneric.t.
+Print DebugLinkedGeneric.IsLink.
+Print DebugLinkedGeneric.IsOfTy.
+Check DebugLinkedGeneric.IsOfValueWith_RefValue.
+Check DebugLinkedGeneric.IsOfValue_RefValue.
+Check DebugLinkedGeneric.SubPointer.get_RefValue_0.
+
+Module DebugGenericRecord.
+  RocqOfRustLinkGenericRecord "debug::GenericRecord" [ T ] := {
+    payload : T;
+    flag : bool
+  }.
+End DebugGenericRecord.
+
+Print DebugGenericRecord.t.
+Print DebugGenericRecord.IsLink.
+Print DebugGenericRecord.IsOfTy.
+Check DebugGenericRecord.IsOfValueWith.
+Check DebugGenericRecord.IsOfValue.
+Check DebugGenericRecord.SubPointer.get_payload.

--- a/RocqOfRust/revm/revm_context_interface/links/journaled_state.v
+++ b/RocqOfRust/revm/revm_context_interface/links/journaled_state.v
@@ -17,74 +17,10 @@ pub struct StateLoad<T> {
 }
 *)
 Module StateLoad.
-  Record t {T : Set} : Set := {
+  RocqOfRustLinkGenericRecord "revm_context_interface::journaled_state::StateLoad" [ T ] := {
     data : T;
-    is_cold : bool;
+    is_cold : bool
   }.
-  Arguments t : clear implicits.
-
-  Instance IsLink {T : Set} `{Link T} : Link (t T) := {
-    Φ := Ty.apply (Ty.path "revm_context_interface::journaled_state::StateLoad") [] [Φ T];
-    φ x :=
-      Value.StructRecord "revm_context_interface::journaled_state::StateLoad" [] [Φ T] [
-        ("data", φ x.(data));
-        ("is_cold", φ x.(is_cold))
-      ];
-  }.
-
-  Definition of_ty (T_ty : Ty.t) :
-    OfTy.t T_ty ->
-    OfTy.t (Ty.apply (Ty.path "revm_context_interface::journaled_state::StateLoad") [] [T_ty]).
-  Proof.
-    intros [T].
-    eapply OfTy.Make with (A := t T).
-    now subst.
-  Defined.
-  Smpl Add apply of_ty : of_ty.
-
-  Lemma of_value_with (T : Set) `{Link T}
-      (data : T) data'
-      (is_cold : bool) is_cold' :
-    data' = φ data ->
-    is_cold' = φ is_cold ->
-    Value.StructRecord "revm_context_interface::journaled_state::StateLoad" [] [Φ T] [
-      ("data", data');
-      ("is_cold", is_cold')
-    ] = φ (Build_t _ data is_cold).
-  Proof.
-    now intros; subst.
-  Qed.
-  Smpl Add eapply of_value_with : of_value.
-
-  Module SubPointer.
-    Definition get_data (T : Set) `{Link T} : SubPointer.Runner.t (t T)
-      (Pointer.Index.StructRecord "revm_context_interface::journaled_state::StateLoad" "data") :=
-    {|
-      SubPointer.Runner.projection x := Some x.(data);
-      SubPointer.Runner.injection x y := Some (x <| data := y |>);
-    |}.
-
-    Lemma get_data_is_valid (T : Set) `{Link T} :
-      SubPointer.Runner.Valid.t (get_data T).
-    Proof.
-      now constructor.
-    Qed.
-    Smpl Add apply get_data_is_valid : run_sub_pointer.
-
-    Definition get_is_cold (T : Set) `{Link T} : SubPointer.Runner.t (t T)
-      (Pointer.Index.StructRecord "revm_context_interface::journaled_state::StateLoad" "is_cold") :=
-    {|
-      SubPointer.Runner.projection x := Some x.(is_cold);
-      SubPointer.Runner.injection x y := Some (x <| is_cold := y |>);
-    |}.
-
-    Lemma get_is_cold_is_valid (T : Set) `{Link T} :
-      SubPointer.Runner.Valid.t (get_is_cold T).
-    Proof.
-      now constructor.
-    Qed.
-    Smpl Add apply get_is_cold_is_valid : run_sub_pointer.
-  End SubPointer.
 End StateLoad.
 Export (hints) StateLoad.
 
@@ -145,77 +81,10 @@ pub struct Eip7702CodeLoad<T> {
 }
 *)
 Module Eip7702CodeLoad.
-  Record t {T : Set} : Set := {
-    state_load : StateLoad.t T;
-    is_delegate_account_cold : option bool;
+  RocqOfRustLinkGenericRecord "revm_context_interface::journaled_state::Eip7702CodeLoad" [ T ] := {
+    state_load : (StateLoad.t T);
+    is_delegate_account_cold : (option bool)
   }.
-  Arguments t : clear implicits.
-
-  Instance IsLink {T : Set} `{Link T} : Link (t T) :=
-  {
-    Φ := Ty.apply (Ty.path "revm_context_interface::journaled_state::Eip7702CodeLoad") [] [Φ T];
-    φ x :=
-      Value.StructRecord "revm_context_interface::journaled_state::Eip7702CodeLoad" [] [Φ T] [
-        ("is_delegate_account_cold", φ x.(is_delegate_account_cold));
-        ("state_load", φ x.(state_load))
-      ];
-  }.
-
-  Definition of_ty (T_ty : Ty.t) :
-    OfTy.t T_ty ->
-    OfTy.t (Ty.apply (Ty.path "revm_context_interface::journaled_state::Eip7702CodeLoad") [] [T_ty]).
-  Proof.
-    intros [T].
-    eapply OfTy.Make with (A := t T).
-    now subst.
-  Defined.
-  Smpl Add apply of_ty : of_ty.
-
-  Lemma of_value_with
-      {T : Set} `{Link T} T'
-      (state_load : StateLoad.t T) state_load'
-      (is_delegate_account_cold : option bool) is_delegate_account_cold' :
-    T' = Φ T ->
-    state_load' = φ state_load ->
-    is_delegate_account_cold' = φ is_delegate_account_cold ->
-    Value.StructRecord "revm_context_interface::journaled_state::Eip7702CodeLoad" [] [T'] [
-      ("is_delegate_account_cold", is_delegate_account_cold');
-      ("state_load", state_load')
-    ] = φ (Build_t _ state_load is_delegate_account_cold).
-  Proof.
-    intros; now subst.
-  Qed.
-  Smpl Add apply of_value_with : of_value.
-
-  Module SubPointer.
-    Definition get_state_load (T : Set) `{Link T} : SubPointer.Runner.t (t T)
-      (Pointer.Index.StructRecord "revm_context_interface::journaled_state::Eip7702CodeLoad" "state_load") :=
-    {|
-      SubPointer.Runner.projection x := Some x.(state_load);
-      SubPointer.Runner.injection x y := Some (x <| state_load := y |>);
-    |}.
-
-    Lemma get_state_load_is_valid (T : Set) `{Link T} :
-      SubPointer.Runner.Valid.t (get_state_load T).
-    Proof.
-      now constructor.
-    Qed.
-    Smpl Add apply get_state_load_is_valid : run_sub_pointer.
-
-    Definition get_is_delegate_account_cold (T : Set) `{Link T} : SubPointer.Runner.t (t T)
-      (Pointer.Index.StructRecord "revm_context_interface::journaled_state::Eip7702CodeLoad" "is_delegate_account_cold") :=
-    {|
-      SubPointer.Runner.projection x := Some x.(is_delegate_account_cold);
-      SubPointer.Runner.injection x y := Some (x <| is_delegate_account_cold := y |>);
-    |}.
-
-    Lemma get_is_delegate_account_cold_is_valid (T : Set) `{Link T} :
-      SubPointer.Runner.Valid.t (get_is_delegate_account_cold T).
-    Proof.
-      now constructor.
-    Qed.
-    Smpl Add apply get_is_delegate_account_cold_is_valid : run_sub_pointer.
-  End SubPointer.
 End Eip7702CodeLoad.
 Export (hints) Eip7702CodeLoad.
 
@@ -307,53 +176,10 @@ End AccountLoad.
 Export (hints) AccountLoad.
 
 Module Cow.
-  Inductive t (T : Set) `{Link T} : Set :=
-  | Borrowed (_ : '& T)
-  | Owned (_ : T).
-  Arguments t _ {_}.
-  Arguments Borrowed {_ _}.
-  Arguments Owned {_ _}.
-
-  Instance IsLink {T : Set} `{Link T} : Link (t T) := {
-    Φ := Ty.apply (Ty.path "alloc::borrow::Cow") [] [Φ T];
-    φ x :=
-      match x with
-      | Borrowed value =>
-          Value.StructTuple "alloc::borrow::Cow::Borrowed" [] [Φ T] [φ value]
-      | Owned value =>
-          Value.StructTuple "alloc::borrow::Cow::Owned" [] [Φ T] [φ value]
-      end;
-  }.
-
-  Definition of_ty (T_ty : Ty.t) :
-    OfTy.t T_ty ->
-    OfTy.t (Ty.apply (Ty.path "alloc::borrow::Cow") [] [T_ty]).
-  Proof.
-    intros [T].
-    eapply OfTy.Make with (A := t T).
-    now subst.
-  Defined.
-  Smpl Add apply of_ty : of_ty.
-
-  Lemma of_value_with_Borrowed {T : Set} `{Link T} T' value' (value : '& T) :
-    T' = Φ T ->
-    value' = φ value ->
-    Value.StructTuple "alloc::borrow::Cow::Borrowed" [] [T'] [value'] =
-    φ (Borrowed value).
-  Proof.
-    now intros; subst.
-  Qed.
-  Smpl Add apply of_value_with_Borrowed : of_value.
-
-  Lemma of_value_with_Owned {T : Set} `{Link T} T' value' (value : T) :
-    T' = Φ T ->
-    value' = φ value ->
-    Value.StructTuple "alloc::borrow::Cow::Owned" [] [T'] [value'] =
-    φ (Owned value).
-  Proof.
-    now intros; subst.
-  Qed.
-  Smpl Add apply of_value_with_Owned : of_value.
+  RocqOfRustLinkLinkedGenericEnum "alloc::borrow::Cow" [ T ] :=
+  | Borrowed (value : ('& T))
+  | Owned (value : T)
+  .
 End Cow.
 Export (hints) Cow.
 

--- a/RocqOfRust/revm/revm_context_interface/links/journaled_state.v
+++ b/RocqOfRust/revm/revm_context_interface/links/journaled_state.v
@@ -29,7 +29,7 @@ impl<T> Deref for StateLoad<T> {
     type Target = T;
 *)
 Module Impl_Deref_for_StateLoad.
-  Definition Self (T : Set) : Set :=
+  Definition Self (T : Set) `{Link T} : Set :=
     StateLoad.t T.
 
   Instance run_deref (T : Set) `{Link T} (self : '& (Self T)) :
@@ -59,7 +59,7 @@ End Impl_Deref_for_StateLoad.
 Export (hints) Impl_Deref_for_StateLoad.
 
 Module Impl_StateLoad.
-  Definition Self (T : Set) : Set :=
+  Definition Self (T : Set) `{Link T} : Set :=
     StateLoad.t T.
 
   Instance run_new (T : Set) `{Link T} (data : T) (is_cold : bool) :
@@ -176,7 +176,7 @@ End AccountLoad.
 Export (hints) AccountLoad.
 
 Module Cow.
-  RocqOfRustLinkLinkedGenericEnum "alloc::borrow::Cow" [ T ] :=
+  RocqOfRustLinkGenericEnum "alloc::borrow::Cow" [ T ] :=
   | Borrowed (value : ('& T))
   | Owned (value : T)
   .

--- a/RocqOfRust/revm/revm_context_interface/simulate/host.v
+++ b/RocqOfRust/revm/revm_context_interface/simulate/host.v
@@ -1,4 +1,5 @@
 Require Import simulate.RocqOfRust.
+Require Import alloy_primitives.bits.links.fixed_FixedBytes.
 Require Import alloy_primitives.bits.links.address.
 Require Import alloy_primitives.bytes.links.mod.
 Require Import alloy_primitives.links.aliases.

--- a/RocqOfRust/revm/revm_context_interface/simulate/journaled_state.v
+++ b/RocqOfRust/revm/revm_context_interface/simulate/journaled_state.v
@@ -6,7 +6,7 @@ Require Import alloy_primitives.links.aliases.
 Require Import revm.revm_context_interface.links.journaled_state.
 
 Module Impl_Deref_for_StateLoad.
-  Definition Self (T : Set) : Set :=
+  Definition Self (T : Set) `{Link T} : Set :=
     StateLoad.t T.
 
   Definition deref {T : Set} `{Link T} : RefStub.t (Self T) T := {|
@@ -49,10 +49,10 @@ End Impl_Deref_for_StateLoad.
 Export (hints) Impl_Deref_for_StateLoad.
 
 Module Impl_Eip7702CodeLoad.
-  Definition Self (T : Set) : Set :=
+  Definition Self (T : Set) `{Link T} : Set :=
     Eip7702CodeLoad.t T.
 
-  Definition into_components {T : Set} (self : Self T) : T * Self unit :=
+  Definition into_components {T : Set} `{Link T} (self : Self T) : T * Self unit :=
     (
       self.(Eip7702CodeLoad.state_load).(StateLoad.data),
       {|

--- a/RocqOfRust/ruint/simulate/from.v
+++ b/RocqOfRust/ruint/simulate/from.v
@@ -7,7 +7,7 @@ Require Import ruint.links.lib.
 Require Import ruint.simulate.lib.
 
 Module UintTryFrom.
-  Class C (Self T : Set) : Set := {
+  Class C (Self T : Set) `{Link Self} : Set := {
     uint_try_from (value : T) : Result.t Self (ToUintError.t Self);
   }.
 
@@ -19,10 +19,10 @@ Module UintTryFrom.
       uint_try_from_eq (value : T) (stack : Stack.t) :
         {{
           SimulateM.eval_f
-            (UintTryFrom.run_uint_try_from value)
+            (UintTryFrom.run_uint_try_from (Self := Self) (T := T) value)
             stack 🌲
           (
-            Output.Success (uint_try_from value),
+            Output.Success (UintTryFrom.uint_try_from (Self := Self) (T := T) value),
             stack
           )
         }};
@@ -85,7 +85,7 @@ Module Impl_Uint.
   Definition from {BITS LIMBS : usize} {T : Set} `{!UintTryFrom.C (Self BITS LIMBS) T}
       (value : T) :
       Self BITS LIMBS :=
-    match UintTryFrom.uint_try_from value with
+    match UintTryFrom.uint_try_from (Self := Self BITS LIMBS) (T := T) value with
     | Result.Ok n => n
     | Result.Err e => Impl_Uint.ZERO
     end.
@@ -96,7 +96,7 @@ Module Impl_Uint.
       `{H_TryFrom : !UintTryFrom.Eq.C I_TryFrom}
       (value : T) (stack : Stack.t)
       (H_success :
-        match UintTryFrom.uint_try_from value with
+        match UintTryFrom.uint_try_from (Self := Self BITS LIMBS) (T := T) value with
         | Result.Ok _ => True
         | Result.Err _ => False
         end


### PR DESCRIPTION
Adds generic record and linked generic enum support to the links plugin, then migrates journaled-state StateLoad, Eip7702CodeLoad, and Cow to use it.