### PR TITLE
Extend test bytecode model for PUSH

### DIFF
--- a/RocqOfRust/revm/revm_interpreter/instructions/tests/memory.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/tests/memory.v
@@ -46,6 +46,7 @@ Qed.
 Definition make_interpreter_with_memory (stack : Stack.t) (memory : Memory.t)
     (gas_val : Gas.t) : Interpreter.t WIRE WIRE_types := {|
   Interpreter.bytecode := {|
+    Bytecode.code := [];
     Bytecode.pc := {| Integer.value := 0 |};
     Bytecode.action := None;
   |};

--- a/RocqOfRust/revm/revm_interpreter/instructions/tests/stack.v
+++ b/RocqOfRust/revm/revm_interpreter/instructions/tests/stack.v
@@ -151,24 +151,26 @@ Qed.
 
 (** ** PUSH tests *)
 
-(** Test that PUSH1 pushes a value onto the stack (zero bytes from test bytecode) *)
+(** Test that PUSH1 pushes the immediate byte onto the stack *)
 Goal
   let stack := {| Stack.value := [] |} in
-  let interpreter := make_interpreter stack in
+  let interpreter := make_interpreter_with_bytecode [(42 : u8)] stack in
   let result := push 1 interpreter in
-  result.(Interpreter.stack).(Stack.value) = [{| Uint.value := 0 |}].
+  result.(Interpreter.stack).(Stack.value) = [{| Uint.value := 42 |}].
 Proof.
   timeout 1 vm_compute.
   reflexivity.
 Qed.
 
-(** Test that PUSH1 does not set an error *)
+(** Test that PUSH2 reads bytes in big-endian order and advances the program counter *)
 Goal
   let stack := {| Stack.value := [] |} in
-  let interpreter := make_interpreter stack in
-  let result := push 1 interpreter in
-  result.(Interpreter.control).(Control.instruction_result) = None.
+  let interpreter :=
+    make_interpreter_with_bytecode [(18 : u8); (52 : u8)] stack in
+  let result := push 2 interpreter in
+  result.(Interpreter.stack).(Stack.value) = [{| Uint.value := 4660 |}] /\
+  result.(Interpreter.bytecode).(Bytecode.pc) = {| Integer.value := 2 |}.
 Proof.
   timeout 1 vm_compute.
-  reflexivity.
+  split; reflexivity.
 Qed.

--- a/RocqOfRust/revm/revm_interpreter/tests/interpreter.v
+++ b/RocqOfRust/revm/revm_interpreter/tests/interpreter.v
@@ -5,8 +5,12 @@ Require Import revm.revm_interpreter.links.interpreter_types.
 Require Import revm.revm_interpreter.tests.interpreter_types.
 Require Import revm.revm_primitives.links.hardfork.
 
-Definition make_interpreter (stack : Stack.t) : Interpreter.t WIRE WIRE_types := {|
+Definition make_interpreter_with_bytecode
+    (code : list u8)
+    (stack : Stack.t) :
+    Interpreter.t WIRE WIRE_types := {|
   Interpreter.bytecode := {|
+    Bytecode.code := code;
     Bytecode.pc := {| Integer.value := 0 |};
     Bytecode.action := None;
   |};
@@ -40,3 +44,6 @@ Definition make_interpreter (stack : Stack.t) : Interpreter.t WIRE WIRE_types :=
   Interpreter.runtime_flag := SpecId.PRAGUE;
   Interpreter.extend := tt;
 |}.
+
+Definition make_interpreter (stack : Stack.t) : Interpreter.t WIRE WIRE_types :=
+  make_interpreter_with_bytecode [] stack.

--- a/RocqOfRust/revm/revm_interpreter/tests/interpreter_types.v
+++ b/RocqOfRust/revm/revm_interpreter/tests/interpreter_types.v
@@ -127,6 +127,7 @@ Export (hints) MemorySlice.
 
 Module Bytecode.
   Record t : Set := {
+    code : list u8;
     pc : usize;
     action : option InterpreterAction.t;
   }.
@@ -135,6 +136,7 @@ Module Bytecode.
     Φ := Ty.path "revm_interpreter::tests::Bytecode";
     φ x :=
       Value.StructRecord "revm_interpreter::tests::Bytecode" [] [] [
+        ("code", φ x.(code));
         ("pc", φ x.(pc));
         ("action", φ x.(action))
       ];
@@ -179,9 +181,13 @@ Module Immediates.
   Definition read_u8 (self : Self) : u8 := 0.
   Definition read_offset_i16 (self : Self) (offset : isize) : i16 := 0.
   Definition read_offset_u16 (self : Self) (offset : isize) : u16 := 0.
+  Definition read_slice_value (self : Self) (len : usize) : list u8 :=
+    Memory.take_pad
+      (Z.to_nat i[len])
+      (List.skipn (Z.to_nat i[self.(Bytecode.pc)]) self.(Bytecode.code)).
   Definition read_slice (len : usize) : RefStub.t Self (list u8) := {|
     RefStub.path := [];
-    RefStub.projection := fun _ => List.repeat (0 : u8) (Z.to_nat i[len]);
+    RefStub.projection := fun self => read_slice_value self len;
     RefStub.injection := fun x _ => x;
   |}.
 


### PR DESCRIPTION
Extends the test bytecode model to read real PUSH immediates and track the program counter.