### PR TITLE
Add tuple link plugin support

### DIFF
--- a/RocqOfRust/plugin/link_model.ml
+++ b/RocqOfRust/plugin/link_model.ml
@@ -17,6 +17,11 @@ type variant = {
   payload : variant_payload;
 }
 
+type record_layout =
+  | StructRecord of string
+  | StructTuple of string
+  | Tuple
+
 type command =
   | EnumDecl of {
       path : string;
@@ -24,7 +29,7 @@ type command =
       variants : variant list;
     }
   | RecordDecl of {
-      path : string;
+      layout : record_layout;
       type_params : string list;
       fields : field list;
     }

--- a/RocqOfRust/plugin/link_render.ml
+++ b/RocqOfRust/plugin/link_render.ml
@@ -31,6 +31,15 @@ let path_ty_with_args (path : string) (args : string list) : string =
   | [] -> path_ty path
   | _ -> "Ty.apply (" ^ path_ty path ^ ") [] " ^ ty_args args
 
+let tuple_ty (fields : field list) : string =
+  "Ty.tuple " ^ ty_args (List.map (fun field -> "Φ (" ^ field.field_ty ^ ")") fields)
+
+let layout_ty (layout : record_layout) (type_params : string list) (fields : field list) : string =
+  match layout with
+  | StructRecord path | StructTuple path ->
+      path_ty_with_args path (List.map (fun param -> "Φ " ^ param) type_params)
+  | Tuple -> tuple_ty fields
+
 let type_param_binders (type_params : string list) : string =
   String.concat " " (List.map (fun param -> "(" ^ param ^ " : Set)") type_params)
 
@@ -189,6 +198,32 @@ let render_record_value
          fields)
   @ [ "]" ]
 
+let render_struct_tuple_value
+    ?(type_args = "[]") (path : string) (fields : field list) (value_of : field -> string) : string list =
+  [ "Value.StructTuple " ^ quote path ^ " [] " ^ type_args ^ " [" ]
+  @ indent "  "
+      (semicolon_list value_of fields)
+  @ [ "]" ]
+
+let render_tuple_value (fields : field list) (value_of : field -> string) : string list =
+  [ "Value.Tuple [" ]
+  @ indent "  "
+      (semicolon_list value_of fields)
+  @ [ "]" ]
+
+let render_link_value
+    ?(type_args = "[]")
+    (layout : record_layout)
+    (fields : field list)
+    (value_of : field -> string) : string list =
+  match layout with
+  | StructRecord path ->
+      render_record_value ~type_args path (sorted_fields fields) value_of
+  | StructTuple path ->
+      render_struct_tuple_value ~type_args path fields value_of
+  | Tuple ->
+      render_tuple_value fields value_of
+
 (* StructRecord values are rendered in sorted field-name order to keep the
    generated value shape stable across plugin migrations. *)
 let render_variant_value (path : string) (type_params : string list) (variant : variant) : string =
@@ -227,7 +262,7 @@ let render_enum_link (path : string) (type_params : string list) (variants : var
   @ [ "    end";
       "}." ]
 
-let render_record_link (path : string) (type_params : string list) (fields : field list) : string list =
+let render_record_link (layout : record_layout) (type_params : string list) (fields : field list) : string list =
   let instance_head =
     match type_params with
     | [] -> "Instance IsLink : Link t := {"
@@ -237,10 +272,10 @@ let render_record_link (path : string) (type_params : string list) (fields : fie
         ^ " : Link " ^ type_app type_params ^ " := {"
   in
   [ instance_head;
-    "  Φ := " ^ path_ty_with_args path (List.map (fun param -> "Φ " ^ param) type_params) ^ ";";
+    "  Φ := " ^ layout_ty layout type_params fields ^ ";";
     "  φ x :=" ]
   @ indent "    "
-      (render_record_value ~type_args:(type_param_ty_args type_params) path (sorted_fields fields)
+      (render_link_value ~type_args:(type_param_ty_args type_params) layout fields
          (fun field -> "φ x.(" ^ field.field_name ^ ")"))
   @ [ "}." ]
 
@@ -289,9 +324,13 @@ let render_enum_inductive_of_ty (path : string) (type_params : string list) : st
         ^ "); subst; reflexivity).";
         "Smpl Add eapply of_ty : of_ty." ]
 
-let render_type_of_ty (path : string) (type_params : string list) : string list =
+let render_type_of_ty (layout : record_layout) (type_params : string list) (fields : field list) : string list =
   match type_params with
-  | [] -> render_of_ty path
+  | [] ->
+      [ "Instance IsOfTy : OfTy.C (" ^ layout_ty layout type_params fields ^ ") := {";
+        "  A := t;";
+        "  eq := eq_refl;";
+        "}." ]
   | _ ->
       let params =
         List.map
@@ -301,13 +340,17 @@ let render_type_of_ty (path : string) (type_params : string list) : string list 
       [ "Instance IsOfTy" ]
       @ List.map (fun param -> "    " ^ param) params
       @ [ "    : OfTy.C ("
-          ^ path_ty_with_args path (List.map (fun param -> param ^ "'") type_params)
+          ^ (match layout with
+             | StructRecord path | StructTuple path ->
+                 path_ty_with_args path (List.map (fun param -> param ^ "'") type_params)
+             | Tuple ->
+                 tuple_ty fields)
           ^ ") := {";
           "  A := " ^ type_app_of_ty type_params ^ ";";
           "  eq := ltac:(sauto lq: on);";
           "}." ]
 
-let render_type_inductive_of_ty (path : string) (type_params : string list) : string list =
+let render_type_inductive_of_ty (layout : record_layout) (type_params : string list) (fields : field list) : string list =
   match type_params with
   | [] -> []
   | _ ->
@@ -320,7 +363,11 @@ let render_type_inductive_of_ty (path : string) (type_params : string list) : st
                (fun param -> "OfTy.t " ^ param)
                ty_params
              @ [ "OfTy.t ("
-                 ^ path_ty_with_args path ty_params
+                 ^ (match layout with
+                    | StructRecord path | StructTuple path ->
+                        path_ty_with_args path ty_params
+                    | Tuple ->
+                        tuple_ty fields)
                  ^ ")" ])
         ^ " :=";
         "  ltac:(intros " ^ String.concat " " intros
@@ -341,14 +388,18 @@ let render_instance_params ?(type_params = []) ?(use_of_ty = false) (fields : fi
       ^ " : OfValueWith.C (" ^ field_ty ^ ") " ^ field.field_name ^ "'}")
     fields
 
-let render_value_fields ?(type_args = "[]") (path : string) (fields : field list) : string list =
-  render_record_value ~type_args path fields (fun (field : field) -> field.field_name ^ "'")
+let render_value_fields ?(type_args = "[]") (layout : record_layout) (fields : field list) : string list =
+  render_link_value ~type_args layout fields (fun (field : field) -> field.field_name ^ "'")
 
 (* Record constructors still receive fields in declaration order; only the
    StructRecord value used for matching is sorted. *)
 let render_record_of_value
-    (kind : [ `Plain | `With ]) (path : string) (type_params : string list) (fields : field list) : string list =
-  let sorted = sorted_fields fields in
+    (kind : [ `Plain | `With ]) (layout : record_layout) (type_params : string list) (fields : field list) : string list =
+  let value_fields =
+    match layout with
+    | StructRecord _ -> sorted_fields fields
+    | StructTuple _ | Tuple -> fields
+  in
   let head =
     match kind with
     | `With -> "Instance IsOfValueWith"
@@ -397,10 +448,10 @@ let render_record_of_value
   in
   [ head ]
   @ params
-  @ render_instance_params ~type_params ~use_of_ty:(kind = `Plain) sorted
+  @ render_instance_params ~type_params ~use_of_ty:(kind = `Plain) value_fields
   @ [ "    :";
       "  " ^ class_head ^ " (" ]
-  @ indent "    " (render_value_fields ~type_args path sorted)
+  @ indent "    " (render_value_fields ~type_args layout value_fields)
   @ [ "  ) := {" ]
   @ of_value_body_prefix
   @ [ "  value := " ^ constructor ]
@@ -477,7 +528,8 @@ let render_enum_of_value
         [ "Value.StructTuple " ^ quote vpath ^ " [] " ^ type_args ^ " ["
           ^ String.concat "; " (List.map (fun (field : field) -> field.field_name ^ "'") fields)
           ^ "]" ]
-    | RecordPayload fields -> render_value_fields ~type_args vpath (sorted_fields fields)
+    | RecordPayload fields -> render_record_value ~type_args vpath (sorted_fields fields)
+                                (fun (field : field) -> field.field_name ^ "'")
   in
   if fields = [] then
     [ head ]
@@ -505,7 +557,7 @@ let render_enum_of_value
 (* SubPointer proofs are emitted as proof terms with ltac:(...), because the
    plugin interprets complete vernacular sentences rather than entering proof
    mode for generated tactic commands. *)
-let render_record_subpointer (path : string) (type_params : string list) (field : field) : string list =
+let render_record_subpointer (layout : record_layout) (type_params : string list) (index : int) (field : field) : string list =
   let get = "get_" ^ field.field_name in
   let definition_head =
     match type_params with
@@ -528,8 +580,17 @@ let render_record_subpointer (path : string) (type_params : string list) (field 
         ^ type_param_set_link_binders type_params
         ^ " :"
   in
+  let index_expr =
+    match layout with
+    | StructRecord path ->
+        "Pointer.Index.StructRecord " ^ quote path ^ " " ^ quote field.field_name
+    | StructTuple path ->
+        "Pointer.Index.StructTuple " ^ quote path ^ " " ^ string_of_int index
+    | Tuple ->
+        "Pointer.Index.Tuple " ^ string_of_int index
+  in
   [ definition_head;
-    "  (Pointer.Index.StructRecord " ^ quote path ^ " " ^ quote field.field_name ^ ") :=";
+    "  (" ^ index_expr ^ ") :=";
     "{|";
     "  SubPointer.Runner.projection x := Datatypes.Some x.(" ^ field.field_name ^ ");";
     "  SubPointer.Runner.injection x y := Datatypes.Some (x <| " ^ field.field_name ^ " := y |>);";
@@ -625,25 +686,25 @@ let render_subpointer_module (body : string list) : string list =
 
 (* Top-level renderers validate first so all downstream functions can assume a
    well-formed declaration. *)
-let render_record (path : string) (type_params : string list) (fields : field list) : string list =
-  validate (RecordDecl { path; type_params; fields });
+let render_record (layout : record_layout) (type_params : string list) (fields : field list) : string list =
+  validate (RecordDecl { layout; type_params; fields });
   render_record_decl type_params fields
   @ [ "" ]
-  @ render_record_link path type_params fields
+  @ render_record_link layout type_params fields
   @ [ "" ]
-  @ render_type_of_ty path type_params
+  @ render_type_of_ty layout type_params fields
   @ [ "" ]
-  @ render_type_inductive_of_ty path type_params
+  @ render_type_inductive_of_ty layout type_params fields
   @ [ "" ]
-  @ render_record_of_value `With path type_params fields
+  @ render_record_of_value `With layout type_params fields
   @ [ "" ]
-  @ render_record_of_value `Plain path type_params fields
+  @ render_record_of_value `Plain layout type_params fields
   @ [ "" ]
   @ render_subpointer_module
       (List.concat
          (List.mapi
             (fun i field ->
-              let lines = render_record_subpointer path type_params field in
+              let lines = render_record_subpointer layout type_params i field in
               if i = List.length fields - 1 then lines else lines @ [ "" ])
             fields))
 
@@ -682,5 +743,5 @@ let render_enum (path : string) (type_params : string list) (variants : variant 
 
 let render (command : command) : string list =
   match command with
-  | RecordDecl { path; type_params; fields } -> render_record path type_params fields
+  | RecordDecl { layout; type_params; fields } -> render_record layout type_params fields
   | EnumDecl { path; type_params; variants } -> render_enum path type_params variants

--- a/RocqOfRust/plugin/rocqofrust_link_plugin.ml
+++ b/RocqOfRust/plugin/rocqofrust_link_plugin.ml
@@ -336,7 +336,65 @@ let () : unit =
                               Vernacextend.TyTerminal ("}", Vernacextend.TyNil) ) ) ) ) ),
           (fun path fields ?loc:_ ~atts () ->
             Attributes.unsupported_attributes atts;
-            command_typed_vernac (Link_model.RecordDecl { path; type_params = []; fields })),
+            command_typed_vernac
+              (Link_model.RecordDecl
+                 { layout = Link_model.StructRecord path; type_params = []; fields })),
+          None );
+    ]
+
+(* Rust tuple-struct command.  This handles structs such as [OpCode(u8)] whose
+   link type has a path but whose value uses [Value.StructTuple]. *)
+let () : unit =
+  Vernacextend.static_vernac_extend
+    ~plugin:(Some plugin_name)
+    ~command:"RocqOfRustLinkTupleStruct"
+    ~classifier:(fun _ -> Vernacextend.classify_as_sideeff)
+    [
+      Vernacextend.TyML
+        ( false,
+          Vernacextend.TyTerminal
+            ( "RocqOfRustLinkTupleStruct",
+              Vernacextend.TyNonTerminal
+                ( Extend.TUentry (Genarg.get_arg_tag wit_string),
+                  Vernacextend.TyTerminal
+                    ( ":=",
+                      Vernacextend.TyTerminal
+                        ( "{",
+                          Vernacextend.TyNonTerminal
+                            ( Extend.TUentry (Genarg.get_arg_tag wit_link_fields),
+                              Vernacextend.TyTerminal ("}", Vernacextend.TyNil) ) ) ) ) ),
+          (fun path fields ?loc:_ ~atts () ->
+            Attributes.unsupported_attributes atts;
+            command_typed_vernac
+              (Link_model.RecordDecl
+                 { layout = Link_model.StructTuple path; type_params = []; fields })),
+          None );
+    ]
+
+(* Plain tuple-value command.  This handles helper records whose link type is a
+   [Ty.tuple] and whose values are [Value.Tuple], without a Rust path. *)
+let () : unit =
+  Vernacextend.static_vernac_extend
+    ~plugin:(Some plugin_name)
+    ~command:"RocqOfRustLinkTupleRecord"
+    ~classifier:(fun _ -> Vernacextend.classify_as_sideeff)
+    [
+      Vernacextend.TyML
+        ( false,
+          Vernacextend.TyTerminal
+            ( "RocqOfRustLinkTupleRecord",
+              Vernacextend.TyTerminal
+                ( ":=",
+                  Vernacextend.TyTerminal
+                    ( "{",
+                      Vernacextend.TyNonTerminal
+                        ( Extend.TUentry (Genarg.get_arg_tag wit_link_fields),
+                          Vernacextend.TyTerminal ("}", Vernacextend.TyNil) ) ) ) ),
+          (fun fields ?loc:_ ~atts () ->
+            Attributes.unsupported_attributes atts;
+            command_typed_vernac
+              (Link_model.RecordDecl
+                 { layout = Link_model.Tuple; type_params = []; fields })),
           None );
     ]
 
@@ -366,7 +424,9 @@ let () : unit =
                                   Vernacextend.TyTerminal ("}", Vernacextend.TyNil) ) ) ) ) ) ),
           (fun path type_params fields ?loc:_ ~atts () ->
             Attributes.unsupported_attributes atts;
-            command_typed_vernac (Link_model.RecordDecl { path; type_params; fields })),
+            command_typed_vernac
+              (Link_model.RecordDecl
+                 { layout = Link_model.StructRecord path; type_params; fields })),
           None );
     ]
 

--- a/RocqOfRust/plugin/test_inline_print.expected
+++ b/RocqOfRust/plugin/test_inline_print.expected
@@ -270,3 +270,72 @@ DebugGenericRecord.SubPointer.get_payload
      : forall (T : Set) (H_T : Link T),
        SubPointer.Runner.t (DebugGenericRecord.t T)
          (Pointer.Index.StructRecord "debug::GenericRecord" "payload")
+Record t : Set := Build_t { value : u8 }.
+
+t has primitive projections with eta conversion.
+Arguments DebugTupleStruct.Build_t value
+Arguments DebugTupleStruct.value t
+DebugTupleStruct.IsLink =
+{|
+  Φ := Ty.path "debug::TupleStruct";
+  φ :=
+    fun x : DebugTupleStruct.t =>
+    Value.StructTuple "debug::TupleStruct" [] []
+      [Integer.IsLink.(φ) x.(DebugTupleStruct.value)]
+|}
+     : Link DebugTupleStruct.t
+DebugTupleStruct.IsOfTy =
+{|
+  OfTy.A := DebugTupleStruct.t;
+  OfTy.H := DebugTupleStruct.IsLink;
+  OfTy.eq := eq_refl
+|}
+     : OfTy.C (Ty.path "debug::TupleStruct")
+DebugTupleStruct.IsOfValueWith
+     : forall value' : Value.t,
+       OfValueWith.C u8 value' ->
+       OfValueWith.C DebugTupleStruct.t
+         (Value.StructTuple "debug::TupleStruct" [] [] [value'])
+DebugTupleStruct.IsOfValue
+     : forall value' : Value.t,
+       OfValueWith.C u8 value' ->
+       OfValue.C (Value.StructTuple "debug::TupleStruct" [] [] [value'])
+DebugTupleStruct.SubPointer.get_value
+     : SubPointer.Runner.t DebugTupleStruct.t
+         (Pointer.Index.StructTuple "debug::TupleStruct" 0)
+Record t : Set := Build_t { left : u64;  right : bool }.
+
+t has primitive projections with eta conversion.
+Arguments DebugTupleRecord.Build_t left right%bool_scope
+Arguments DebugTupleRecord.left t
+Arguments DebugTupleRecord.right t
+DebugTupleRecord.IsLink =
+{|
+  Φ := Ty.tuple [Integer.IsLink.(Φ _); Bool.IsLink.(Φ _)];
+  φ :=
+    fun x : DebugTupleRecord.t =>
+    Value.Tuple
+      [Integer.IsLink.(φ) x.(DebugTupleRecord.left);
+       Bool.IsLink.(φ) x.(DebugTupleRecord.right)]
+|}
+     : Link DebugTupleRecord.t
+DebugTupleRecord.IsOfTy =
+{|
+  OfTy.A := DebugTupleRecord.t;
+  OfTy.H := DebugTupleRecord.IsLink;
+  OfTy.eq := eq_refl
+|}
+     : OfTy.C (Ty.tuple [Integer.IsLink.(Φ _); Bool.IsLink.(Φ _)])
+DebugTupleRecord.IsOfValueWith
+     : forall left' : Value.t,
+       OfValueWith.C u64 left' ->
+       forall right' : Value.t,
+       OfValueWith.C bool right' ->
+       OfValueWith.C DebugTupleRecord.t (Value.Tuple [left'; right'])
+DebugTupleRecord.IsOfValue
+     : forall left' : Value.t,
+       OfValueWith.C u64 left' ->
+       forall right' : Value.t,
+       OfValueWith.C bool right' -> OfValue.C (Value.Tuple [left'; right'])
+DebugTupleRecord.SubPointer.get_left
+     : SubPointer.Runner.t DebugTupleRecord.t (Pointer.Index.Tuple 0)

--- a/RocqOfRust/plugin/test_inline_print.v
+++ b/RocqOfRust/plugin/test_inline_print.v
@@ -56,3 +56,30 @@ Print DebugGenericRecord.IsOfTy.
 Check DebugGenericRecord.IsOfValueWith.
 Check DebugGenericRecord.IsOfValue.
 Check DebugGenericRecord.SubPointer.get_payload.
+
+Module DebugTupleStruct.
+  RocqOfRustLinkTupleStruct "debug::TupleStruct" := {
+    value : u8
+  }.
+End DebugTupleStruct.
+
+Print DebugTupleStruct.t.
+Print DebugTupleStruct.IsLink.
+Print DebugTupleStruct.IsOfTy.
+Check DebugTupleStruct.IsOfValueWith.
+Check DebugTupleStruct.IsOfValue.
+Check DebugTupleStruct.SubPointer.get_value.
+
+Module DebugTupleRecord.
+  RocqOfRustLinkTupleRecord := {
+    left : u64;
+    right : bool
+  }.
+End DebugTupleRecord.
+
+Print DebugTupleRecord.t.
+Print DebugTupleRecord.IsLink.
+Print DebugTupleRecord.IsOfTy.
+Check DebugTupleRecord.IsOfValueWith.
+Check DebugTupleRecord.IsOfValue.
+Check DebugTupleRecord.SubPointer.get_left.

--- a/RocqOfRust/revm/revm_bytecode/links/opcode.v
+++ b/RocqOfRust/revm/revm_bytecode/links/opcode.v
@@ -3,47 +3,12 @@ Require Import revm.revm_bytecode.opcode.
 
 (* pub struct OpCode(u8); *)
 Module OpCode.
-  Record t : Set := {
-    value : u8;
+  RocqOfRustLinkTupleStruct "revm_bytecode::opcode::OpCode" := {
+    value : u8
   }.
-
-  Global Instance IsLink : Link t := {
-    Φ := Ty.path "revm_bytecode::opcode::OpCode";
-    φ x := Value.StructTuple "revm_bytecode::opcode::OpCode" [] [] [φ x.(value)];
-  }.
-
-  Definition of_ty : OfTy.t (Ty.path "revm_bytecode::opcode::OpCode").
-  Proof. eapply OfTy.Make with (A := t); reflexivity. Defined.
-  Smpl Add apply of_ty : of_ty.
-
-  Lemma of_value_with value value' :
-    value' = φ value ->
-    Value.StructTuple "revm_bytecode::opcode::OpCode" [] [] [value'] = φ (Build_t value).
-  Proof. now intros; subst. Qed.
-  Smpl Add apply of_value_with : of_value.
-
-  Definition of_value (value : u8) value' :
-    value' = φ value ->
-    OfValue.t (Value.StructTuple "revm_bytecode::opcode::OpCode" [] [] [value']).
-  Proof. econstructor; apply of_value_with; eassumption. Defined.
-  Smpl Add eapply of_value : of_value.
-
-  Module SubPointer.
-    Definition get_value : SubPointer.Runner.t t
-      (Pointer.Index.StructTuple "revm_bytecode::opcode::OpCode" 0) :=
-    {|
-      SubPointer.Runner.projection x := Some x.(value);
-      SubPointer.Runner.injection x y := Some (x <| value := y |>);
-    |}.
-
-    Lemma get_value_is_valid :
-      SubPointer.Runner.Valid.t get_value.
-    Proof.
-      now constructor.
-    Qed.
-    Smpl Add apply get_value_is_valid : run_sub_pointer.
-  End SubPointer.
 End OpCode.
+Export (hints) OpCode.
+#[export] Existing Instance OpCode.IsLink.
 
 Module Impl_OpCode.
   Instance run_STOP :

--- a/RocqOfRust/revm/revm_interpreter/instructions/contract/links/call_helpers.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/contract/links/call_helpers.v
@@ -25,69 +25,14 @@ Require Import ruint.links.lib.
 #[export] Existing Instance FixedBytes.IsLink.
 
 Module LoadAccAndCalcGasResult.
-  Record t : Set := {
+  RocqOfRustLinkTupleRecord := {
     gas_limit : u64;
     bytecode : Bytecode.t;
-    bytecode_hash : aliases.B256.t;
+    bytecode_hash : aliases.B256.t
   }.
-
-  Global Instance IsLink : Link t := {
-    Φ := Ty.tuple [
-      Φ u64;
-      Φ Bytecode.t;
-      Φ aliases.B256.t
-    ];
-    φ x := Value.Tuple [
-      φ x.(gas_limit);
-      φ x.(bytecode);
-      φ x.(bytecode_hash)
-    ];
-  }.
-
-  Definition of_ty :
-    OfTy.t (Ty.tuple [
-      Φ u64;
-      Φ Bytecode.t;
-      Φ aliases.B256.t
-    ]).
-  Proof. eapply OfTy.Make with (A := t); reflexivity. Defined.
-  Smpl Add apply of_ty : of_ty.
-
-  Module SubPointer.
-    Definition get_gas_limit : SubPointer.Runner.t t (Pointer.Index.Tuple 0) :=
-    {|
-      SubPointer.Runner.projection x := Some x.(gas_limit);
-      SubPointer.Runner.injection x y := Some (x <| gas_limit := y |>);
-    |}.
-
-    Lemma get_gas_limit_is_valid :
-      SubPointer.Runner.Valid.t get_gas_limit.
-    Proof. now constructor. Qed.
-    Smpl Add apply get_gas_limit_is_valid : run_sub_pointer.
-
-    Definition get_bytecode : SubPointer.Runner.t t (Pointer.Index.Tuple 1) :=
-    {|
-      SubPointer.Runner.projection x := Some x.(bytecode);
-      SubPointer.Runner.injection x y := Some (x <| bytecode := y |>);
-    |}.
-
-    Lemma get_bytecode_is_valid :
-      SubPointer.Runner.Valid.t get_bytecode.
-    Proof. now constructor. Qed.
-    Smpl Add apply get_bytecode_is_valid : run_sub_pointer.
-
-    Definition get_bytecode_hash : SubPointer.Runner.t t (Pointer.Index.Tuple 2) :=
-    {|
-      SubPointer.Runner.projection x := Some x.(bytecode_hash);
-      SubPointer.Runner.injection x y := Some (x <| bytecode_hash := y |>);
-    |}.
-
-    Lemma get_bytecode_hash_is_valid :
-      SubPointer.Runner.Valid.t get_bytecode_hash.
-    Proof. now constructor. Qed.
-    Smpl Add apply get_bytecode_hash_is_valid : run_sub_pointer.
-  End SubPointer.
 End LoadAccAndCalcGasResult.
+Export (hints) LoadAccAndCalcGasResult.
+#[export] Existing Instance LoadAccAndCalcGasResult.IsLink.
 
 (*
 pub fn resize_memory(


### PR DESCRIPTION
Adds tuple-struct and tuple-record support to the links plugin, then migrates OpCode and LoadAccAndCalcGasResult to use it.