### PR TITLE
Add initial evaluator for linked translations

### DIFF
--- a/RocqOfRust/evaluate/M.v
+++ b/RocqOfRust/evaluate/M.v
@@ -34,7 +34,9 @@ Module Evaluate.
             )).
           }
         }
-        { exact Execution.Unsupported. }
+        { (* Mutable references require access evidence for the heterogeneous stack. *)
+          exact Execution.Unsupported.
+        }
       }
       { exact Execution.Unsupported. }
       { exact (@eval fuel R Output (k (SubPointer.Runner.apply ref_core runner)) stack). }

--- a/RocqOfRust/evaluate/M.v
+++ b/RocqOfRust/evaluate/M.v
@@ -1,0 +1,87 @@
+Require Import simulate.RocqOfRust.
+
+Module Execution.
+  Inductive t (A : Set) : Set :=
+  | Done (value : A)
+  | OutOfFuel
+  | Unsupported.
+  Arguments Done {_}.
+  Arguments OutOfFuel {_}.
+  Arguments Unsupported {_}.
+End Execution.
+
+Module Evaluate.
+  Fixpoint eval
+      (fuel : nat)
+      {R Output : Set}
+      (e : LinkM.t R Output)
+      (stack : Stack.t)
+      {struct fuel} :
+      Execution.t (Output.t R Output * Stack.t).
+  Proof.
+    destruct fuel as [|fuel].
+    { exact Execution.OutOfFuel. }
+    destruct e.
+    { exact (Execution.Done (value, stack)). }
+    { destruct primitive.
+      { exact (@eval fuel R Output (k (Ref.Core.Immediate (Some value))) stack). }
+      { destruct ref_core as [value|Address Big_A address path big_to_value projection injection].
+        { destruct value as [value|].
+          { exact (@eval fuel R Output (k value) stack). }
+          { exact (Execution.Done (
+              Output.Exception Output.Exception.BreakMatch,
+              stack
+            )).
+          }
+        }
+        { exact Execution.Unsupported. }
+      }
+      { exact Execution.Unsupported. }
+      { exact (@eval fuel R Output (k (SubPointer.Runner.apply ref_core runner)) stack). }
+    }
+    { destruct (@eval fuel R A e stack) as [[output stack']| |].
+      { exact (@eval fuel R Output (k output) stack'). }
+      { exact Execution.OutOfFuel. }
+      { exact Execution.Unsupported. }
+    }
+    { exact Execution.Unsupported. }
+    { destruct (@eval fuel A A (links.M.evaluate run_f) stack) as [[output stack']| |].
+      { destruct output as [value|exception].
+        { exact (@eval fuel R Output (k value) stack'). }
+        { exact Execution.Unsupported. }
+      }
+      { exact Execution.OutOfFuel. }
+      { exact Execution.Unsupported. }
+    }
+    { exact Execution.Unsupported. }
+    { exact (
+        if cond then
+          @eval fuel R Output e1 stack
+        else
+          @eval fuel R Output e2 stack
+      ).
+    }
+    { destruct output as [value|exception].
+      { exact (@eval fuel R Output (k_success value) stack). }
+      { destruct exception.
+        { exact (@eval fuel R Output (k_return return_) stack). }
+        { exact (@eval fuel R Output (k_break tt) stack). }
+        { exact (@eval fuel R Output (k_continue tt) stack). }
+        { exact (@eval fuel R Output (k_break_match tt) stack). }
+      }
+    }
+    { exact Execution.Unsupported. }
+  Defined.
+
+  Definition eval_f
+      (fuel : nat)
+      {f : PolymorphicFunction.t}
+      {epsilon : list Value.t}
+      {types : list Ty.t}
+      {arguments : list Value.t}
+      {Output : Set} `{Link Output}
+      (run : Run.Trait f epsilon types arguments Output)
+      (stack : Stack.t) :
+      Execution.t (Output.t Output Output * Stack.t) :=
+    @eval fuel Output Output (links.M.evaluate run.(Run.run_f)) stack.
+End Evaluate.

--- a/RocqOfRust/evaluate/README.md
+++ b/RocqOfRust/evaluate/README.md
@@ -1,0 +1,43 @@
+# Evaluation
+
+The goal of these experiments is to run translated Rust code on concrete inputs
+and compare the results with the original Rust code. There are several possible
+evaluation layers.
+
+## Generated code
+
+The generated code has type `M` and is the closest representation to the Rust
+source. Evaluating it directly would test the translation before linking, but
+the evaluator would need executable resolution for types, functions, associated
+functions, and trait methods.
+
+## Linked code without mutable stack access
+
+The evaluator in [`M.v`](M.v) runs the typed `LinkM` representation produced by
+`links.M.evaluate`. It uses fuel for recursive calls and currently handles the
+cases needed by the [`add_one` test](../examples/default/examples/custom/evaluate/add_one.v).
+
+This evaluator returns `Unsupported` for operations that require mutable stack
+access. `Stack.t` is heterogeneous, so reading or writing a mutable reference
+requires evidence that the referenced value has the expected type.
+
+## Linked code through simulation proofs
+
+For programs that use the stack, another direction is to derive an output
+together with a proof that `SimulateM.eval_f` produces it. The Rocq `Derive`
+command can introduce the output as an existential value, while repeated use of
+the simulation tactic `s` can construct the execution proof and the required
+stack-access evidence.
+
+## Simulate definitions
+
+Pure simulate definitions can already be evaluated efficiently with
+`vm_compute`. This is useful for testing the functional model, while the
+corresponding `_eq` lemma connects that model to the linked translation.
+
+## Extraction
+
+An executable Rocq evaluator or simulate definition can be extracted to OCaml.
+This may provide faster execution and easier integration with an external test
+runner, but it still depends on first choosing and completing the Rocq
+evaluation layer.

--- a/RocqOfRust/evaluate/RocqOfRust.v
+++ b/RocqOfRust/evaluate/RocqOfRust.v
@@ -1,0 +1,2 @@
+Require Export simulate.RocqOfRust.
+Require Export evaluate.M.

--- a/RocqOfRust/examples/default/examples/custom/evaluate/add_one.v
+++ b/RocqOfRust/examples/default/examples/custom/evaluate/add_one.v
@@ -1,0 +1,16 @@
+Require Import evaluate.RocqOfRust.
+Require Import examples.default.examples.custom.links.add_one.
+
+Goal
+  Evaluate.eval_f
+    20
+    (run_add_one {| Integer.value := 41 |})
+    []%stack =
+  Execution.Done (
+    Output.Success {| Integer.value := 42 |},
+    []%stack
+  ).
+Proof.
+  vm_compute.
+  reflexivity.
+Qed.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -7,15 +7,16 @@ evaluation layers.
 ## Generated code
 
 The generated code has type `M` and is the closest representation to the Rust
-source. Evaluating it directly would test the translation before linking, but
-the evaluator would need executable resolution for types, functions, associated
-functions, and trait methods.
+source. Evaluating it directly would test the translation before linking. Type
+resolution can be avoided, but the evaluator would still need executable
+resolution for functions, associated functions, and trait methods.
 
 ## Linked code without mutable stack access
 
-The evaluator in [`M.v`](M.v) runs the typed `LinkM` representation produced by
-`links.M.evaluate`. It uses fuel for recursive calls and currently handles the
-cases needed by the [`add_one` test](../examples/default/examples/custom/evaluate/add_one.v).
+The evaluator in [`M.v`](../RocqOfRust/evaluate/M.v) runs the typed `LinkM`
+representation produced by `links.M.evaluate`. It uses fuel for recursive calls
+and currently handles the cases needed by the
+[`add_one` test](../RocqOfRust/examples/default/examples/custom/evaluate/add_one.v).
 
 This evaluator returns `Unsupported` for operations that require mutable stack
 access. `Stack.t` is heterogeneous, so reading or writing a mutable reference
@@ -39,5 +40,7 @@ corresponding `_eq` lemma connects that model to the linked translation.
 
 An executable Rocq evaluator or simulate definition can be extracted to OCaml.
 This may provide faster execution and easier integration with an external test
-runner, but it still depends on first choosing and completing the Rocq
-evaluation layer.
+runner. OCaml is also more expressive and supports side effects, which could be
+used to implement name and trait resolution outside Rocq. This can be an
+advantage for evaluation methods that require these resolutions, but extraction
+still depends on first choosing and completing the Rocq evaluation layer.


### PR DESCRIPTION
Adds a fuelled evaluator for the initial LinkM cases, with a test showing that the linked add_one translation evaluates to 42. The recursive calls use explicit R and Output arguments because Rocq cannot infer them inside the Fixpoint definition.