### PR TITLE
Use links plugin for remaining alloy link types

### DIFF
--- a/RocqOfRust/alloy_primitives/links/common.v
+++ b/RocqOfRust/alloy_primitives/links/common.v
@@ -9,21 +9,9 @@ pub enum TxKind {
 }
 *)
 Module TxKind.
-  Inductive t : Set :=
+  RocqOfRustLinkEnum "alloy_primitives::common::TxKind" :=
   | Create
-  | Call (address : Address.t).
-
-  Instance IsLink : Link t := {
-    Φ := Ty.path "alloy_primitives::common::TxKind";
-    φ x :=
-      match x with
-      | Create => Value.StructTuple "alloy_primitives::common::TxKind::Create" [] [] []
-      | Call address => Value.StructTuple "alloy_primitives::common::TxKind::Call" [] [] [φ address]
-      end;
-  }.
-
-  Definition of_ty : OfTy.t (Ty.path "alloy_primitives::common::TxKind").
-  Proof. eapply OfTy.Make with (A := t); reflexivity. Defined.
-  Smpl Add apply of_ty : of_ty.
+  | Call (address : Address.t)
+  .
 End TxKind.
 Export (hints) TxKind.

--- a/RocqOfRust/alloy_primitives/log/links/mod.v
+++ b/RocqOfRust/alloy_primitives/log/links/mod.v
@@ -15,49 +15,11 @@ pub struct Log<T = LogData> {
     pub data: T,
 }
 *)
-(* Note: Log<T> is polymorphic, kept manually for now *)
 Module Log.
-  Record t {T : Set} : Set := {
+  RocqOfRustLinkGenericRecord "alloy_primitives::log::Log" [ T ] := {
     address : Address.t;
-    data : T;
+    data : T
   }.
-  Arguments t : clear implicits.
-
-  Instance IsLink (T : Set) `{Link T}: Link (t T) := {
-    Φ := Ty.apply (Ty.path "alloy_primitives::log::Log") [] [Φ T];
-    φ x :=
-      Value.StructRecord "alloy_primitives::log::Log" [] [Φ T] [
-        ("address", φ x.(address));
-        ("data", φ x.(data))
-      ];
-  }.
-
-  Definition of_ty T' :
-    OfTy.t T' ->
-    OfTy.t (Ty.apply (Ty.path "alloy_primitives::log::Log") [] [T']).
-  Proof.
-    intros [T].
-    eapply OfTy.Make with (A := t T).
-    now subst.
-  Defined.
-  Smpl Add unshelve eapply of_ty : of_ty.
-
-  Lemma of_value_with
-      (T : Set) `{Link T} T'
-      address address'
-      (data : T) data' :
-    T' = Φ T ->
-    address' = φ address ->
-    data' = φ data ->
-    Value.StructRecord "alloy_primitives::log::Log" [] [T'] [
-      ("address", address');
-      ("data", data')
-    ] = φ (Build_t T address data).
-  Proof.
-    intros.
-    now subst.
-  Qed.
-  Smpl Add unshelve eapply of_value_with : of_value.
 End Log.
 Export (hints) Log.
 


### PR DESCRIPTION
Migrates the remaining simple alloy link types, Log<T> and TxKind, to the links plugin.