### PR TITLE
Use links plugin for v103 journaled state AccountLoad

### DIFF
--- a/RocqOfRust/revm/revm_context_interface/links/host.v
+++ b/RocqOfRust/revm/revm_context_interface/links/host.v
@@ -55,7 +55,7 @@ Export (hints) SelfDestructResult.
 
 (*
 pub trait Host: TransactionGetter + BlockGetter + CfgGetter {
-    fn load_account_delegated(&mut self, address: Address) -> Option<AccountLoad>;
+    fn load_account_delegated(&mut self, address: Address) -> Option<StateLoad<AccountLoad>>;
     fn block_hash(&mut self, number: u64) -> Option<B256>;
     fn max_initcode_size(&self) -> usize;
     fn beneficiary(&self) -> Address;
@@ -156,12 +156,14 @@ Module Host.
         (Result.t AccountInfoLoad.t LoadError.t);
   }.
 
-  (* fn load_account_delegated(&mut self, address: Address) -> Option<AccountLoad>; *)
+  (* fn load_account_delegated(&mut self, address: Address) -> Option<StateLoad<AccountLoad>>; *)
   Class Method_load_account_delegated (Self : Set) `{Link Self} : Set := {
     load_account_delegated : PolymorphicFunction.t;
     load_account_delegated_is_method :: IsTraitMethod.C (trait Self) "load_account_delegated" load_account_delegated;
     run_load_account_delegated (self : '&mut Self) (address : Address.t) ::
-      Run.Trait load_account_delegated [] [] [ φ self; φ address ] (option AccountLoad.t);
+      Run.Trait
+        load_account_delegated [] [] [ φ self; φ address ]
+        (option (StateLoad.t AccountLoad.t));
   }.
 
   (* fn load_account_code(&mut self, address: Address) -> Option<StateLoad<Bytes>>; *)

--- a/RocqOfRust/revm/revm_context_interface/links/journaled_state.v
+++ b/RocqOfRust/revm/revm_context_interface/links/journaled_state.v
@@ -90,90 +90,15 @@ Export (hints) Eip7702CodeLoad.
 
 (*
 pub struct AccountLoad {
-    pub load: Eip7702CodeLoad<()>,
+    pub is_delegate_account_cold: Option<bool>,
     pub is_empty: bool,
 }
 *)
 Module AccountLoad.
-  (* This still models the pre-v103 [load] field. The translated v103 type uses
-     [is_delegate_account_cold], so it cannot be migrated mechanically. *)
-  Record t : Set := {
-    load : Eip7702CodeLoad.t unit;
-    is_empty : bool;
+  RocqOfRustLinkRecord "revm_context_interface::journaled_state::AccountLoad" := {
+    is_delegate_account_cold : (option bool);
+    is_empty : bool
   }.
-
-  Instance IsLink : Link t :=
-  {
-    Φ := Ty.path "revm_context_interface::journaled_state::AccountLoad";
-    φ x :=
-      Value.StructRecord "revm_context_interface::journaled_state::AccountLoad" [] [] [
-        ("load", φ x.(load));
-        ("is_empty", φ x.(is_empty))
-      ];
-  }.
-  
-  Definition of_ty : OfTy.t (Ty.path "revm_context_interface::journaled_state::AccountLoad").
-  Proof.
-    eapply OfTy.Make with (A := t).
-    reflexivity.
-  Defined.
-  Smpl Add apply of_ty : of_ty.
-
-  Lemma of_value_with load load' is_empty is_empty' :
-    load' = φ load ->
-    is_empty' = φ is_empty ->
-    Value.StructRecord "revm_context_interface::journaled_state::AccountLoad" [] [] [
-      ("load", load');
-      ("is_empty", is_empty')
-    ] = φ (Build_t load is_empty).
-  Proof.
-    now intros; subst.
-  Qed.
-  Smpl Add apply of_value_with : of_value.
-
-  Definition of_value (load : Eip7702CodeLoad.t unit) load' (is_empty : bool) is_empty' :
-    load' = φ load ->
-    is_empty' = φ is_empty ->
-    OfValue.t (
-      Value.StructRecord "revm_context_interface::journaled_state::AccountLoad" [] [] [
-        ("load", load');
-        ("is_empty", is_empty')
-      ]
-    ).
-  Proof.
-    econstructor; apply of_value_with; eassumption.
-  Defined.
-  Smpl Add apply of_value : of_value.
-
-  Module SubPointer.
-    Definition get_load : SubPointer.Runner.t t
-      (Pointer.Index.StructRecord "revm_context_interface::journaled_state::AccountLoad" "load") :=
-    {|
-      SubPointer.Runner.projection x := Some x.(load);
-      SubPointer.Runner.injection x y := Some (x <| load := y |>);
-    |}.
-
-    Lemma get_load_is_valid :
-      SubPointer.Runner.Valid.t get_load.
-    Proof.
-      now constructor.
-    Qed.
-    Smpl Add apply get_load_is_valid : run_sub_pointer.
-
-    Definition get_is_empty : SubPointer.Runner.t t
-      (Pointer.Index.StructRecord "revm_context_interface::journaled_state::AccountLoad" "is_empty") :=
-    {|
-      SubPointer.Runner.projection x := Some x.(is_empty);
-      SubPointer.Runner.injection x y := Some (x <| is_empty := y |>);
-    |}.
-
-    Lemma get_is_empty_is_valid :
-      SubPointer.Runner.Valid.t get_is_empty.
-    Proof.
-      now constructor.
-    Qed.
-    Smpl Add apply get_is_empty_is_valid : run_sub_pointer.
-  End SubPointer.
 End AccountLoad.
 Export (hints) AccountLoad.
 

--- a/RocqOfRust/revm/revm_context_interface/simulate/host.v
+++ b/RocqOfRust/revm/revm_context_interface/simulate/host.v
@@ -47,11 +47,11 @@ Module Host.
       (load_code : bool)
       (skip_cold_load : bool) :
       Result.t AccountInfoLoad.t LoadError.t * Self;
-    (* fn load_account_delegated(&mut self, address: Address) -> Option<AccountLoad>; *)
+    (* fn load_account_delegated(&mut self, address: Address) -> Option<StateLoad<AccountLoad>>; *)
     load_account_delegated
       (self : Self)
       (address : Address.t) :
-      option AccountLoad.t * Self;
+      option (StateLoad.t AccountLoad.t) * Self;
     (* fn load_account_code(&mut self, address: Address) -> Option<StateLoad<Bytes>>; *)
     load_account_code
       (self : Self)

--- a/RocqOfRust/revm/revm_interpreter/gas/links/calc.v
+++ b/RocqOfRust/revm/revm_interpreter/gas/links/calc.v
@@ -289,8 +289,8 @@ Proof.
 Admitted.
 Global Opaque run_warm_cold_cost.
 
-(* pub const fn warm_cold_cost_with_delegation(load: Eip7702CodeLoad<()>) -> u64 *)
-Instance run_warm_cold_cost_with_delegation (load : Eip7702CodeLoad.t unit) :
+(* pub const fn warm_cold_cost_with_delegation(load: StateLoad<AccountLoad>) -> u64 *)
+Instance run_warm_cold_cost_with_delegation (load : StateLoad.t AccountLoad.t) :
   Run.Trait
     gas.calc.warm_cold_cost_with_delegation [] [] [ φ load ]
     u64.

--- a/RocqOfRust/revm/revm_interpreter/gas/simulate/calc.v
+++ b/RocqOfRust/revm/revm_interpreter/gas/simulate/calc.v
@@ -394,11 +394,11 @@ Lemma warm_cold_cost_eq (stack : Stack.t) (is_cold : bool) :
   }}.
 Admitted.
 
-Definition warm_cold_cost_with_delegation (load : Eip7702CodeLoad.t unit) : u64 :=
+Definition warm_cold_cost_with_delegation (load : StateLoad.t AccountLoad.t) : u64 :=
   {| Integer.value := 0 |}.
 
 Lemma warm_cold_cost_with_delegation_eq (stack : Stack.t)
-    (load : Eip7702CodeLoad.t unit) :
+    (load : StateLoad.t AccountLoad.t) :
   {{
     SimulateM.eval_f
       (run_warm_cold_cost_with_delegation load)

--- a/RocqOfRust/revm/revm_interpreter/instructions/contract/simulate/call_helpers.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/contract/simulate/call_helpers.v
@@ -27,8 +27,8 @@ Require Import revm.revm_primitives.links.hardfork.
 Require Import revm.revm_primitives.simulate.hardfork.
 Require Import ruint.simulate.lib.
 
-Parameter bytecode_of_account_load : AccountLoad.t -> Bytecode.t.
-Parameter bytecode_hash_of_account_load : AccountLoad.t -> aliases.B256.t.
+Parameter bytecode_of_account_load : StateLoad.t AccountLoad.t -> Bytecode.t.
+Parameter bytecode_hash_of_account_load : StateLoad.t AccountLoad.t -> aliases.B256.t.
 
 Definition resize_memory
     {WIRE : Set} `{Link WIRE}
@@ -240,7 +240,7 @@ Definition load_acc_and_calc_gas
     (None, interpreter, host)
   | (Some account_load, host) =>
 
-  let dynamic_gas := warm_cold_cost_with_delegation account_load.(AccountLoad.load) in
+  let dynamic_gas := warm_cold_cost_with_delegation account_load in
   gas_macro interpreter dynamic_gas
     (fun interpreter => (None, interpreter, host))
     (fun interpreter =>

--- a/RocqOfRust/revm/revm_interpreter/instructions/links/contract/create.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/links/contract/create.v
@@ -73,18 +73,5 @@ Proof.
   destruct (Impl_AsRef_for_Slice.run u8).
   destruct run_Deref_for_Synthetic.
   run_symbolic.
-  { eapply (@Impl_Interpreter.run_halt WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
-  { eapply (@Impl_Interpreter.run_halt_not_activated WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
-  { eapply (@Impl_Interpreter.run_halt WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
-  { eapply (@Impl_Interpreter.run_halt WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
-  { eapply (@Impl_Interpreter.run_halt_oog WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
-  { eapply (@Impl_Interpreter.run_halt WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
-  { eapply (@Impl_Interpreter.run_halt_memory_oog WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
-  { eapply (@Impl_Interpreter.run_halt_oog WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
-  { eapply (@Impl_Interpreter.run_halt_oog WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
-  { eapply (@Impl_Interpreter.run_halt_underflow WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
-  { eapply (@Impl_Interpreter.run_halt_oog WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
-  { eapply (@Impl_Interpreter.run_halt_oog WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
-  { eapply (@Impl_Interpreter.run_halt_underflow WIRE H0 WIRE_types H2 run_InterpreterTypes_for_WIRE_copy). }
 Defined.
 Global Opaque run_create.

--- a/RocqOfRust/revm/revm_interpreter/instructions/tests/contract.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/tests/contract.v
@@ -144,7 +144,7 @@ Goal
   let interpreter := make_interpreter stack in
   let host : TestHost.t := TestHost.Make in
   let '(result_interpreter, _) := create false interpreter host in
-  result_interpreter.(Interpreter.control).(Control.instruction_result) =
+  bytecode_result result_interpreter =
     Some InstructionResult.StateChangeDuringStaticCall \/
   bytecode_result result_interpreter = Some InstructionResult.StackUnderflow.
 Proof.
@@ -161,7 +161,7 @@ Goal
   let interpreter := make_interpreter stack in
   let host : TestHost.t := TestHost.Make in
   let '(result_interpreter, _) := create false interpreter host in
-  result_interpreter.(Interpreter.control).(Control.instruction_result) =
+  bytecode_result result_interpreter =
     Some InstructionResult.StateChangeDuringStaticCall \/
   is_create_frame result_interpreter.
 Proof.

--- a/RocqOfRust/revm/revm_interpreter/tests/host.v
+++ b/RocqOfRust/revm/revm_interpreter/tests/host.v
@@ -1,5 +1,6 @@
 Require Import simulate.RocqOfRust.
 Require Import alloy_primitives.bits.links.address.
+Require Import alloy_primitives.bits.links.fixed_FixedBytes.
 Require Import alloy_primitives.bytes.links.mod.
 Require Import alloy_primitives.links.common.
 Require Import alloy_primitives.links.aliases.
@@ -61,7 +62,7 @@ Module TestHost.
     (Result.Err LoadError.DBError, Make).
 
   Definition load_account_delegated (self : t) (_address : Address.t) :
-      option AccountLoad.t * t :=
+      option (StateLoad.t AccountLoad.t) * t :=
     (None, Make).
 
   Definition load_account_code (self : t) (_address : Address.t) :
@@ -104,6 +105,10 @@ Module TestHost.
       aliases.U256.t * t :=
     (Impl_Uint.ZERO, Make).
 
+  Definition host_effective_gas_price (self : t) :
+      aliases.U256.t * t :=
+    (Impl_Uint.ZERO, Make).
+
   Definition host_difficulty (self : t) :
       aliases.U256.t * t :=
     (Impl_Uint.ZERO, Make).
@@ -128,6 +133,14 @@ Module TestHost.
       option (StateLoad.t aliases.U256.t) * t :=
     (None, Make).
 
+  Definition sload_skip_cold_load
+      (self : t)
+      (_address : Address.t)
+      (_key : aliases.U256.t)
+      (_skip_cold_load : bool) :
+      Result.t (StateLoad.t aliases.U256.t) LoadError.t * t :=
+    (Result.Err LoadError.DBError, Make).
+
   Definition sstore
       (self : t)
       (_address : Address.t)
@@ -135,6 +148,15 @@ Module TestHost.
       (_value : aliases.U256.t) :
       option (StateLoad.t SStoreResult.t) * t :=
     (None, Make).
+
+  Definition sstore_skip_cold_load
+      (self : t)
+      (_address : Address.t)
+      (_key : aliases.U256.t)
+      (_value : aliases.U256.t)
+      (_skip_cold_load : bool) :
+      Result.t (StateLoad.t SStoreResult.t) LoadError.t * t :=
+    (Result.Err LoadError.DBError, Make).
 
   Definition tload (self : t) (_address : Address.t) (_index : aliases.U256.t) :
       aliases.U256.t * t :=
@@ -285,13 +307,16 @@ Module TestHost.
     Host.chain_id := host_chain_id;
     Host.basefee := host_basefee;
     Host.blob_gasprice := host_blob_gasprice;
+    Host.effective_gas_price := host_effective_gas_price;
     Host.difficulty := host_difficulty;
     Host.prevrandao := host_prevrandao;
     Host.balance := balance;
     Host.code := code;
     Host.code_hash := code_hash;
     Host.sload := sload;
+    Host.sload_skip_cold_load := sload_skip_cold_load;
     Host.sstore := sstore;
+    Host.sstore_skip_cold_load := sstore_skip_cold_load;
     Host.tload := tload;
     Host.tstore := tstore;
     Host.log := log;
@@ -336,15 +361,12 @@ Module TestHostWithAccount.
   Definition prevrandao (_self : t) : option aliases.B256.t := None.
   Definition blob_gasprice (_self : t) : option u128 := None.
 
-  Definition test_account_load : AccountLoad.t := {|
-    AccountLoad.load := {|
-      Eip7702CodeLoad.state_load := {|
-        StateLoad.data := tt;
-        StateLoad.is_cold := false;
-      |};
-      Eip7702CodeLoad.is_delegate_account_cold := None;
+  Definition test_account_load : StateLoad.t AccountLoad.t := {|
+    StateLoad.data := {|
+      AccountLoad.is_delegate_account_cold := None;
+      AccountLoad.is_empty := true;
     |};
-    AccountLoad.is_empty := true;
+    StateLoad.is_cold := false;
   |}.
 
   Definition load_account_info_skip_cold_load
@@ -356,7 +378,7 @@ Module TestHostWithAccount.
     (Result.Err LoadError.DBError, Make).
 
   Definition load_account_delegated (self : t) (_address : Address.t) :
-      option AccountLoad.t * t :=
+      option (StateLoad.t AccountLoad.t) * t :=
     (Some test_account_load, Make).
 
   Definition load_account_code (self : t) (_address : Address.t) :
@@ -399,6 +421,10 @@ Module TestHostWithAccount.
       aliases.U256.t * t :=
     (Impl_Uint.ZERO, Make).
 
+  Definition host_effective_gas_price (self : t) :
+      aliases.U256.t * t :=
+    (Impl_Uint.ZERO, Make).
+
   Definition host_difficulty (self : t) :
       aliases.U256.t * t :=
     (Impl_Uint.ZERO, Make).
@@ -423,6 +449,14 @@ Module TestHostWithAccount.
       option (StateLoad.t aliases.U256.t) * t :=
     (None, Make).
 
+  Definition sload_skip_cold_load
+      (self : t)
+      (_address : Address.t)
+      (_key : aliases.U256.t)
+      (_skip_cold_load : bool) :
+      Result.t (StateLoad.t aliases.U256.t) LoadError.t * t :=
+    (Result.Err LoadError.DBError, Make).
+
   Definition sstore
       (self : t)
       (_address : Address.t)
@@ -430,6 +464,15 @@ Module TestHostWithAccount.
       (_value : aliases.U256.t) :
       option (StateLoad.t SStoreResult.t) * t :=
     (None, Make).
+
+  Definition sstore_skip_cold_load
+      (self : t)
+      (_address : Address.t)
+      (_key : aliases.U256.t)
+      (_value : aliases.U256.t)
+      (_skip_cold_load : bool) :
+      Result.t (StateLoad.t SStoreResult.t) LoadError.t * t :=
+    (Result.Err LoadError.DBError, Make).
 
   Definition tload (self : t) (_address : Address.t) (_index : aliases.U256.t) :
       aliases.U256.t * t :=
@@ -580,13 +623,16 @@ Module TestHostWithAccount.
     Host.chain_id := host_chain_id;
     Host.basefee := host_basefee;
     Host.blob_gasprice := host_blob_gasprice;
+    Host.effective_gas_price := host_effective_gas_price;
     Host.difficulty := host_difficulty;
     Host.prevrandao := host_prevrandao;
     Host.balance := balance;
     Host.code := code;
     Host.code_hash := code_hash;
     Host.sload := sload;
+    Host.sload_skip_cold_load := sload_skip_cold_load;
     Host.sstore := sstore;
+    Host.sstore_skip_cold_load := sstore_skip_cold_load;
     Host.tload := tload;
     Host.tstore := tstore;
     Host.log := log;


### PR DESCRIPTION
Migrates `AccountLoad` to the links plugin with its v103 fields, updates its `StateLoad` consumers, and removes the stale manual halt cleanup from `create`.